### PR TITLE
SY TCU clarifications

### DIFF
--- a/docs/aerodromes/Albury.md
+++ b/docs/aerodromes/Albury.md
@@ -44,8 +44,6 @@ A next call is made for all aircraft when they are next to depart and will be de
     **AY TWR** -> **BLA**: "Next QFA400"  
     **BLA** -> **AY TWR**: "QFA400"    
 
-The Standard Assignable level from AY TWR to BLA is the lower of `A070` or the `RFL`, any other level must be prior coordinated.
-
 ### Arrivals
 BLA will coordinate the sequence to AY TWR
 
@@ -53,4 +51,8 @@ BLA will coordinate the sequence to AY TWR
     **BLA** -> **AY TWR**: "RXA3421, estimating YMAY time 52, via ARRAN1 arrival”  
     **AY TWR** -> **BLA**: "RXA3421"  
 
-The Standard Assignable level from BLA to AY TWR is `A080`, any other level must be prior coordinated.
+## Standard Assignable Levels
+
+Aircraft departing from Albury shall be assigned `A070` or `RFL` if lower.
+
+Aircraft arriving into Albury shall be assigned `A080` by BLA.

--- a/docs/aerodromes/Coffs.md
+++ b/docs/aerodromes/Coffs.md
@@ -49,8 +49,6 @@ A next call is made for all aircraft when they are next to depart and will be de
     **CFS TWR** -> **MNN**: "Next, QJE1573"  
     **MNN** -> **CFS TWR**: "QJE1573"  
 
-The Standard Assignable level from CFS TWR to INL/ARL(MNN) is the lower of `A070` or the `RFL`, any other level must be prior coordinated.
-
 ### Arrivals
 INL/ARL(MNN) will coordinate the sequence to CFS TWR.
 
@@ -58,4 +56,8 @@ INL/ARL(MNN) will coordinate the sequence to CFS TWR.
     **INL** -> **CFS TWR**: "New Sequence of 2. Via GAMBL, RXA9904, Number 1. Via TUCAB, LYM, Number 2”  
     **CFS TWR** -> **INL**: "RXA9904, Number 1. LYM, Number 2"  
 
-The Standard Assignable level from INL/ARL(MNN) to CFS TWR is `A080`, any other level must be prior coordinated.
+## Standard Assignable Levels
+
+Aircraft departing from Coffs Harbour shall be assigned `A070` or `RFL` if lower.
+
+Aircraft arriving into Coffs Harbour shall be assigned `A080` by INL/ARL(MNN).

--- a/docs/aerodromes/Hammo.md
+++ b/docs/aerodromes/Hammo.md
@@ -51,7 +51,6 @@ A next call is made for all aircraft when they are next to depart and will be de
     **HM TWR** -> **SWY**: "Next QFA797"  
     **SWY** -> **HM TWR**: "QFA797"  
 
-The Standard Assignable level from HM TWR to KEN(SWY) is the lower of `A050` or the `RFL`, any other level must be prior coordinated.
 ### Arrivals
 KEN(SWY) will coordinate the sequence to HM TWR.
 
@@ -59,4 +58,9 @@ KEN(SWY) will coordinate the sequence to HM TWR.
     **SWY** -> **HM TWR**: "New Sequence of 2. Via OPOSI for RNP U RWY 32, JST848, Number 1. Via SWIFT, UTY551, Number 2”  
     **HM TWR** -> **SWY**: "JST848, Number 1. UTY551, Number 2"  
 
-The Standard Assignable level from KEN(SWY) to HM TWR is `A060`, any other level must be prior coordinated.
+
+## Standard Assignable Levels
+
+Aircraft departing from Hamilton Island shall be assigned `A050` or `RFL` if lower.
+
+Aircraft arriving into Hamilton Island shall be assigned `A060` by KEN(SWY).

--- a/docs/aerodromes/Hobart.md
+++ b/docs/aerodromes/Hobart.md
@@ -41,24 +41,30 @@ Other aircraft shall be assigned an appropriate **Procedural SID** or a visual d
 
 ## Cambridge (YCBG)
 
-HB ADC and/or HB SMC is resposible for clearances into and out of Cambridge (YCBG).
+Due to it's close proximity, HB ADC & SMC are resposible for clearances into and out of Cambridge (YCBG), which sits inside the Hobart class D control zone.
 
