### PR TITLE
Add 09A/16D Operational Info

### DIFF
--- a/docs/aerodromes/Melbourne.md
+++ b/docs/aerodromes/Melbourne.md
@@ -94,6 +94,12 @@ This permits controllers to assign aircraft either the Alpha or Victor STAR and 
 | 16A/27D    | 16 FOR ARR, RWY 27 FOR DEPARTURES  |
 | 09A/16D    | 09 FOR ARR, RWY 16 FOR DEPARTURES  |
 
+### Operational Info
+When using runway mode 09A/16D, the ATIS OPR INFO shall include:  
+`SIMUL INDEP CROSSING RWY OPS IN PROG`
+
+This allows for both Runway 09 and Runway 16 to operate independently of each other, with aircraft departing Runway 16 from Taxiway Echo.
+
 ## Coordination
 ### ML ADC / ML TCU
 #### Auto Release


### PR DESCRIPTION
## Add 09A/16D Operational Info

Added D-ATIS operational info and description, as per the Melbourne Tower Local Instructions (2021, Version 23, Section 12.1.2):

![image](https://user-images.githubusercontent.com/48381358/231253741-c4633668-f495-4bfb-85f1-e6410e7dd5ae.png)

![image](https://user-images.githubusercontent.com/48381358/231253194-c3778c6b-c266-4630-af45-91a3cb26f19a.png)

### Attached documents
[Melbourne Tower Local Instructions (2021)](https://github.com/vatpac-technology/sops/files/11203630/Docs_3-4_FOI-21-37.pdf)
