### PR TITLE
Table of Contents Colour, YSSY Sequencing Notes & Small Fixes

### DIFF
--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -51,12 +51,12 @@ The Standard Assignable level from SY TCU to ARL(All) is the lower of `F280` or 
 Refer to [Sydney TCU Airspace Division](../../terminal/sydney/#airspace-division) for information on airspace divisions when **SAS**, **SDN**, **SDS** and/or **SRI** are online.
 
 ### ARL (All) / ENR
-As per [Standard coordination procedures](../../controller-skills/coordination/#enr-enr), Voiceless, no changes to route or CFL within **50nm** to boundary.
+As per [Standard coordination procedures](../../../controller-skills/coordination/#enr-enr), Voiceless, no changes to route or CFL within **50nm** to boundary.
 
 ### ARL/MDE/CNK/MNN/MLD/OCN Internal
-As per [Standard coordination procedures](../../controller-skills/coordination/#enr-enr), Voiceless, no changes to route or CFL within **50nm** to boundary.
+As per [Standard coordination procedures](../../../controller-skills/coordination/#enr-enr), Voiceless, no changes to route or CFL within **50nm** to boundary.
 
-That being said, it is *advised* that ARL(All) gives **Heads-up Coordination** in the following scenarios:   
+That being said, due to their small sizes and frequent random-track traffic, it is *advised* that ARL(All) gives **Heads-up Coordination** in the following scenarios:   
 - MNN to ARL for all aircraft  
 - ARL to MNN for all aircraft  
 - CNK to MLD for all aircraft  
@@ -146,4 +146,4 @@ To put it bluntly, the R574 Restricted Area is quite large.
 It also occupies a lot of airspace that would commonly be used by YSSY arrivals and departures. If YWLM military operations are taking ownership of this airspace, it is good practice to negotiate an airspace release, whether that be a lateral or vertical portion of airspace (or a combination), to enable them to facilitate YSSY arrivals and departures with minimal impact.
 
 ### OCN/MNN / TSN/HWE (Oceanic)
-As per [Standard coordination procedures](../../controller-skills/coordination/#enr-oceanic), Heads-up coordinate prior to **15 mins** to boundary.
+As per [Standard coordination procedures](../../../controller-skills/coordination/#enr-oceanic), Heads-up coordinate prior to **15 mins** to boundary.

--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -58,16 +58,18 @@ Refer to the [Sequencing into YSSY](#sequencing-into-yssy) notes below for runwa
 ### Sequencing into YSSY
 Sequencing arrivals from the north/east into YSSY is a joint responsibility of the subsectors of ARL. Initial sequencing actions for aircraft from the north should be performed by ARL and MNN, with fine tuning and any holding required issued by CNK. 
 
-Aircraft from the north/east are *generally* assigned 16L/34R and aircraft from the south/west assigned 16R/34L to simplify the sequencing required.  However, some heavy aircraft from the north/east may operationally require the longer runway. In this case, coordination may be required with Melbourne Centre or Sydney Flow (if operating) to ensure that the sequence is built in an efficient and orderly way. Similarly, it may be beneficial for the sequence to assign an arrival to runway 16R/34L to avoid unnecessary delays for the other runway.
+Aircraft from the north/east shall be assigned **runway 16L/34R** during PROPS. However, some situations may warrant the use of the main runway (16R/34L), such as heavy aircraft operationally requiring the longer runway or large volumes of traffic requiring the use of both runways to minimise delay. In this case, coordination must be conducted with Melbourne Centre or Sydney Flow (if operating) to ensure that the sequence is built in an efficient and orderly way.
 
-!!! note
-    Consider traffic inbound from the south/west when assigning runway 16R/34L, as Melbourne Centre will preference that runway for arrivals from their airspace.
+!!! example
+    <span class="hotline">**ARL** -> **BIK**</span>: "North of Sydney, CPA21, with your concurrence will be assigned runway 34L due operational requirement"  
+    <span class="hotline">**BIK** -> **ARL**</span>: "Concur, CPA21 runway 34L, required landing time 43 due sequence from the west"  
+    <span class="hotline">**ARL** -> **BIK**</span>: "Runway 34L, landing time 43, CPA21"
 
 Jet aircraft for YSSY shall be assigned the **BOREE** STAR.  
 Non-jet aircraft for YSSY shall be assigned the **MEPIL** STAR.
 
 !!! tip
-    Whilst the preference is to keep jet/non-jet aircraft assigned the default STAR as above, there are situations where the sequence may be improved by assigning the adjacent STAR (e.g. a jet assigned the MEPIL STAR).  
+    Whilst the preference is to keep jet/non-jet aircraft assigned the default STAR as above, there are situations where the sequence may be improved by assigning the adjacent STAR (e.g. a jet assigned the MEPIL STAR). This is most common when assigning the alternate runway to an arrival.  
     
     Either **SY TCU** or **ARL** may propose utilising the adjacent STAR where two aircraft with significantly different cruise/descent speeds will be required to overtake or pass abeam each other to achieve a sequenced landing time, or if assigned different runways. This technique can allow aircraft to be processed for different runways independently with minimal delay by using the built-in separation afforded by the STAR height requirements.  
 

--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -56,7 +56,7 @@ OCN is responsible for sequencing, issuing STAR Clearances, and issuing descent 
 Refer to the [Sequencing into YSSY](#sequencing-into-yssy) notes below for runway selection notes.
 
 ### Sequencing into YSSY
-Sequencing arrivals from the north/east into YSSY is a joint responsibility of the subsectors of ARL. Initial sequencing actions should be performed by ARL and MNN, with fine tuning and any holding required issued by CNK.
+Sequencing arrivals from the north/east into YSSY is a joint responsibility of the subsectors of ARL. Initial sequencing actions for aircraft from the north should be performed by ARL and MNN, with fine tuning and any holding required issued by CNK. 
 
 Aircraft from the north/east are *generally* assigned 16L/34R and aircraft from the south/west assigned 16R/34L to simplify the sequencing required.  However, some heavy aircraft from the north/east may operationally require the longer runway. In this case, coordination may be required with Melbourne Centre or Sydney Flow (if operating) to ensure that the sequence is built in an efficient and orderly way. Similarly, it may be beneficial for the sequence to assign an arrival to runway 16R/34L to avoid unnecessary delays for the other runway.
 

--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -27,17 +27,52 @@ When **CFS ADC** is offline, CFS CTR (Class D `SFC` to `A045`) reverts to Class 
 
 ## Sector Responsibilities
 ### Armidale (ARL) / Manning (MNN)
-ARL and MNN are responsible for initial sequencing, issuing STAR Clearances, and issuing initial descent for aircraft bound for YSSY, via BOREE and MEPIL respectively.  
+ARL and MNN are responsible for initial sequencing, issuing STAR Clearances, and issuing initial descent for aircraft bound for YSSY, via BOREE and MEPIL respectively. Aircraft cruising above `F250` should be assigned *no lower* than `F250` and handed to CNK for further descent. Aircraft cruising below `F250` should be transferred to CNK at their cruise level.
+
+Refer to the [Sequencing into YSSY](#sequencing-into-yssy) notes below for runway and STAR selection notes.
+
+ARL is also responsible for aircraft operating into/out of YSTW from the south/east when TW ADC is operating.
+
+!!! note
+    ARL and MDE share a joint responsibility to build the final sequence of arrivals into YSTW when the tower is open. Coordination with MDE should be conducted to ensure that aircraft from each sector are sequenced appropriately with each other.
+
+### Cessnock (CNK) 
+CNK is responsible for final sequencing and descent for aircraft bound for YSSY, via BOREE and MEPIL.
+
+Refer to the [Sequencing into YSSY](#sequencing-into-yssy) notes below for runway and STAR selection notes.
+
+### Maitland (MLD)
+MLD is responsible for handling northbound departures from YSSY and arrivals into YWLM from the south.
+
+### Mudgee (MDE)
+MDE is responsible for aircraft operating into/out of YSTW from the north/west when TW ADC is operating.
+
+!!! note
+    ARL and MDE share a joint responsibility to build the final sequence of arrivals into YSTW when the tower is open. Coordination with ARL should be conducted to ensure that aircraft from each sector are sequenced appropriately with each other.
+
+### Ocean (OCN)
+OCN is responsible for sequencing, issuing STAR Clearances, and issuing descent for aircraft bound for YSSY via MARLN.
+
+Refer to the [Sequencing into YSSY](#sequencing-into-yssy) notes below for runway selection notes.
+
+### Sequencing into YSSY
+Sequencing arrivals from the north/east into YSSY is a joint responsibility of the subsectors of ARL. Initial sequencing actions should be performed by ARL and MNN, with fine tuning and any holding required issued by CNK.
+
+Aircraft from the north/east are *generally* assigned 16L/34R and aircraft from the south/west assigned 16R/34L to simplify the sequencing required.  However, some heavy aircraft from the north/east may operationally require the longer runway. In this case, coordination may be required with Melbourne Centre or Sydney Flow (if operating) to ensure that the sequence is built in an efficient and orderly way. Similarly, it may be beneficial for the sequence to assign an arrival to runway 16R/34L to avoid unnecessary delays for the other runway.
+
+!!! note
+    Consider traffic inbound from the south/west when assigning runway 16R/34L, as Melbourne Centre will preference that runway for arrivals from their airspace.
+
 Jet aircraft for YSSY shall be assigned the **BOREE** STAR.  
 Non-jet aircraft for YSSY shall be assigned the **MEPIL** STAR.
 
-For Sequencing purposes, MEPIL and BOREE must be considered to be the same STAR. Practically, this means ARL must sequence at least a 2 minute gap between all YSSY arrivals, whether they are arriving via the same feeder fix or not.
-### Cessnock (CNK) / Maitland (MLD)
-CNK and MLD are responsible for final sequencing for aircraft bound for YSSY, via BOREE and MEPIL respectively.
-### Mudgee (MDE)
-Just keeping them separated!
-### Ocean (OCN)
-OCN is responsible for sequencing, issuing STAR Clearances, and issuing descent for aircraft bound for YSSY via MARLN.
+!!! tip
+    Whilst the preference is to keep jet/non-jet aircraft assigned the default STAR as above, there are situations where the sequence may be improved by assigning the adjacent STAR (e.g. a jet assigned the MEPIL STAR).  
+    
+    Either **SY TCU** or **ARL** may propose utilising the adjacent STAR where two aircraft with significantly different cruise/descent speeds will be required to overtake or pass abeam each other to achieve a sequenced landing time, or if assigned different runways. This technique can allow aircraft to be processed for different runways independently with minimal delay by using the built-in separation afforded by the STAR height requirements.  
+
+    In this case, coordination should be conducted to ensure that both controllers agree and no additional conflicts are created as a result (particularly with aircraft inbound from the south/west).
+
 ## Coordination
 ### ARL (All) / SY TCU
 The Standard Assignable level from ARL(All) to SY TCU is:  

--- a/docs/enroute/Melbourne Centre/BIK.md
+++ b/docs/enroute/Melbourne Centre/BIK.md
@@ -62,16 +62,18 @@ Refer to the [Sequencing into YSSY](#sequencing-into-yssy) notes below for runwa
 ### Sequencing into YSSY
 Sequencing arrivals from the west into YSSY is a joint responsibility of GUN and BIK. Initial sequencing actions should be performed by GUN, with fine tuning and any holding required issued by BIK.
 
-Aircraft from the south/west are *generally* assigned 16R/34L and aircraft from the north/east assigned 16L/34R to simplify the sequencing required.  However, some heavy aircraft from the north/east may operationally require the longer runway, so consider assigning an aircraft on the ODALE/RIVET STAR 16L/34R to free up a slot on the other runway as necessary. Similarly, it may be beneficial for the sequence to assign an arrival to runway 16L/34R to avoid unnecessary delays for the main runway.
+Aircraft from the south/west shall be assigned **runway 16R/34L** during PROPS. However, some situations may warrant the use of the alternate runway (16L/34R), such as heavy aircraft operationally requiring the longer runway from the north or large volumes of traffic requiring the use of both runways to minimise delay. In this case, coordination must be conducted with Brisbane Centre or Sydney Flow (if operating) to ensure that the sequence is built in an efficient and orderly way.
 
-!!! note
-    Consider traffic inbound from the north/east when assigning runway 16L/34R, as Brisbane Centre will preference that runway for arrivals from their airspace.
+!!! example
+    <span class="hotline">**BIK** -> **ARL**</span>: "Southwest of Sydney, VOZ421, with your concurrence will be assigned runway 34R for sequencing"  
+    <span class="hotline">**ARL** -> **BIK**</span>: "Concur, VOZ421 runway 34R, required landing time 22 due sequence from the north"  
+    <span class="hotline">**BIK** -> **ARL**</span>: "Runway 34R, landing time 22, VOZ421"
 
 Jet aircraft for YSSY shall be assigned the **RIVET** STAR.  
 Non-jet aircraft for YSSY shall be assigned the **ODALE** STAR.
 
 !!! tip
-    Whilst the preference is to keep jet/non-jet aircraft assigned the default STAR as above, there are situations where the sequence may be improved by assigning the adjacent STAR (e.g. a non-jet assigned the RIVET STAR).  
+    Whilst the preference is to keep jet/non-jet aircraft assigned the default STAR as above, there are situations where the sequence may be improved by assigning the adjacent STAR (e.g. a non-jet assigned the RIVET STAR). This is most common when assigning the alternate runway to an arrival.   
     
     Either **SY TCU** or **BIK** may propose utilising the adjacent STAR where two aircraft with significantly different cruise/descent speeds will be required to overtake or pass abeam each other to achieve a sequenced landing time, or if assigned different runways. This technique can allow aircraft to be processed for different runways independently with minimal delay by using the built-in separation afforded by the STAR height requirements.  
 

--- a/docs/enroute/Melbourne Centre/BIK.md
+++ b/docs/enroute/Melbourne Centre/BIK.md
@@ -35,12 +35,9 @@ BIK will provide final sequencing actions and descent into YSSY. The BIK sector 
 
 If no subsectors are online, it is advisable to continue this practice, issuing STAR clearance with airways clearance or on first contact (see the WOL & GUN notes below) and leaving runway assignment until the aircraft enters the BIK sector.
 
-!!! tip
-    Aircraft from the south/west are *generally* assigned 16R/34L and aircraft from the north/east assigned 16L/34R to simplify the sequencing required.  However, some heavy aircraft from the north/east may operationally require the longer runway, so consider assigning an aircraft on the ODALE STAR 16L/34R to free up a slot on the other runway.
-
 For aircraft overflying the SY TMA, place *'O/FLY'* in the LABEL DATA field.
 
-For Sequencing purposes, ODALE and RIVET must be considered to be the same STAR. Practically, this means BIK must sequence at least a 2 minute gap between all YSSY arrivals, whether they are arriving via the same feeder fix or not.
+Refer to the [Sequencing into YSSY](#sequencing-into-yssy) notes below for runway and STAR selection notes.
 
 ### Wollongong (WOL)
 WOL is reponsible for issuing STAR clearances, initial descent, and sequencing actions for aircraft inbound to YSCB. WOL is also responsible for issuing STAR clearance *(but not runway assignment)* to aircraft processed via the ODALE STAR into YSSY which depart from an aerodrome within the subsector. The BIK controller will issue runway assignment to these aircraft on first contact.
@@ -57,11 +54,28 @@ GUN is reponsible for issuing STAR clearances and initial descent for aircraft i
     *VOZ655 (operated by a SAAB 340) has departed YSCB for YSSY and been handed off from CB TCU to GUN*  
     **VOZ655:** "Melbourne Centre, VOZ655, climbing F130"  
     **GUN:** "VOZ655, Melbourne Centre, cleared ODALE7 arrival, climb F130"
+    
+GUN is also responsible for initial sequencing actions into YSSY. Aircraft cruising above `F250` should be assigned *no lower* than `F250` and handed to BIK for further descent. Aircraft cruising below `F250` should be transferred to BIK at their cruise level.
+
+Refer to the [Sequencing into YSSY](#sequencing-into-yssy) notes below for runway and STAR selection notes.
+
+### Sequencing into YSSY
+Sequencing arrivals from the west into YSSY is a joint responsibility of GUN and BIK. Initial sequencing actions should be performed by GUN, with fine tuning and any holding required issued by BIK.
+
+Aircraft from the south/west are *generally* assigned 16R/34L and aircraft from the north/east assigned 16L/34R to simplify the sequencing required.  However, some heavy aircraft from the north/east may operationally require the longer runway, so consider assigning an aircraft on the ODALE/RIVET STAR 16L/34R to free up a slot on the other runway as necessary. Similarly, it may be beneficial for the sequence to assign an arrival to runway 16L/34R to avoid unnecessary delays for the main runway.
+
+!!! note
+    Consider traffic inbound from the north/east when assigning runway 16L/34R, as Brisbane Centre will preference that runway for arrivals from their airspace.
 
 Jet aircraft for YSSY shall be assigned the **RIVET** STAR.  
 Non-jet aircraft for YSSY shall be assigned the **ODALE** STAR.
+
+!!! tip
+    Whilst the preference is to keep jet/non-jet aircraft assigned the default STAR as above, there are situations where the sequence may be improved by assigning the adjacent STAR (e.g. a non-jet assigned the RIVET STAR).  
     
-GUN is also responsible for initial sequencing actions into YSSY. Aircraft cruising above `F250` should be assigned *no lower* than `F250` and handed to BIK for further descent. Aircraft cruising below `F250` should be transferred to BIK at their cruise level.
+    Either **SY TCU** or **BIK** may propose utilising the adjacent STAR where two aircraft with significantly different cruise/descent speeds will be required to overtake or pass abeam each other to achieve a sequenced landing time, or if assigned different runways. This technique can allow aircraft to be processed for different runways independently with minimal delay by using the built-in separation afforded by the STAR height requirements.  
+
+    In this case, coordination should be conducted to ensure that both controllers agree and no additional conflicts are created as a result (particularly with aircraft inbound from the north/east).
 
 ## Coordination
 ### BIK/WOL / SY TCU

--- a/docs/enroute/Melbourne Centre/BIK.md
+++ b/docs/enroute/Melbourne Centre/BIK.md
@@ -14,7 +14,7 @@
 † *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
-BIK assumes responsibility of the airspace within 45nm of SY DME above `FL280`.  
+BIK assumes responsibility of the airspace within 45nm of SY DME above `FL285`.  
 GUN BIK assumes responsibility of the airspace within the lateral limits of the CB TCU above `FL245`, except for the region to the south west, which is assumed by ELW(BLA).
 
 !!! note

--- a/docs/stylesheets/navigation.css
+++ b/docs/stylesheets/navigation.css
@@ -30,6 +30,9 @@
   color: var(--md-primary-fg-color);
   height: -webkit-fill-available;
 }
+.md-nav__link[data-md-state=blur]:not(.md-nav__link--active) {
+  color: inherit;
+}
 
 /*Announcement Bar*/
 .md-banner {

--- a/docs/terminal/adelaide.md
+++ b/docs/terminal/adelaide.md
@@ -40,7 +40,7 @@ The TCU controller will coordinate these aircraft with ADC prior to issuing airw
 | Southbound | HNLY |
 
 <figure markdown>
-![Clearance Limits](img/adclearancelimits.png){ width="500" }
+![Clearance Limits](../aerodromes/img/adclearancelimits.png){ width="500" }
   <figcaption>Clearance Limits (red) and Approach/Departure Path (green)</figcaption>
 </figure>
 

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -54,9 +54,9 @@ SRI is responsible for the provision of FIS in Class G airspace within the SY TM
 
 ## Arrival Procedures
 ### STAR and Runway Assignment
-Enroute sequencing of arrivals into YSSY is a joint responsibility of ARL and BIK.
+Sequencing of arrivals into YSSY is a joint responsibility of ARL and BIK, with input from SY TCU.
 
-Aircraft from the south/west are *generally* assigned 16R/34L and aircraft from the north/east assigned 16L/34R to simplify the sequencing required.  However, some heavy aircraft from the north/east may operationally require the longer runway. Similarly, it may be beneficial for the sequence to assign an arrival to an alternate runway to avoid unnecessary delays.
+Aircraft from the south/west are be assigned 16R/34L and aircraft from the north/east assigned 16L/34R.  However, some heavy aircraft from the north/east may operationally require the longer runway. Similarly, it may be beneficial for the sequence to assign an arrival to an alternate runway to avoid unnecessary delays.
 
 Jet aircraft for YSSY shall be assigned the **RIVET**, **BOREE**, or **MARLN** STARs.  
 Non-jet aircraft for YSSY shall be assigned the **ODALE**, **MEPIL**, or **MARLN** STARs.
@@ -66,7 +66,7 @@ Whilst the preference is to keep aircraft assigned the default STAR & runway as 
 !!! note
     Before reassigning an aircraft to an alternate runway, consider arrivals inbound from all directions to ensure that no additional conflict is created.
 
-Approach controllers can use the built-in separation afforded by the STAR height requirements to process aircraft on adjacent STARs (e.g. RIVET and ODALE, or BOREE and MEPIL), allowing aircraft to pass abeam or overtake each other, as dictated by the overall sequence.
+Approach controllers can use the built-in separation afforded by the STAR height requirements to process aircraft on adjacent STARs (e.g. RIVET and ODALE, or BOREE and MEPIL), allowing aircraft to pass abeam or overtake each other, as dictated by the overall sequence. See [Level Assignment](#level-assignment) below for details on maintaining separation using the STAR height requirements.
 
 !!! example
     During a busy Milk Run Monday, a large volume of traffic is approaching YSSY from the southwest, with no arrivals from the north or east. To prevent unnecessarily delaying inbound aircraft by processing them for a single runway, coordinate with **BIK** to request certain aircraft are tactically assigned runway 16L/34R, to improve the overall efficiency of the sequence.  

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -21,7 +21,7 @@
 * [Additional requirements](#airspace-structural-arrangements) must be met prior to opening SRI as a stand-alone position.
 
 ## Airspace
-The Vertical limits of the SY TCU are `SFC` to `F280`.  
+The Vertical limits of the SY TCU are `SFC` to `F285`.  
 SY TCU is responsible for the Sydney TMA, except:  
 
 - SY CTR `SFC` to `A005` as outlined [here](../../aerodromes/sydney/#airspace)

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -53,6 +53,26 @@ SRI is responsible for the provision of FIS in Class G airspace within the SY TM
     During a busy event, Sydney Departures is experiencing a high workload and wishes to delegate the SRI role to another TMA controller who isn't as busy.  SAN's sector is quiet, so they elect to perform the role.
 
 ## Arrival Procedures
+### STAR and Runway Assignment
+Enroute sequencing of arrivals into YSSY is a joint responsibility of ARL and BIK.
+
+Aircraft from the south/west are *generally* assigned 16R/34L and aircraft from the north/east assigned 16L/34R to simplify the sequencing required.  However, some heavy aircraft from the north/east may operationally require the longer runway. Similarly, it may be beneficial for the sequence to assign an arrival to an alternate runway to avoid unnecessary delays.
+
+Jet aircraft for YSSY shall be assigned the **RIVET**, **BOREE**, or **MARLN** STARs.  
+Non-jet aircraft for YSSY shall be assigned the **ODALE**, **MEPIL**, or **MARLN** STARs.
+
+Whilst the preference is to keep aircraft assigned the default STAR & runway as above, there are situations where the sequence may be improved by assigning the adjacent STAR or an alternate runway. It is a joint responsibility of **SY TCU** and the surrounding enroute controllers to consider these STAR/runway changes when reviewing the inbound sequence. If a change is recommended, coordination should be conducted with the enroute controller to request that an aircraft be reassigned. Where aircraft will be passing in close proximity (even if assigned different runways), consider the use of the adjacent STAR, to maintain a separation standard during the arrival.
+
+!!! note
+    Before reassigning an aircraft to an alternate runway, consider arrivals inbound from all directions to ensure that no additional conflict is created.
+
+Approach controllers can use the built-in separation afforded by the STAR height requirements to process aircraft on adjacent STARs (e.g. RIVET and ODALE, or BOREE and MEPIL), allowing aircraft to pass abeam or overtake each other, as dictated by the overall sequence.
+
+!!! example
+    During a busy Milk Run Monday, a large volume of traffic is approaching YSSY from the southwest, with no arrivals from the north or east. To prevent unnecessarily delaying inbound aircraft by processing them for a single runway, coordinate with **BIK** to request certain aircraft are tactically assigned runway 16L/34R, to improve the overall efficiency of the sequence.  
+
+    Where aircraft are moved to the alternate runway, consider requesting that they are also assigned the alternate STAR to an aircraft approaching at a similar time on the main runway (i.e. a jet aircraft is moved to runway 34R and cleared the ODALE STAR for separation with a jet aircraft nearby assigned runway 34L via the RIVET STAR).
+
 ### Level Assignment
 !!! note
     Inbound aircraft will be handed from Enroute to Approach assigned the [standard assignable level](#arrivals).  This section refers to further descent issued by the Approach controller.

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -56,7 +56,7 @@ SRI is responsible for the provision of FIS in Class G airspace within the SY TM
 ### STAR and Runway Assignment
 Sequencing of arrivals into YSSY is a joint responsibility of ARL and BIK, with input from SY TCU.
 
-Aircraft from the south/west are be assigned 16R/34L and aircraft from the north/east assigned 16L/34R.  However, some heavy aircraft from the north/east may operationally require the longer runway. Similarly, it may be beneficial for the sequence to assign an arrival to an alternate runway to avoid unnecessary delays.
+Aircraft from the south/west are assigned 16R/34L and aircraft from the north/east assigned 16L/34R.  However, some heavy aircraft from the north/east may operationally require the longer runway. Similarly, it may be beneficial for the sequence to assign an arrival to an alternate runway to avoid unnecessary delays.
 
 Jet aircraft for YSSY shall be assigned the **RIVET**, **BOREE**, or **MARLN** STARs.  
 Non-jet aircraft for YSSY shall be assigned the **ODALE**, **MEPIL**, or **MARLN** STARs.


### PR DESCRIPTION
- Stop table of contents making links above the active one grey
- Add notes to BIK, ARL and SY TMA regarding the use of each runway and STAR (and when to use the alternate one)
- Update ARL subsector responsibilities
- Fix broken links
- Adjust SY TMA upper limit to FL285