-Prior to leaving the apron, aircraft will establish communications with HB SMC for Airways Clearance.
+### Departures
+Prior to leaving the apron, all outbound aircraft will establish communications with **HB SMC** for Airways Clearance.  
+
+All IFR Aircraft departing Cambridge shall be assigned a **Visual Departure** or one of Hobart's **Procedural SIDs**.
+
+!!! note
+    Both VFR and IFR aircraft require a clearance to operate in class D airspace (even if this is an implied clearance to depart a leg of the circuit).  The examples below show an IFR aircraft departing.
 
 !!! Example
     **NDR:** "Hobart Ground, NDR, for Devonport, Request Clearance"  
-    **HB ADC:** "NDR, Cleared to Devonport via KANLI flight plan route, KANLI3 Departure, Climb via SID A045, Squawk 4432"
+    **HB SMC:** "NDR, Cleared to Devonport via KANLI flight plan route, KANLI3 Departure, Climb via SID A045, Squawk 4432"
     `AIP GEN 3.4`
 
-When ready to taxi and prior to leaving the apron aircraft must contact HB ADC, advising intended runway for departure and receipt of YMHB ATIS, to obtain TFC information.
+When ready to taxi and prior to leaving the apron aircraft must contact **HB ADC**, advising intended runway for departure and receipt of YMHB ATIS, to obtain traffic information.
 
 !!! Example
-    **NDR:** "Hobart Tower, NDR, Cambridge Runway 32, Hobart Information D"  
+    **NDR:** "Hobart Tower, NDR, taxiing Cambridge Runway 32, received Hobart Information D"  
     **HB ADC:** "NDR, No reported IFR traffic, report ready"  
     **NDR:** "Wilco, NDR"  
     `AIP GEN 3.4`
 
-Landing and Takeoff clearances are not given. ACFT will remain clear of active runway and report ready to HB ADC. Aircraft must not enter ACTIVE runway and become airborne until departure instructions have been issued.
+Takeoff clearances are not given. Aircraft will remain clear of the active runway and report ready to HB ADC. Aircraft must not enter an active runway or become airborne until departure instructions have been issued.
 
 !!! Example
     **NDR:** "NDR, Ready"  
@@ -67,10 +73,29 @@ Landing and Takeoff clearances are not given. ACFT will remain clear of active r
     `AIP GEN 3.4`
 
 
-All IFR Aircraft departing Cambridge shall be assigned a **Visual Departure** or one of Hobart's **Procedural SIDs**.
+### Arrivals
+Inbound VFR aircraft should be instructed to join a leg of the circuit and cleared for a visual approach (traffic permitting).  In IMC, IFR aircraft will fly one of Hobart's instrument approaches until visual, then break off to circle to land.
 
-!!! Note
-    If IMC conditions apply, IFR aircraft inbound to Cambridge will fly Hobart instrument approaches, then breakoff to circle to land.
+As a landing clearance is not given, aircraft should instead be informed of any traffic operating on the aerodrome and instructed to report clear of the runway.
+
+!!! example
+    *UJA is an IFR Aero Commander who has been cleared the YMHB RNAV-Z RWY 30 approach by HB APP and handed off to HB ADC.*  
+    **UJA:** "Hobart Tower, UJA"  
+    **HB ADC:** "UJA, Hobart Tower, report visual"  
+    **UJA:** "Wilco, UJA"  
+
+    **UJA:** "UJA, visual"  
+    **HB ADC:** "UJA, track for final runway 30, no reported traffic, report clear of the runway"  
+    **UJA:** "Track for final runway 30, wilco, UJA"
+
+!!! example
+    *KLR is a VFR Cherokee who is tracking inbound on the Victor East VFR route.*  
+    **HB ADC:** "KLR, enter the control zone tracking via the Victor East, A015, clearance limit Sorell"  
+    **KLR:** "Enter control zone tracking via the Victor East, A015, clearance limit Sorell, KLR"  
+
+    **KLR:** "KLR, approaching Sorell"  
+    **HB ADC:** "KLR, join base runway 12, cleared visual approach, no reported traffic, report clear of the runway"  
+    **KLR:** "Join base runway 12, cleared visual approach, wilco, KLR"
 
 ## VFR Operations
 
@@ -101,7 +126,7 @@ All IFR Aircraft departing Cambridge shall be assigned a **Visual Departure** or
 Clearances for aircraft entering the CTR must be worded so as to leave no possibility for misinterpretation by the pilot.
 
 !!! Example
-    **NDR:** "Hobart Tower, NDR, Campania, A015, on the Victor Northwest, Request Clearance"  
+    **NDR:** "Hobart Tower, NDR, Campania, A015, on the Victor Northwest, received Romeo, request clearance"  
     **HB ADC:** "NDR, enter the CTR tracking via the Victor Northwest at A015."
     `AIP GEN 3.4`
 

