### PR TITLE
Correct Port Vila Tower airspace definition

### DIFF
--- a/docs/pacific/vanuatu.md
+++ b/docs/pacific/vanuatu.md
@@ -18,7 +18,7 @@ Port Vila Class D CTA exists:
 - Within a 20 NM-radius circle centred on the Port Vila/Bauerfield ARP from surface to 3500 FT (base of TMA).  
 - Within a 50 NM-radius circle centred on the Port Vila/Bauerfield ARP from 3500 FT (top of CTR) to 9500 FT (base of CTA).  
 
-During Port Vila hours of watch, **Port Vila Tower** provides ATS for the entire Port Vila Sector. 
+During Port Vila hours of watch, **Port Vila Tower** provides ATS for the Port Vila TMA.
 
 !!! note
     Outside of hours of watch, Port Vila Class D CTR is reclassified Class G and **Nadi Oceanic** provides ATS for the entire Sector.  


### PR DESCRIPTION
The Vanuatu page of the pacific sops state "During Port Vila hours of watch, Port Vila Tower provides ATS for the entire Port Vila Sector." 😰😰. Port Vila Tower only provides air traffic services for the Port Vila TMA: SFC-3500ft, and 3500ft-9500ft

The Port Vila Sector the SOPs reference is the Port Vila CTA (Class D) from 9500ft-FL245, which is serviced by Port Vila Centre when online. Otherwise, the CTA reverts to Class G and is serviced by Nadi Oceanic

I'm not sure if this is a change made to allow for more air traffic control service provided in the pacific due to a lack of controllers or if it was just a mistake made in writing the SOPs

![image](https://github.com/vatpac-technology/sops/assets/105491171/8544c0a9-9237-4561-bd63-7556252ebceb)
![image](https://github.com/vatpac-technology/sops/assets/105491171/3934a437-38a8-497f-8f2a-b1aa7d41d3bb)
![image](https://github.com/vatpac-technology/sops/assets/105491171/6cfc47da-c62e-4519-9e12-96db467a7d9d)
