### PR TITLE
OLW, TRT, misc fixes

### DIFF
--- a/docs/controller-skills/.pages
+++ b/docs/controller-skills/.pages
@@ -1,4 +1,21 @@
 title: Controller Skills
 nav:
     - "Overview": index.md
+    - "Advanced Techniques": advanced.md
+    - "Airwork / Special Operations": airwork.md
+    - "Annotations": annotations.md
+    - "ATIS": atis.md
+    - "Callsigns": callsigns.md
+    - "Circuit Operations": CircuitOperations.md
+    - "Class D Tower": classdtwr.md
+    - "Classes of Airspace": classofairspace.md
+    - "Coordination": coordination.md
+    - "Extending": extending.md
+    - "Handover/Takeover": hoto.md
+    - "Lowest Safe Altitude (LSALT)": lsalt.md
+    - "MAESTRO": maestro.md
+    - "Restricted Areas": restrictedareas.md
+    - "Separation Standards": sepstandards.md
+    - "Sequencing": sequencing.md
+    - "vatSys": vatsys.md
     - ...

--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -34,7 +34,7 @@ CNK and MLD are responsible for final sequencing for aircraft bound for YSSY, vi
 ### Mudgee (MDE)
 Just keeping them separated!
 ### Ocean (OCN)
-OCN responsible for sequencing, issuing STAR Clearances, and issuing descent for aircraft bound for YSSY via MARLN.
+OCN is responsible for sequencing, issuing STAR Clearances, and issuing descent for aircraft bound for YSSY via MARLN.
 ## Coordination
 ### ARL (All) / SY TCU
 
@@ -71,7 +71,8 @@ Departures from YSTW in to ARL/MDE Class C will be coordinated when ready for de
 
 !!! example
     <span class="hotline">**TW ADC** -> **MDE**</span>: "Next, SKV"  
-    <span class="hotline">**MDE** -> **TW ADC**</span>: "SKV"  
+    <span class="hotline">**MDE** -> **TW ADC**</span>: "SKV, Unrestricted"  
+    <span class="hotline">**TW ADC** -> **MDE**</span>: "Unrestricted, SKV"  
 
 The Standard Assignable level from **TW ADC** to ARL/MDE is the lower of `A070` or the `RFL`.
 
@@ -92,7 +93,8 @@ Departures from YCFS in to MNN Class C will be coordinated when ready for depart
 
 !!! example
     <span class="coldline">**CFS ADC** -> **MNN**</span>: "Next, CFH21"  
-    <span class="coldline">**MNN** -> **CFS ADC**</span>: "CFH21"  
+    <span class="coldline">**MNN** -> **CFS ADC**</span>: "CFH21, Unrestricted"  
+    <span class="coldline">**CFS ADC** -> **MNN**</span>: "Unrestricted, CFH21"  
 
 The Standard Assignable level from **CFS ADC** to MNN is the lower of `A070` or the `RFL`.
 
@@ -108,8 +110,8 @@ YCFS arrivals shall be coordinated to **CFS ADC** from MNN prior to transfer of 
 Any aircraft that will enter CFS ADC airspace, and not landing at YCFS, must be Heads-up coordinated prior to **5 mins** from the boundary.
 
 !!! example
-    **MNN** -> **CFS ADC**: "via CFS, GNP"  
-    **CFS ADC** -> **MNN**: "GNP, A030"
+    <span class="hotline">**MNN** -> **CFS ADC**</span>: "via CFS, GNP"  
+    <span class="hotline">**CFS ADC** -> **MNN**</span>: "GNP, A030"
 
 ### ARL (All) / WLM TCU
 #### Airspace

--- a/docs/enroute/Brisbane Centre/INL.md
+++ b/docs/enroute/Brisbane Centre/INL.md
@@ -80,7 +80,8 @@ Departures from YBSU in to NSA Class C will be coordinated when ready for depart
 
 !!! example
     <span class="hotline">**SU ADC** -> **NSA**</span>: "Next, BNZ123"  