--- a/docs/aerodromes/Hobart.md
+++ b/docs/aerodromes/Hobart.md
@@ -35,44 +35,42 @@ Refer to [Class D Tower Skills](../../controller-skills/classdtwr/) for more inf
 
 Jet Aircraft planned via **CLARK**, **LATUM**, or **LAVOP**, shall be assigned the **Procedural SID** that terminates at the appropriate waypoint.
 
-Jet Aircraft **not** planned via **CLARK**, **LATUM**, or **LAVOP**, shall be assigned an appropriate **Procedural SID** or a visual departure.
-
 Non-Jet Aircraft planned via **CLARK**, **KANLI**, or **LAVOP**, shall be assigned the **Procedural SID** that terminates at the appropriate waypoint.
 
-Non-Jet Aircraft **not** planned via **CLARK**, **KANLI**, or **LAVOP**, shall be assigned an appropriate **Procedural SID** or a visual departure.
+Other aircraft shall be assigned an appropriate **Procedural SID** or a visual departure.
 
 ## Cambridge (YCBG)
 
 HB ADC and/or HB SMC is resposible for clearances into and out of Cambridge (YCBG).
 
-Prior to leaving APN, aircraft will establish communications with HB SMC for Airways Clearance.
+Prior to leaving the apron, aircraft will establish communications with HB SMC for Airways Clearance.
 
 !!! Example
-    **NDR** -> **HB SMC**: "Hobart Ground, NDR, for Devonport, Request Clearance"  
-    **HB ADC** -> **NDR**: "NDR, Cleared to Devonport via KANLI flight plan route, KANLI# Departure, Climb via SID A045, Squawk 4432"
+    **NDR:** "Hobart Ground, NDR, for Devonport, Request Clearance"  
+    **HB ADC:** "NDR, Cleared to Devonport via KANLI flight plan route, KANLI3 Departure, Climb via SID A045, Squawk 4432"
     `AIP GEN 3.4`
 
 When ready to taxi and prior to leaving the apron aircraft must contact HB ADC, advising intended runway for departure and receipt of YMHB ATIS, to obtain TFC information.
 
 !!! Example
-    **NDR** -> **HB ADC**: "Hobart Tower, NDR, Cambridge Runway 32, Hobart Information D"  
-    **HB ADC** -> **NDR**: "NDR, No reported IFR traffic, report ready"
-    **NDR** -> **HB ADC**: "Wilco, NDR"  
+    **NDR:** "Hobart Tower, NDR, Cambridge Runway 32, Hobart Information D"  
+    **HB ADC:** "NDR, No reported IFR traffic, report ready"  
+    **NDR:** "Wilco, NDR"  
     `AIP GEN 3.4`
 
 Landing and Takeoff clearances are not given. ACFT will remain clear of active runway and report ready to HB ADC. Aircraft must not enter ACTIVE runway and become airborne until departure instructions have been issued.
 
 !!! Example
-    **NDR** -> **HB ADC**: "NDR, Ready"  
-    **HB ADC** -> **NDR**: "NDR, track via the KANLI# departure, report airbourne"
-    **NDR** -> **HB ADC**: "Track via the KANLI# departure, wilco, NDR"  
+    **NDR:** "NDR, Ready"  
+    **HB ADC:** "NDR, track via the KANLI3 departure, report airborne"  
+    **NDR:** "Track via the KANLI3 departure, wilco, NDR"  
     `AIP GEN 3.4`
 
 
-All IFR Aircraft departing Cambridge shall be assigned a **Visual Departure** or **Hobart SID**.
+All IFR Aircraft departing Cambridge shall be assigned a **Visual Departure** or one of Hobart's **Procedural SIDs**.
 
 !!! Note
-    If IMC conditions apply, IFR aircraft will fly Hobart IAP's then breakoff to circle to land.
+    If IMC conditions apply, IFR aircraft inbound to Cambridge will fly Hobart instrument approaches, then breakoff to circle to land.
 
 ## VFR Operations
 
@@ -103,8 +101,8 @@ All IFR Aircraft departing Cambridge shall be assigned a **Visual Departure** or
 Clearances for aircraft entering the CTR must be worded so as to leave no possibility for misinterpretation by the pilot.
 
 !!! Example
