### PR TITLE
Remove IAP vectoring distances/levels

### DIFF
--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -109,15 +109,6 @@ SFW/SFE may provide distance to touchdown, when transferring an aircraft to towe
 !!! example
     "QFA490, 8 miles to touchdown, contact tower 120.5"
 
-### Instrument Approach
-
-Aim to vector aircraft to the following Intercept points during instrument PROPS (GLS or ILS approach) unless sufficient separation can be established between parallel approaches:
-
-| Runway | Distance from Threshold | Level  |
-| --| ----------------| --------- |
-|RWY 16R/34L| 10nm   | `A030`     |
-|RWY 16L/34R| 15nm or further | `A040` |
-
 ### Independent Visual Approach
 
 When conducting IVAs, aircraft shall not be transferred to **SY ADC** until established on final.

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -109,6 +109,12 @@ SFW/SFE may provide distance to touchdown, when transferring an aircraft to towe
 !!! example
     "QFA490, 8 miles to touchdown, contact tower 120.5"
 
+### Instrument Approach
+
+Aircraft joining parallel instrument approaches must remain separated from aircraft on the adjacent approach until they are established. This usually involves keeping aircraft vertically separated and may require aircraft to intercept the localiser/final approach course and maintain their assigned level, only allowing descent on the approach once they are established.  
+
+Two aircraft established on adjacent parallel approaches require `1nm` lateral separation as opposed to the 3nm standard required in the TMA generally.
+
 ### Independent Visual Approach
 
 When conducting IVAs, aircraft shall not be transferred to **SY ADC** until established on final.


### PR DESCRIPTION
Had some students recently vectoring huge circuits to comply with this paragraph. From my understanding, this existed for PRMs and since aircraft on adjacent approaches only require 1nm between them now, these huge circuits don't seem to be necessary. Added a general note requiring a separation standard until adjacent aircraft are established, then descent on the approach.

~~Can someone with the knowhow confirm that aircraft established on parallel approaches at SY only require 1nm lateral sep?~~
Edit: confirmed with Jake 