### PR TITLE
Tassie top down & extension rules

### DIFF
--- a/docs/controller-skills/extending.md
+++ b/docs/controller-skills/extending.md
@@ -6,8 +6,10 @@ title: Extending
 
 As per [VATPAC Ratings and Controller Positions Policy](https://cdn.vatpac.org/documents/policy/Controller+Positions+and+Ratings+Policy+v5.2.pdf), Enroute controllers are permitted to *extend* to any adjacent sector, with the exception of:
 
-- ML-ASP_CTR, which can only extend to adjacent YMMM (Melbourne Centre) sectors.
-- BN-ISA_CTR, which can only extend to adjacent YBBB (Brisbane Centre) sectors.
+- ASP, which can only extend to adjacent YMMM (Melbourne Centre) sectors.
+- ISA, which can only extend to adjacent YBBB (Brisbane Centre) sectors.
+
+TCU controllers operating the **Coral** or **Tasmania** TMAs may elect to extend to the adjacent TMA (e.g. HBA extend to LTA) at their discretion.
 
 ## Frequency Management
 When providing extended coverage, controllers must have all the frequencies of the sectors they are extending to; **active**, and **cross-coupled**. 
@@ -15,14 +17,15 @@ When providing extended coverage, controllers must have all the frequencies of t
 Here are tips to help manage frequencies when extending:
 
 - Advise the aircraft to transfer frequencies at specific times/situations, such as
-    - "at time xx, contact me xxx.xx"
-    - "at waypoint ABABI, contact me xxx.xx"
-    - "at top of descent, contact me xxx.xx"
+    - *"at time xx, contact me xxx.xx"*
+    - *"at waypoint ABABI, contact me xxx.xx"*
+    - *"at top of descent, contact me xxx.xx"*
 - Include which frequency the aircraft is currently on by placing the 3 letter sector designator in the label.
-    - An aircraft on the ML-TBD_CTR frequency would have `TBD` in the label.
-    - An aircraft on the BN-ARL_CTR frequency would have `ARL` in the label.
+    - An aircraft on the TBD frequency would have `TBD` in the label.
+    - An aircraft on the ARL frequency would have `ARL` in the label.
 - *Optional:* When transferring an aircraft to its final frequency in your airspace, you can remove the frequency designator from the label
 - *Optional:* Prior to handing off an aircraft to another ENR sector that is extending to at least 2 sectors that the aircraft will fly through, put the frequency designator of the frequency you are telling the aircraft to call in the label. eg, controlling **ELW**, transferring aircraft bound for YPAD to **YWE**, who is also extending to **TBD**: Put `YWE` in label prior to handoff.
+
 ## Workload
 Extending to adjacent sectors **must** be done with traffic levels and complexity in mind. It is very easy to start controlling to several adjacent sectors when traffic is calm, then it slowly builds up without you noticing, and all of a sudden everyone is receiving a sub-par service. A great way to see this coming is from your **Preactive** and **Announced** strip windows. The more full they are, the busier you'll be in the next 10-60 minutes.
 
@@ -34,13 +37,13 @@ If the frequency is constantly getting stepped on by multiple aircraft, **relinq
     Stay vigilant for aircraft in your airspace taxiing without calling up. Many aerodromes have Radar/ADSB on the ground, and this can be used in conjunction with the ground radar to check for aircraft movements. If you zoom right in to a Radar/ADSB return on the ground, and it has a velocity vector, time to send a contact me!
 
 ## Remarks
-
 When extending, include in your remarks, *"Extending to (Sector) (frequency), (Sector) (frequency), etc.* This will have the benefit of:  
 - Helping pilots be aware of whether or not they are in your airspace, so they are less likely to start taxiing without a clearance or traffic statement  
 - Helping pilots know which frequency to use  
 - If entered in this format, display on Volanta the extensions on the ATC map.
 
 !!! example
-    Melbourne (ELW) Centre. Extending to HUO 122.6, YWE 134.325, BIK 129.8.  
+    Melbourne Centre  
+    Extending to HUO 122.6, YWE 134.325, BIK 129.8.  
     Charts - vats.im/pac/charts  
     ATC feedback - helpdesk.vatpac.org

--- a/docs/enroute/Melbourne Centre/HUO.md
+++ b/docs/enroute/Melbourne Centre/HUO.md
@@ -15,27 +15,17 @@
 </figure>
 
 ## Responsibilities
-Whilst the **HBA** controller is expected to provide a [top-down service](../../../aerodromes/Hobart) to YMHB when **HB ADC** is offline, this is not expected of a HUO controller when both **HBA** and **HB ADC** are offline. If electing not to provide a top-down service to YMHB, the HB CTR Class D `SFC` to `A015` reverts to Class G.  
-Whilst the **LTA** controller is expected to provide a [top-down service](../../../aerodromes/Launceston) to YMLT when **LT ADC** is offline, this is not expected of a HUO controller when both **LTA** and **LT ADC** are offline. If electing not to provide a top-down service to YMLT, the LT CTR Class D `SFC` to `A015` reverts to Class G.  
+HUO is reponsible for issuing STAR clearances, sequencing, and descent for aircraft bound for YMLT and YMHB.
 
-HUO is reponsible for issuing STAR clearances, initial descent, and sequencing for aircraft bound for YMLT and YMHB.
-## HB/LT ADC Offline
-When **HB ADC** or **LT ADC** is offline, the relevant CTR (Class D `SFC` to `A015`) airspace reverts to Class G, and is administered by HUO. Alternatively, HUO may provide a top-down service if they wish.
+### Top Down Extension
+When **HBA** and/or **LTA** are offline, the class C and D airspace `SFC` to `A085` in the relevant TMA is reclassified as class G.
 
-If not providing a top-down service, due to the low level of CTA at these aerodromes, it is best practice to give airways clearance to aircraft at the holding point, to ensure departing aircraft can have uninterrupted climb.
+HUO may choose to operate either YMHB or YMLT (or both) aerodromes top down, including the terminal airspace within the Tasmania TMA. Due to limited surveillence coverage and the complex airspace setup, **extending top down to one or both aerodromes is not compulsory.**
 
-Departures shall be cleared via a SID.
+If HUO chooses to operate top down to either aerodrome, they must administer all relevant airspace within the appropriate TMA, including the class D CTR.
 
-!!! example
-    **JST718:** "Melbourne Centre, JST718, A320, IFR, Taxiing YMHB for YSSY, Runway 12"  
-    **HUO:** "JST718, Melbourne Centre, Squawk 3601, No Reported IFR Traffic, Call me Ready at the Holding Point for Airways Clearance"  
-    **JST718:** "Squawk 3601, Wilco, JST718"  
-      
-    **JST718:** "JST718, Ready Runway 12, Request clearance"  
-    **HUO:** "JST718, Cleared to YSSY via LATUM, flight planned route. Runway 12, LATUM2 Departure. Climb via SID to A080"  
-    **JST718:** "Cleared to YSSY via LATUM, flight planned route. Runway 12, LATUM2 Departure. Climb via SID to A080, JST718"  
-
-YMHB arrivals shall still be assigned the relevant STAR for their requested arrival runway.
+!!! important
+    Ensure you are familiar with the aerodrome procedures for [Launceston](../../aerodromes/Launceston.md) and [Hobart](../../aerodromes/Hobart.md) before extending top down, and are aware of the limited surveillence coverage available in the lower levels of the TMA.
 
 ## Coordination
 ### HUO / TAS TCU
@@ -46,6 +36,10 @@ The Standard assignable level from HUO to TAS TCU TCU is:
 All other aircraft must be voice coordinated to HBA/LTA prior to **20nm** from the boundary.
 
 The Standard Assignable level from HBA and LTA to HUO is the lower of `F240` or the `RFL`, and tracking via a SID terminus.
+
+!!! note
+    LTA owns the terminal airspace within a 30nm radius of LT VOR. HBA owns the remainder of the TCU.
+
 ### HUO / ENR
 As per [Standard coordination procedures](../../../controller-skills/coordination/#enr-enr), Voiceless, no changes to route or CFL within **50nm** to boundary.
 

--- a/docs/terminal/coral.md
+++ b/docs/terminal/coral.md
@@ -12,13 +12,12 @@
 | Rockhampton Approach  | RKA | Coral Approach   | 123.750        | RK_APP                 |
 
 ## Airspace
-The Vertical limits of the COR TCU are `SFC` to `F150`.  
+The Coral TCU includes the airpsace `SFC` to `F150` within the Mackay and Rockhampton keyholes (shown below).  
 MK ADC own the Class D airspace within MK CTR `SFC` to `A010`.  
 RK ADC own the Class D airspace within RK CTR `SFC` to `A010`.  
 
 ## Extending
-!!! Note
-    MKA may extend to RKA and vice versa, callsigns remain the same.
+MKA may extend to RKA and vice versa, callsigns remain the same. See [Controller Skills](../controller-skills/extending.md) for details.
 
 !!! tip
     When setting up vatSys while providing coverage to RKA and MKA, it is recommended that you have seperate air displays open for MKA and RKA.

--- a/docs/terminal/tassie.md
+++ b/docs/terminal/tassie.md
@@ -15,7 +15,7 @@
     HBA may elect to extend to LTA and vice versa, callsigns remain the same. See [Controller Skills](../controller-skills/extending.md) for details.
 
 ## Airspace
-**LTA** owns the airpsace `SFC` to `F245` within a 30nm radius of the LT VOR. LT ADC owns the Class D airspace within LT CTR `SFC` to `A015` when open.  
+**LTA** owns the airspace `SFC` to `F245` within a 30nm radius of the LT VOR. LT ADC owns the Class D airspace within LT CTR `SFC` to `A015` when open.  
 
 **HBA** owns the airspace `SFC` to `F245` within the remainder of the Tasmania TMA (shown below). HB ADC owns the Class D airspace within HB CTR `SFC` to `A015` (north of runway centreline) and `A025` (south of runway centreline) when open. 
 

--- a/docs/terminal/tassie.md
+++ b/docs/terminal/tassie.md
@@ -12,22 +12,22 @@
 | Launceston Approach  | LTA | Launy Approach   | 123.800        | LT_APP                 |
 
 !!! Note
-    Hobart Approach **must** extend to Launceston Approach and vice versa, callsigns remain the same.
+    HBA may elect to extend to LTA and vice versa, callsigns remain the same. See [Controller Skills](../controller-skills/extending.md) for details.
 
 ## Airspace
-The Vertical limits of the TAS TCU are `SFC` to `F245`.  
-HB ADC own the Class D airspace within HB CTR `SFC` to `A010`.  
-LT ADC own the Class D airspace within LT CTR `SFC` to `A010`.  
+**LTA** owns the airpsace `SFC` to `F245` within a 30nm radius of the LT VOR. LT ADC owns the Class D airspace within LT CTR `SFC` to `A015` when open.  
+
+**HBA** owns the airspace `SFC` to `F245` within the remainder of the Tasmania TMA (shown below). HB ADC owns the Class D airspace within HB CTR `SFC` to `A015` (north of runway centreline) and `A025` (south of runway centreline) when open. 
 
 <figure markdown>
 ![TAS TCU](img/TASTCU.png){ width="700" }
 </figure>
 
 ## Hobart
-All aircraft should be kept on SIDs and STARs. If due to operational requirements or routing, an aircraft is unable to accept the SID or STAR, Voice Coordination with HUO will be required.
+All aircraft should be kept on SIDs and STARs. If due to operational requirements or routing, an aircraft is unable to accept the SID or STAR, voice coordination with HUO will be required.
 
 ## Launceston
-Visual approaches are preferred into Launceston. If due to operational requirements, an aircraft is unable to accept a visual approach, Coordination with **LT ADC** may be required.  
+Visual approaches are preferred into Launceston. If due to operational requirements, an aircraft is unable to accept a visual approach, coordination with **LT ADC** may be required.  
 
 Runway 32L is regularly the duty runway due to prevailing winds. To assist traffic flow in and out of the TCU, ATC will instruct aircraft to track for runway 32L via `IRSOM, NODAS, MLTSC` which keeps the aircraft within CTA and away from the departures stream.
 
@@ -45,14 +45,15 @@ Any aircraft not meeting the above criteria must be prior coordinated to HUO.
 
 #### Arrivals
 The Standard assignable level from HUO to HBA/LTA is:  
-`A090` for YMLT arrivals, tracking IRSOM DCT LT, or NUNPA DCT LT.  
+`A090` for YMLT arrivals, tracking `IRSOM DCT LT`, or `NUNPA DCT LT`.  
 `F130` for YMHB arrivals, and assigned the IPLET STAR or MORGO STAR.
 
 All other aircraft must be voice coordinated to HBA/LTA.
 
 ### HB ADC / HBA
 #### Airspace
-HB ADC owns the Class D airspace in the HB CTR `SFC` to `A010`. HBA owns the Class D and C airspace above `A010`.
+HB ADC owns the Class D airspace in the HB CTR `SFC` to `A015` north of the runway centreline and `A025` south of the runway centreline. HBA owns the Class D and C airspace above these levels.
+
 #### Departures
 HB ADC will give a "Next" call for:
 
@@ -77,7 +78,8 @@ HBA will coordinate all YMHB arrivals to HB ADC prior to **5 mins** from the bou
 
 ### LT ADC / LTA
 #### Airspace
-LT ADC owns the Class D airspace in the LT CTR `SFC` to `A010`. LTA owns the Class D and C airspace above `A010`.
+LT ADC owns the Class D airspace in the LT CTR `SFC` to `A015`. LTA owns the Class D and C airspace above `A015`.
+
 #### Departures
 LT ADC will give a "Next" call for:
 


### PR DESCRIPTION
- TAS TMA is an optional extension for S3 controllers, not a compulsory one (in line with Coral App)
- HUO can choose to extend top down to either YMHB, YMLT, both, or neither. If they extend top down, they are expected to cover the TMA airspace and the aerodrome itself (previously they could cover the airspace to A015 and leave SFC-A015 uncontrolled). If they choose not to extend top down to a TMA, the class C & D A085 and below becomes class G
- Other tidy ups

**Feel free to review PR but please don't merge content until after event tonight (Monday)**