-    **NDR** -> **HB ADC**: "Hobart Tower, NDR, Campania, A015, on the Victor Northwest, Request Clearance"  
-    **HB ADC** -> **NDR**: "NDR, enter the CTR tracking via the Victor Northwest at A015."
+    **NDR:** "Hobart Tower, NDR, Campania, A015, on the Victor Northwest, Request Clearance"  
+    **HB ADC:** "NDR, enter the CTR tracking via the Victor Northwest at A015."
     `AIP GEN 3.4`
 
 ## Coordination
@@ -119,8 +117,9 @@ Clearances for aircraft entering the CTR must be worded so as to leave no possib
     **HB ADC** -> **HB TCU**: "Next, ABC"  
     **HB TCU** -> **HB ADC**: "ABC, Heading 150 Visual"  
     **HB ADC** -> **HB TCU**: "Heading 150 Visual, ABC"  
-    **HB ADC** -> **ABC**: "ABC, Assigned heading right 150 Visual, Runway 12, Cleared for Takeoff"  
-    **ABC** -> **HB ADC**: "Right heading 150 Visual, Runway 12, Cleared for Takeoff, ABC"  
+
+    **HB ADC:** "ABC, Assigned heading right 150 Visual, Runway 12, Cleared for Takeoff"  
+    **ABC:** "Right heading 150 Visual, Runway 12, Cleared for Takeoff, ABC"  
     `AIP GEN 3.4`
 
 The HB TCU controller can suspend/resume Auto Release at any time, with the concurrence of **HB ADC**.
@@ -142,10 +141,10 @@ HB TCU will coordinate all **non-STAR** arrivals 5min from IAF or 5min from CTA 
 - Sequence Number (if applicable)
 
 !!! example
-    **HB TCU** -> **HB ADC**: "JST419, A320, estimates Hobart 52, RNAV-Z 12 via HBZWG, 5000ft, number 1”
+    **HB TCU** -> **HB ADC**: "JST419, A320, estimates Hobart 52, RNAV-Z 12 via HBZWG, 5000ft, number 1”  
     **HB ADC** -> **HB TCU**: "JST419"
 
 ## Standard Assignable Levels
 
-Jets: `A080`
+Jets: `A080`  
 Non-jets: `A045` or `RFL` if lower

--- a/docs/aerodromes/Launceston.md
+++ b/docs/aerodromes/Launceston.md
@@ -30,9 +30,7 @@ Refer to [Class D Tower Skills](../../controller-skills/classdtwr/) for more inf
 
 ## SID Selection
 
-Aircraft planned via **IRSOM**, **ONAGI**, **NUNPA**, **MOTRA**, **IRONS**, **MORGO**, **KAREN**, **TASUM**, or **NOLAN**, shall be assigned the **Procedural SID** that terminates at the appropriate waypoint.
-
-Aircraft planned via **IRSOM**, **ONAGI**, **NUNPA**, **MOTRA**, **IRONS**, **MORGO**, **KAREN**, **TASUM**, or **NOLAN**, shall be assigned an appropriate **Procedural SID** or a visual departure.
+Aircraft planned via **IRSOM**, **ONAGI**, **NUNPA**, **MOTRA**, **IRONS**, **MORGO**, **KAREN**, **TASUM**, or **NOLAN**, shall be assigned the appropriate **Procedural SID**.  Other aircraft shall be assigned a visual departure.
 
 ## VFR Operations
 
@@ -87,5 +85,5 @@ LT TCU will coordinate all arrivals into Launceston Prior to handing over to tow
 
 ## Standard Assignable Levels
 
-Jets: `A080`
+Jets: `A080`  
 Non-jets: `A045` or `RFL` if lower

--- a/docs/aerodromes/tamworth.md
+++ b/docs/aerodromes/tamworth.md
@@ -98,8 +98,6 @@ A next call is made for all aircraft when they are next to depart and will be de
     **TW TWR** -> **ARL**: "Next, QLK5D"  
     **BLA** -> **AY TWR**: "QLK5D"    
 
-The Standard Assignable level from TW TWR to ARL/MDE is the lower of `A070` or the `RFL`, any other level must be prior coordinated.
-
 ### Arrivals
 ARL/MDE will coordinate the sequence to TW TWR.
 
@@ -107,4 +105,8 @@ ARL/MDE will coordinate the sequence to TW TWR.
     **MDE** -> **TW TWR**: "New Sequence of 2. Via MOR DCT, FD272, Number 1. Via NBR DCT, AM217, Number 2”  
     **TW TWR** -> **MDE**: "FD272, Number 1. AM217, Number 2"  
 