-    <span class="hotline">**NSA** -> **SU ADC**</span>: "BNZ123"  
+    <span class="hotline">**NSA** -> **SU ADC**</span>: "BNZ123, Unrestricted"  
+    <span class="hotline">**SU ADC** -> **NSA**</span>: "Unrestricted, BNZ123"
 
 The Standard Assignable level from **SU ADC** to NSA is the lower of `A050` or the `RFL`.
 
@@ -97,8 +98,8 @@ YBSU arrivals shall be coordinated to **SU ADC** from NSA prior to transfer of j
 Any aircraft that will enter SU ADC airspace, and not landing at YBSU, must be Heads-up coordinated prior to **5 mins** from the boundary.
 
 !!! example
-    **NSA** -> **SU ADC**: "via HOLIS, CXB"  
-    **SU ADC** -> **NSA**: "CXB, A025"
+    <span class="hotline">**NSA** -> **SU ADC**</span>: "via HOLIS, CXB"  
+    <span class="hotline">**SU ADC** -> **NSA**</span>: "CXB, A025"
 
 ### KPL / RKA
 
@@ -116,7 +117,8 @@ Departures from YCFS in to INL Class C will be coordinated when ready for depart
 
 !!! example 
     <span class="hotline">**CFS ADC** -> **INL**</span>: "Next, BNZ185"  
-    <span class="hotline">**INL** -> **CFS ADC**</span>: "BNZ185"  
+    <span class="hotline">**INL** -> **CFS ADC**</span>: "BNZ185, Unrestricted"  
+    <span class="hotline">**CFS ADC** -> **INL**</span>: "Unrestricted, BNZ185"  
 
 The Standard Assignable level from **CFS ADC** to INL is the lower of `A070` or the `RFL`.
 
@@ -132,8 +134,8 @@ YCFS arrivals shall be coordinated to **CFS ADC** from INL prior to transfer of 
 Any aircraft that will enter CFS ADC airspace, and not landing at YCFS, must be Heads-up coordinated prior to **5 mins** from the boundary.
 
 !!! example
-    **INL** -> **CFS ADC**: "via CFS, XFC"  
-    **CFS ADC** -> **INL**: "XFC, A040"
+    <span class="hotline">**INL** -> **CFS ADC**</span>: "via CFS, XFC"  
+    <span class="hotline">**CFS ADC** -> **INL**</span>: "XFC, A040"
 
 ### GOL/DOS/BUR / OK TCU and AMB TCU
 #### Airspace