-The Standard Assignable level from ARL/MDE to TW TWR is `A080`, any other level must be prior coordinated.
+## Standard Assignable Levels
+
+Aircraft departing from Tamworth shall be assigned `A070` or `RFL` if lower.
+
+Aircraft arriving into Tamworth shall be assigned `A080` by ARL/MDE.

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -36,14 +36,17 @@ a) **“North”**/**”West”** positions shall assume the airspace of corresp
 b) Approach assumes Director/Departure airspace “on-side” when the latter positions are inactive (e.g. with **SAS** and **SAN** online only, **SAS** assumes **SDS** and **SFW**) 
 ## Arrival Procedures
 ### Level Assignment
-Adjacent STARs do not guarantee lateral separation (particularly as aircraft get closer to TESAT), so to avoid a breakdown of separation standards, Approach should assign levels as follows: <ul><li>ODALE/MEPIL STAR: `A060`</li><li>RIVET/BOREE STAR: `A080`</li><li>MARLN STAR: `A090`</li></ul>
+!!! note
+    Inbound aircraft will be handed from Enroute to Approach assigned the [standard assignable level](#arrivals).  This section refers to further descent issued by the Approach controller.
+
+Adjacent STARs do not guarantee lateral separation (particularly as aircraft get closer to TESAT), so to avoid a breakdown of separation standards, **Approach** should assign levels as follows: <ul><li>ODALE/MEPIL STAR: `A060`</li><li>RIVET/BOREE STAR: `A080`</li><li>MARLN STAR: `A090`</li></ul>
 
 RIVET/BOREE aircraft should only be assigned `A070` when an adjacent ODALE/MEPIL arrival is maintaining `A060`.  These aircraft can be stepped down to `A060` once sufficient lateral separation exists (often during the downwind turn).
 
 MARLN aircraft which require an overfly to the west should be assigned `A090` and stepped down on top of any RIVET arrivals.
 
 !!! tip
-    Be mindful of Sydney's <a href="#radar-entry-procedure-rep">REP airspace</a> arrangement and avoid leaving arrivals at `A100`.  Aircraft should be descended to `A090` or below by 20DME to prevent conflict with departing traffic.
+    Be mindful of Sydney's [REP airspace](#radar-entry-procedure-rep) arrangement and avoid leaving arrivals at `A100`.  Aircraft should be descended to `A090` or below by 20DME to prevent conflict with departing traffic.
 
 All aircraft should be assigned no lower than `A060` until clear of the active runways' departure tracks.  This normally occurs once established on downwind (but changes based on runway config).
 

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -84,7 +84,7 @@ SFW/SFE should provide aircraft an approximate 'miles to run' on first contact, 
 A typical downwind will take roughly 25 track miles from the normal point have handover from SAN/SAS to SFE/SFW.
 
 !!! example
-    "QLK402, Sydney Director, descend via STAR 4000 FT, 25 miles to run"
+    "QLK402, Sydney Director, descend to 4000ft, 25 miles to run"
 
 SFW/SFE may provide distance to touchdown, when transferring an aircraft to tower after the aircraft is established on their approach runway centreline (see below).
 
@@ -114,7 +114,7 @@ When conducting IVAs, aircraft shall not be transferred to **SY ADC** until esta
 ## Sydney Harbour Scenic Flights
 Flights may be cleared for one of two standard scenic flight routes at `A015`, **Harbour Scenic ONE** or **Harbour Scenic TWO**, which are described below. Pilot preference should be accommodated where traffic permits.
 
-Aircraft must Track via Class G airspace to Long Reef and contact SY TCU prior to reaching Long Reef requesting a ‘Harbour Scenic’ clearance. Attempt to identify the aircraft, and if a clearance cannot be given immediately, instruct the pilot to remain in Class G airspace.
+Aircraft must track via Class G airspace to Long Reef and contact SY TCU prior to reaching Long Reef requesting a ‘Harbour Scenic’ clearance. Attempt to identify the aircraft, and if a clearance cannot be given immediately, instruct the pilot to remain in Class G airspace.
 
 !!! example
     LOI, squawk 0542, remain clear of Class C airspace”

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -43,7 +43,7 @@
 									<h3>Search Function</h3>
 
 									<p>
-										Need to quickly find information? The search function can be used to search for words or phrases. Need to be more specific? search with "parenthesis".
+										Need to quickly find information? The search function can be used to search for words or phrases. Need to be more specific? Search with "quotes".
 									</p>
 								</a>
 						</div>


### PR DESCRIPTION
Received feedback that the Level Assignment section was being confused with standard assignable levels from ENR to TMA, added note to clarify.  Fixed other wording items.