--- a/docs/enroute/Brisbane Centre/ISA.md
+++ b/docs/enroute/Brisbane Centre/ISA.md
@@ -31,7 +31,7 @@ ISA is responsible for **ARA**, **STR**, **WEG**, and **CVN** when they are offl
     As per [VATPAC Ratings and Controller Positions Policy](https://cdn.vatpac.org/documents/policy/Controller+Positions+and+Ratings+Policy+v5.2.pdf), BN-ISA_CTR is only permitted to extend to adjacent **YBBB** sectors.
 
 ## Sector Responsibilities
-ISA is purely Classes A, E and G of airspace. [Standard seperation procedures](../../controller-skills/SepStandards.md/#enroute) apply.
+ISA and its subsectors are purely Classes A, E and G of airspace. [Standard seperation procedures](../../controller-skills/SepStandards.md/#enroute) apply.
 ## Coordination
 
 ### ISA (All) / ENR

--- a/docs/enroute/Brisbane Centre/KEN.md
+++ b/docs/enroute/Brisbane Centre/KEN.md
@@ -40,7 +40,7 @@ All other aircraft must be voice coordinated to CS TCU prior to **20nm** from th
 
 The Standard Assignable level from CS TCU to KEN/BAR is the lower of `F180` or the `RFL`
 
-Refer to [Cairns TCU Airspace Division](../../../terminal/cairns/#airspace-division) for information on airspace divisions when **CS TCU** is online.
+Refer to [Cairns TCU Airspace Division](../../../terminal/cairns/#airspace-division) for information on airspace divisions when **CS2** is online.
 
 ### TBP / TL TCU
 Reserved.
@@ -59,11 +59,9 @@ When **MKA** is online, they own up to `F150` in the **shaded** are shown below:
 </figure>
 
 ### KEN (All) / ENR
-
 As per [Standard coordination procedures](../../../controller-skills/coordination/#enr-enr), Voiceless, no changes to route or CFL within **20nm** to boundary.
 
 ### KEN/BAR/TBP/SWY Internal
-
 As per [Standard coordination procedures](../../../controller-skills/coordination/#enr-enr), Voiceless, no changes to route or CFL within **20nm** to boundary.
 
 TBP may make changes to CFL up to the boundary with KEN for the purposes of issuing descent for YBCS.
@@ -74,7 +72,8 @@ Departures from YBHM in to SWY Class C will be coordinated when ready for depart
 
 !!! example
     <span class="hotline">**HM ADC** -> **SWY**</span>: "Next, QFA797"  
-    <span class="hotline">**SWY** -> **HM ADC**</span>: "QFA797"  
+    <span class="hotline">**SWY** -> **HM ADC**</span>: "QFA797, Unrestricted"  
+    <span class="hotline">**HM ADC** -> **SWY**</span>: "Unrestricted, QFA797"  
 
 The Standard Assignable level from HM ADC to SWY is the lower of `A050` or the `RFL`, any other level must be prior coordinated.
 #### Arrivals
@@ -90,8 +89,8 @@ The Standard Assignable level from KEN(SWY) to HM ADC is `A060`, any other level
 Any aircraft that will enter HM ADC airspace, and not landing at YBHM, must be Heads-up coordinated prior to **5 mins** from the boundary.
 
 !!! example
-    **SWY** -> **HM ADC**: "via OVRON, KNV"  
-    **HM ADC** -> **SWY**: "KNV, A030"
+    <span class="hotline">**SWY** -> **HM ADC**</span>: "via OVRON, KNV"  
+    <span class="hotline">**HM ADC** -> **SWY**</span>: "KNV, A030"
 
 ### TBP/SWY / TSN(FLD) (Oceanic)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#enr-oceanic), Voice coordinate estimate and level prior to **15 mins** to boundary.

--- a/docs/enroute/Brisbane Centre/TRT.md
+++ b/docs/enroute/Brisbane Centre/TRT.md
@@ -4,14 +4,70 @@
 
 --8<-- "includes/abbreviations.md"
 
+## Positions
+| Name | Callsign | Frequency | Login ID |
+| ---- | -------- | --------- | -------- |
+| **Territory** | **Brisbane Centre** | **133.200** | **BN-TRT_CTR** |
+| Kimberley† | Brisbane Centre | 133.400 | BN-KIY_CTR |
+
+† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+## Airspace
+TRT is responsible for **KIY** when they are offline.  
+
 <figure markdown>
 ![Territory Airspace](../assets/trt.png){ width="700" }
   <figcaption>Territory Airspace</figcaption>
 </figure>
 
-Reserved.
+## Sector Responsibilities
+TRT is responsible for sequencing, issuing STAR Clearances, and issuing descent for aircraft bound for YPDN.  
+KIY is responsible for issuing descent and ascertaining arrival intentions for aircraft bound for YBRM.
 
 ## Coordination
+
+### TRT/KIY / ENR
+As per [Standard coordination procedures](../../../controller-skills/coordination/#enr-enr), Voiceless, no changes to route or CFL within **20nm** to boundary.
+
+### TRT/KIY Internal
+As per [Standard coordination procedures](../../../controller-skills/coordination/#enr-enr), Voiceless, no changes to route or CFL within **20nm** to boundary.
+
+### TRT / DN TCU
+The Standard Assignable level from TRT to DN TCU is `A100` and assigned the relevant STAR. 
+
+All other aircraft must be voice coordinated to DN TCU prior to **20nm** from the boundary.
+
+The Standard Assignable level from DN TCU to TRT is the lower of `F180` or the `RFL`
+
+Refer to [Darwin TCU Airspace Division](../../../military/darwin/#tcu) for information on airspace divisions when **DAW** is online.
+
+### KIY / BRM ADC
+#### Departures
+Departures from YBRM in to KIY CTA will be coordinated when ready for departure.  
+
+!!! example
+    <span class="hotline">**BRM ADC** -> **KIY**</span>: "Next, ANO333"  
+    <span class="hotline">**KIY** -> **BRM ADC**</span>: "ANO333, Unrestricted"  
+    <span class="hotline">**BRM ADC** -> **KIY**</span>: "Unrestricted, ANO333"  
+
+The Standard Assignable level from BRM ADC to TRT(KIY) is the lower of `A050` or the `RFL`, any other level must be prior coordinated.
+#### Arrivals
+TRT(KIY) must coordinate the sequence to BRM ADC prior to **5 mins** from the boundary.
+
+!!! example
+    <span class="coldline">**TRT** -> **BRM ADC**</span>: "New Sequence of 2. Via SAFIR, FD621, Number 1. Via MASIM, NWK1654 for the RNP U RWY 10, Number 2”  
+    <span class="coldline">**BRM ADC** -> **TRT**</span>: "FD621, Number 1. NWK1654, Number 2"  
+
+The Standard Assignable level from TRT(KIY) to BRM ADC is `A060`, any other level must be prior coordinated.
+
+#### Overfliers
+Any aircraft that will enter BRM ADC airspace, and not landing at YBRM, must be Heads-up coordinated prior to **5 mins** from the boundary.
+
+!!! example
+    <span class="hotline">**KIY** -> **BRM ADC**</span>: "via CIN, NQC"  
+    <span class="hotline">**BRM ADC** -> **SWY**</span>: "NQC, A045"
+
+## KIY / IND(INE) (Oceanic)
+As per [Standard Coordination Procedures](../../../controller-skills/coordination/#enr-oceanic).
 ### TRT/KIY / International (WAAF)
 Coordination to International units must be done prior to **15 mins** from the boundary in the following format:
 

--- a/docs/enroute/Melbourne Centre/ASP.md
+++ b/docs/enroute/Melbourne Centre/ASP.md
@@ -43,8 +43,9 @@ As per [Standard coordination procedures](../../../controller-skills/coordinatio
 Departures from YBAS in to ASP Class C will be coordinated when ready for departure.
 
 !!! example
-    <span class="hotline">**AS ADC** -> **ASP**</span>: "Next QFA797"  
-    <span class="hotline">**ASP** -> **AS ADC**</span>: "QFA797"
+    <span class="hotline">**AS ADC** -> **ASP**</span>: "Next, QFA797"  
+    <span class="hotline">**ASP** -> **AS ADC**</span>: "QFA797, Unrestricted"  
+    <span class="hotline">**AS ADC** -> **ASP**</span>: "Unrestricted, QFA797"  
 
 The Standard Assignable level from **AS ADC** to ASP is the lower of `A070` or the `RFL`, any other level must be prior coordinated.
 #### Arrivals
@@ -60,7 +61,5 @@ The Standard Assignable level from ASP to **AS ADC** is `A080`, any other level 
 Any aircraft that will enter AS ADC airspace, and not landing at YBAS, must be Heads-up coordinated prior to **5 mins** from the boundary.
 
 !!! example
-    **ASP** -> **AS ADC**: "via AS, JDS"  
-    **AS ADC** -> **ASP**: "JDS, A060"
-### WRA / WR ADC
-Reserved.
+    <span class="hotline">**ASP** -> **AS ADC**</span>: "via AS, JDS"  
+    <span class="hotline">**AS ADC** -> **ASP**</span>: "JDS, A060"

--- a/docs/enroute/Melbourne Centre/ELW.md
+++ b/docs/enroute/Melbourne Centre/ELW.md
@@ -94,7 +94,8 @@ Departures from YMAY in to BLA Class C will be coordinated when ready for depart
 
 !!! example
     <span class="hotline">**AY ADC** -> **BLA**</span>: "Next, RXA6772"  
-    <span class="hotline">**BLA** -> **AY ADC**</span>: "RXA6772" 
+    <span class="hotline">**BLA** -> **AY ADC**</span>: "RXA6772, Unrestricted"  
+    <span class="hotline">**AY ADC** -> **BLA**</span>: "Unrestricted, RXA6772"  
 
 The Standard Assignable level from **AY ADC** to BLA is the lower of `A070` or the `RFL`.
 
@@ -111,5 +112,5 @@ The Standard Assignable level from BLA to **AY ADC** is `A080`.
 Any aircraft that will enter AY ADC airspace, and not landing at YMAY, must be Heads-up coordinated prior to **5 mins** from the boundary.
 
 !!! example
-    **BLA** -> **AY ADC**: "via AY, NGJ"  
-    **AY ADC** -> **BLA**: "NGJ, A040"
+    <span class="hotline">**BLA** -> **AY ADC**</span>: "via AY, NGJ"  
+    <span class="hotline">**AY ADC** -> **BLA**</span>: "NGJ, A040"

--- a/docs/enroute/Melbourne Centre/OLW.md
+++ b/docs/enroute/Melbourne Centre/OLW.md
@@ -4,9 +4,62 @@
 
 --8<-- "includes/abbreviations.md"
 
+## Positions
+| Name | Callsign | Frequency | Login ID |
+| ---- | -------- | --------- | -------- |
+| **Onslow** | **Melbourne Centre** | **134.000** | **ML-OLW_CTR** |
+| Port† | Melbourne Centre | 127.000 | ML-POT_CTR |
+| Paraburdoo† | Melbourne Centre | 133.500 | ML-PAR_CTR |
+| Newman† | Melbourne Centre | 125.400 | ML-NEW_CTR |
+| Meekatharra† | Melbourne Centre | 132.000 | ML-MEK_CTR |
+| Mount† | Melbourne Centre | 133.700 | ML-MTK_CTR |
+| Menzies† | Melbourne Centre | 134.300 | ML-MZI_CTR |
+
+† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+## Airspace
+OLW is responsible for **POT**, **PAR**, **NEW**, **MEK**, **MTK** and **MZI** when they are offline.  
+
 <figure markdown>
 ![Onslow Airspace](../assets/olw.png){ width="700" }
   <figcaption>Onslow Airspace</figcaption>
 </figure>
 
-Reserved.
+## Sector Responsibilities
+OLW is responsible for issuing descent and ascertaining arrival intentions for aircraft bound for YPKA.
+
+## Coordination
+
+### OLW(All) / ENR
+As per [Standard coordination procedures](../../../controller-skills/coordination/#enr-enr), Voiceless, no changes to route or CFL within **20nm** to boundary.
+
+### OLW/POT/PAR/NEW/MEK/MTK/MZI Internal
+As per [Standard coordination procedures](../../../controller-skills/coordination/#enr-enr), Voiceless, no changes to route or CFL within **20nm** to boundary.
+
+### OLW / KA ADC
+#### Departures
+Departures from YPKA in to OLW CTA will be coordinated when ready for departure.  
+
+!!! example
+    <span class="hotline">**KA ADC** -> **OLW**</span>: "Next, OHN"  
+    <span class="hotline">**OLW** -> **KA ADC**</span>: "OHN, Unrestricted"  
+    <span class="hotline">**KA ADC** -> **OLW**</span>: "Unrestricted, OHN"  
+
+The Standard Assignable level from KA ADC to OLW is the lower of `A050` or the `RFL`, any other level must be prior coordinated.
+#### Arrivals
+OLW must coordinate the sequence to KA ADC prior to **5 mins** from the boundary.
+
+!!! example
+    <span class="coldline">**OLW** -> **KA ADC**</span>: "New Sequence of 2. Via MCNAB, QFA1214 for the RNP U RWY 26, Number 1. Via PD, FD626J, Number 2”  
+    <span class="coldline">**KA ADC** -> **OLW**</span>: "QFA1214, Number 1. FD626J, Number 2"  
+
+The Standard Assignable level from OLW to KA ADC is `A060`, any other level must be prior coordinated.
+
+#### Overfliers
+Any aircraft that will enter KA ADC airspace, and not landing at YPKA, must be Heads-up coordinated prior to **5 mins** from the boundary.
+
+!!! example
+    <span class="hotline">**OLW** -> **KA ADC**</span>: "via BORAT, QQK"  
+    <span class="hotline">**KA ADC** -> **OLW**</span>: "QQK, A030"
+
+## OLW(All) / IND/INE (Oceanic)
+As per [Standard Coordination Procedures](../../../controller-skills/coordination/#enr-oceanic).

--- a/docs/enroute/Melbourne Centre/PIY.md
+++ b/docs/enroute/Melbourne Centre/PIY.md
@@ -17,9 +17,6 @@
 
 † *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
 ## Airspace
-
-Pingelly assumes responsiblity of the airspace within 36nm of PH DME above `F245`  
-
 <figure markdown>
 ![Pingelly Airspace](../assets/piy.png){ width="700" }
   <figcaption>Pingelly Airspace</figcaption>
@@ -31,7 +28,7 @@ PIY will provide final sequencing actions to ensure aircraft comply with their F
 For aircraft overflying the PH TCU place `O/FLY` in the LABEL DATA field.
 
 ### Leeman (LEA)
-LEA is responsible for assigning and issuing arrival clearance to aircraft inbound to Perth via `WAVES`. LEA is also responsible for transiting aircraft outbound from Perth into the Melbourne Oceanic Control Area. Coordination between this non-radar position (ML-IND_FSS) must be completed in accordance with [Standard Coordination Procedures](../../../controller-skills/coordination/#enr-oceanic){target=new}.  
+LEA is responsible for assigning and issuing arrival clearance to aircraft inbound to Perth via `WAVES`.
 
 !!! note
     Controllers should be aware that VHF coverage near the LEA/IND border may be limited. Controllers should strive to issue HF frequencies and transfer of communications instruction prior to 160 NM PH DME.
@@ -49,17 +46,25 @@ JAR is responsible for assigning and issuing arrival clearance to aircraft inbou
 
 
 ## Coordination
-## ENR / PH TCU
-### Standard Assignable Levels
-The Standard assignable level from ENR to PH TCU is:  
-`A090` for all arrivals on a STAR.
+## PIY(All) / PH TCU
+The Standard Assignable level from PIY(All) to PH TCU is `A090` and assigned the relevant STAR. 
 
 All other aircraft must be voice coordinated to PH TCU prior to **20nm** from the boundary.
-## PIY (ALL) / ENR
 
-As per the enroute coordination requirements, voiceless coordination exists between enroute sectors, with changes permitted up to the boundary with PIY.
+The Standard Assignable level from PH TCU to PIY(All) is the lower of `F240` or the `RFL`.
 
-Refer to [Perth TCU Airspace Division](../../../terminal/perth/#airspace-division){target=new} for information on airspace divisions when **PHD** is online.
-## LEA / IND (Oceanic)
+Refer to [Perth TCU Airspace Division](../../../terminal/perth/#airspace-division) for information on airspace divisions when **PHD** is online.
 
-As per [Standard Coordination Procedures](../../../controller-skills/coordination/#enr-oceanic){target=new}.
+## PIY(All) / ENR
+As per [Standard coordination procedures](../../../controller-skills/coordination/#enr-enr), Voiceless, no changes to route or CFL within **20nm** to boundary.
+
+## PIY/LEA/GVE/HYD/JAR Internal
+Changes to CFL are permitted up to the boundary from GVE, CRS and HYD to PIY.
+
+All else is as per [Standard coordination procedures](../../../controller-skills/coordination/#enr-enr), Voiceless, no changes to route or CFL within **20nm** to boundary.
+
+That being said, it is *advised* that PIY(All) gives **Heads-up Coordination** in the following scenarios:  
+- JAR to PIY for all aircraft  
+- LEA to PIY for all aircraft  
+## PIY(All) / IND (Oceanic)
+As per [Standard Coordination Procedures](../../../controller-skills/coordination/#enr-oceanic).

--- a/docs/military/woomera.md
+++ b/docs/military/woomera.md
@@ -1,7 +1,0 @@
----
-  title: Woomera Tower
----
-
---8<-- "includes/abbreviations.md"
-
-Reserved.

--- a/docs/terminal/brisbane.md
+++ b/docs/terminal/brisbane.md
@@ -116,8 +116,8 @@ Any aircraft that don't meet these criteria must be coordinated to BN TCU with a
 
 !!! example
     <span class="hotline">**BN ADC** -> **BN TCU**</span>: "Next, ABC, runway 19L"  
-    <span class="hotline">**BN TCU** -> **BN ADC**</span>: "ABC, Heading 030, unrestricted"  
-    <span class="hotline">**BN ADC** -> **BN TCU**</span>: "Heading 030 unrestricted, ABC"
+    <span class="hotline">**BN TCU** -> **BN ADC**</span>: "ABC, Heading 030, Unrestricted"  
+    <span class="hotline">**BN ADC** -> **BN TCU**</span>: "Heading 030 Unrestricted, ABC"
 
 ### BN TCU / AF ADC
 #### Departures
@@ -138,7 +138,8 @@ When aircraft planned via a CTA departure are ready for takeoff and expected to 
 
 !!! example
     <span class="hotline">**AF ADC** -> **BN TCU**</span>: "Next, XMM, 10L"  
-    <span class="hotline">**BN TCU** -> **AF ADC**</span>: "XMM, unrestricted"
+    <span class="hotline">**BN TCU** -> **AF ADC**</span>: "XMM, Unrestricted"  
+    <span class="hotline">**AF ADC** -> **BN TCU**</span>: "Unrestricted, XMM"
 
 #### Arrivals
 YBAF arrivals shall be coordinated to **AF ADC** from BN TCU prior to transfer of jurisdiction.  If an instrument approach is planned, include the estimated approach time.

--- a/docs/terminal/perth.md
+++ b/docs/terminal/perth.md
@@ -67,9 +67,9 @@ The divisions of the airspace between **PHA**, and **PHD** change based on the R
 
 ### PH TCU / ENR
 #### Departures
-Voiceless coordination is in place from AD TCU to PIY (and subsectors) for aircraft tracking via a SID and:  
-Planned at or above `F180`: `Assigned F180`  
-Planned below `F180`: `Assigned the RFL`  
+Voiceless coordination is in place from PH TCU to PIY (and subsectors) for aircraft tracking via a SID and:  
+Planned at or above `F240`: `Assigned F240`  
+Planned below `F240`: `Assigned the RFL`  
 
 Any aircraft not meeting the above criteria must be prior coordinated to ENR.
 
@@ -152,5 +152,5 @@ Given that the instrument approach procedure will terminate inside another contr
     <span class="hotline">**PH TCU** -> **JT ADC**</span>: "Cleared RNAV-Z 24R, UJN" 
 
 ### PH TCU / PEA ADC
-Reserved
+Reserved.
 


### PR DESCRIPTION
- further fixes to "unrestricted" phraseology (mainly ENR pages that were missing it)
- controller skills content manually ordered alphabetically
- completed TRT page
- completed OLW page
- multiple fixes to PIY
- general typos
- removed all references to woomera
- added hotline highlight format to overflier coord sections that were missing it
- changed PH std assignable to F240. if they own up to F245, itd be weird that the std assignable is F180. ill double check it though