### PR TITLE
BMN position removal, other misc fixes

### DIFF
--- a/docs/controller-skills/annotations.md
+++ b/docs/controller-skills/annotations.md
@@ -103,7 +103,7 @@ Here is a complete list of standard annotations controllers should be entering i
 | Distance left or right of track | (distance) [LOT/ROT] | 30 LOT |
 | Enter lateral conflict | ELC/(time/position) | ELC/15 |
 | Leaves lateral conflict | LLC/(time)(position) | LLC/190SY |
-| Clearance limit | F/(position) | F/ELW |
+| Clearance limit | F/(position) | F/YMAV |
 | Sight and pass | S+P/(callsign) | S+P/EDM |
 | Sight and follow | S+F/(callsign) | S+F/VOZ882 |
 | Calculated time of passing | TP(time) | TP0835 |

--- a/docs/controller-skills/coordination.md
+++ b/docs/controller-skills/coordination.md
@@ -8,7 +8,7 @@ Coordination is an underutilised tool in VATPAC airspace, primarily due to how d
 
 Coordination requirements are often very location-specific, however this page outlines the general guidelines to coordination, which are supplemented by Local Instructions.
 
-[MATS Chapter 6](https://www.airservicesaustralia.com/mats/docs/nos-saf-2000.pdf) goes in to much more detail about coordination principles, phraseology, and situations. It is well above the level required for VATSIM, but feel free to read up on it if you want to extend your learning.
+[MATS Chapter 6](https://www.airservicesaustralia.com/mats/docs/nos-saf-2000.pdf){target=new} goes in to much more detail about coordination principles, phraseology, and situations. It is well above the level required for VATSIM, but feel free to read up on it if you want to extend your learning.
 
 ## Coordination in vatSys
 Coordination is performed using the VSCS window in vatSys.  Once logged onto a relevant position, controllers have the option of opening **hotlines** and **coldlines** to surrounding positions.  
@@ -16,7 +16,7 @@ Coordination is performed using the VSCS window in vatSys.  Once logged onto a r
 A hotline is opened by pressing the yellow button titled with the sector you wish to communicate with, which creates an instant connection between positions with no need for the other controller to accept the call.  A coldline is opened by pressing the blue button titled with the sector you wish to communicate with, which notifies the other position and requires them to accept the call before communications can begin.
 
 !!! tip
-    For more in depth information, refer to the [vatSys website](https://virtualairtrafficsystem.com/docs/vscs/).
+    For more in depth information, refer to the [vatSys website](https://virtualairtrafficsystem.com/docs/vscs/){target=new}.
 
 Coordination notes are included for most positions, using the following format: 
 !!! note "" 

--- a/docs/controller-skills/maestro.md
+++ b/docs/controller-skills/maestro.md
@@ -14,7 +14,6 @@ MAESTRO is a semi-automatic system, and will manage a small number of arrivals g
 MAESTRO is not a very useful tool in the TMA, however it allows the TCU controllers to have situation awareness on the flow of inbound aircraft from enroute sectors.
 
 ## Limitations
-
 VATPAC's implementation of MAESTRO, whilst good enough for VATSIM, has a number of limitations compared to the real world system.
 
 It will not:  
@@ -23,12 +22,11 @@ It will not:
 - provide for dependent or semi-dependent runway modes (when multiple runways are used for arrivals) such as  
     - Parallel runway operations at Brisbane and Sydney.  
     - LAHSO at Melbourne (34/27).  
-- provide any wake turbulence seperation.
+- provide any wake turbulence separation.
 
 ## How it works
 
 ### The Basics
-
 A Feeder Fix (FF) is a common waypoint that aircraft will 'merge' to from a certain direction, commonly (but not always) the first waypoint on a STAR.
 
 A runway must be specific in MAESTRO. A runway will have a minimum arrival rate (preset and not configurable), usually between 120 and 180 seconds (can be more or less). This is the minimum time between arrivals.
@@ -40,7 +38,6 @@ From these times, MAESTRO will use this minimum arrival rate to generate a seque
 If 2 aircraft have an estimated landing time that is too close, one aircraft will be delayed and have a new schedule arrival time. This new landing time will also be reflected in a delay at the feeder fix, which is how the enroute controllers sequence the aircraft (either by speed, vectors, holding, or other means).
 
 ### The Ladder
-
 The "ladder" is referring to the display of aircraft in the MAESTRO system, with their position on the ladder their landing or feeder fix time (depending on the viewing mode). This is essentially a "time ladder".
 
 If you are in the "sector" view, you will see aircraft on the ladder at their feeder fix schedules time of arrival (FF STA). Note, you will only see the relevent feeder fixes for the sectors that you have selected.
@@ -58,7 +55,6 @@ Each line on the ladder shows information about arriving aircraft. From the cent
 - Total delay
 
 ## Aircraft Stability
-
 An aircraft will begin in the MAESTRO ladder when their ETA is within 60 minutes from the FF. They will be classified as `unstable`, and show as yellow on the ladder.
 
 Unstable aircraft will be re-sequenced every 15 seconds. You should not apply any delaying action to an aircraft that is unstable, as their position in the sequence is not yet confirmed. Early delays could result in that aircraft receiving further (un-needed) delays from MAESTRO.
@@ -74,7 +70,6 @@ SuperStable aircraft will not be delayed for any reason other than congestion in
 If the flow controller decides on a different sequence to MAESTRO, then they may manually enter a landing time in the system, this will `freeze` the aircraft and they will show light blue on the ladder. A frozen aircraft will not be delayed for any reason, unless determined by the flow controller.
 
 ### Interactive Options
-
 The flow controller can interact with aircraft on the ladder if they have delegated themselves as the flow controller.
 
 The best view for the flow controller is the runway view. From this view they can:

--- a/docs/separation-standards/assurance.md
+++ b/docs/separation-standards/assurance.md
@@ -22,10 +22,13 @@ Same tracks are only in conflict if there is a **faster following** scenario, eg
 #### Lateral
 Tracks intersecting at more than 45°, but less than 135°.
 
-The best way to determine if aircraft will be laterally in conflict, is with the use of the Closest Approach tool. A good rule of thumb is, if the Closest Approach tool indicates the aircraft will come with **20nm laterally** of each other, they have the potential to be in lateral conflict.
+The best way to determine if aircraft will be laterally in conflict, is with the use of the Closest Approach tool. A good rule of thumb is, if the Closest Approach tool indicates the aircraft will come within **20nm laterally** of each other for Enroute, or **10nm laterally** for TCU, they have the potential to be in lateral conflict.
 
 !!! note
-    The Closest Approach tool uses calculations based on both aircraft's **routes, planned TAS,** and **estimated climb/descent profiles**. This is why in practice, it won't always get the distance right, which is why we add so much fat to a 5nm lateral standard in the usage of the tool for assessment purposes. The further out from the crossing point the aircraft are, the more inaccurate the tool is.
+    The Closest Approach tool uses calculations based on both aircraft's **routes, planned TAS,** and **estimated climb/descent profiles**. This is why in practice, it won't always get the distance right, which is why we add so much fat to a 5nm/3nm lateral standard in the usage of the tool for assessment purposes. The further out from the crossing point the aircraft are, the more inaccurate the tool is.
+
+!!! important
+    The tool is only as useful as the information it is given. If an aircraft is not following the route shown on the system, if an aircraft has filed an inaccurate TAS, or if there is any other discrepancy, the output of the Closest Approach Tool will become unreliable.
 
 ### Planning to ensure separation
 This is where you decide the method for separation assurance. Are you going to implement a restriction to reach a certain altitude by a certain point? Are you going to place a BRL between the aircraft to monitor closing speed? Are you going to anchor a BRL at the point where lateral conflict is infringed, to monitor the aircraft vertically clear? Are you going to give one aircraft a vector to keep clear? There are several different ways to approach resolving these conflicts, so choose the one that best suits the situation, and that you are comfortable with.

--- a/docs/separation-standards/classd.md
+++ b/docs/separation-standards/classd.md
@@ -15,8 +15,10 @@ Remember that in [Class D Airspace](../../controller-skills/classofairspace), IF
 ## Procedural Separation
 At [Tamworth](../../aerodromes/tamworth), [Coffs Harbour](../../aerodromes/Coffs), [Hamilton Island](../../aerodromes/Hammo), and [Sunshine Coast](../../aerodromes/sunshinecoast) Towers, surveillance coverage cannot be guaranteed at all levels. Therefore, [Procedural Separation](../procedural) must be implemented prior to losing surveillance identification of an aircraft, if [Visual Separation](../visual) cannot be assured below the height at which surveillance coverage will be lost. For more information, refer to Local Instructions.
 
-## 45° Segregated Flight Paths
-### Straight-in
+## Lateral
+
+### 45° Segregated Flight Paths
+#### Straight-in
 - Can be applied between departures and arrivals when the departing aircraft's flight path and the arrival aircraft's flight path are at least 45° clear of each other, and, for a straight-in approach, the arriving aircraft is at least **5nm** from the arrival runway threshold
 
 <figure markdown>
@@ -24,7 +26,7 @@ At [Tamworth](../../aerodromes/tamworth), [Coffs Harbour](../../aerodromes/Coffs
   <figcaption>Segregated Flight Paths - Straight-in</figcaption>
 </figure>
 
-### Visual, DME/GNSS, Circle to land
+#### Visual, DME/GNSS, Circle to land
 - Can be applied between departures and arrivals when the departing aircraft's flight path and the arrival aircraft's flight path are at least 45° clear of each other, and, for a Visual, DME/GNSS or Circle to land approach, the arriving aircraft is at least **10nm** from the airfield
 
 <figure markdown>

--- a/docs/separation-standards/index.md
+++ b/docs/separation-standards/index.md
@@ -5,4 +5,4 @@
 
 --8<-- "includes/abbreviations.md"
 
-Seperation Standards applicable to all levels of ATC in VATPAC airspace.  For more fundamental skill documentation, visit [ATC Academy](https://academy.vatpac.org). For simulation purposes only.
+Separation Standards applicable to all levels of ATC in VATPAC airspace. For more fundamental skill documentation, visit [ATC Academy](https://academy.vatpac.org){target=new}. For simulation purposes only.

--- a/docs/separation-standards/parallelapps.md
+++ b/docs/separation-standards/parallelapps.md
@@ -4,28 +4,25 @@ title: Parallel Approaches
 
 --8<-- "includes/abbreviations.md"
 
-The following page applies to Parallel Runway Operations at [YSSY](../../aerodromes/sydney) and [YBBN](../../aerodromes/brisbane).
+The following page applies to Parallel Runway Operations at [YSSY](../../terminal/sydney/#parallel-runway-operations) and [YBBN](../../terminal/brisbane/#parallel-runway-operations).
 
 ## Dependent Approaches
 - Approaches are any combination of:  
     - a Precision approach procedure; and  
     - an RNP AR approach
 
-- 1000ft or 3nm separation is maintained until aircraft are established:  
+- **1000ft** or **3nm** separation is maintained until aircraft are established:  
     - inbound on the final approach course or track; or  
     - on an RNP AR APCH that will not cross the adjacent parallel runway final approach course or track
 
 - Minimum Diagonal separation between successive aircraft on adjacent final approach courses or tracks is:  
-    - 1.5nm at YBBN  
-    - 1nm at YSSY
+    - **1.5nm** at [YBBN](../../terminal/brisbane/#parallel-runway-operations)  
+    - **1nm** at [YSSY](../../terminal/sydney/#parallel-runway-operations)
 
 ## Independent Visual Approaches
 - When vectoring an aircraft to intercept the final course, ensure that the final vector permits the aircraft to intercept at an angle not greater than 30 degrees.
 
-- 1000ft or 3nm separation is maintained until:  
+- **1000ft** or **3nm** separation is maintained until:  
     - one aircraft is established within the furthest IAF when both aircraft are established on their respective localiser or GLS final approach course in visual conditions; or  
     - one aircraft is established on the localiser or GLS final approach course in visual conditions and the other is established on a heading to intercept final inside the furthest IAF with the runway reported in sight; or  
     - both aircraft are established on a heading to intercept final inside the furthest IAF with the runway reported in sight
-
-### Phraseology at Night
-*"CLEARED INDEPENDENT VISUAL APPROACH RUNWAY (number), NOT BELOW (altitude) UNTIL ESTABLISHED ON THE VASIS (or PAPI) (or GLIDEPATH)"*

--- a/docs/terminal/brisbane.md
+++ b/docs/terminal/brisbane.md
@@ -12,7 +12,6 @@
 | Brisbane Approach South†   |BAS| Brisbane Approach   | 125.600          | BN-S_APP                                 |
 | Brisbane Departures North†    |BDN| Brisbane Departures  | 133.450         | BN_DEP          |
 | Brisbane Departures South†   |BDS| Brisbane Departures | 118.450          | BN-S_DEP         |
-| Brisbane Finals† |BMN| Brisbane Finals   | 119.250          | BN-F_APP                               |
 | Gold Coast Approach† |BAC| Brisbane Approach  | 123.500          | BN-C_APP       |
 | Brisbane Flow†        |BFL|                |          | BN-FLW_CTR                               |
 
@@ -26,7 +25,9 @@ AF CTR reverts to Class G when **AF ADC** is offline, and is administered by the
 ### Airspace Structural Arrangements
 Pursuant to Section 3 of the [VATPAC Ratings and Controller Positions Policy](https://cdn.vatpac.org/documents/policy/Controller+Positions+and+Ratings+Policy+v5.2.pdf), **“North”**/**”West”** positions shall assume the airspace of corresponding **“South”**/**”East”** positions when the latter are inactive (e.g. **BAN** assumes **BAS** airspace), and vice versa.
 
-## Parallel Runway Operations - Runway Selection
+## Parallel Runway Operations
+Refer to [Parallel Runway Separation Standards](../../separation-standards/parallelapps) for more information
+### Runway Selection
 Aircraft shall be assigned the following runways for arrival when PROPS are in progress:
 
 | Aircraft tracking | Runway  |
@@ -43,6 +44,9 @@ Aircraft shall be assigned the following runways for arrival when PROPS are in p
 | From the NORTH and WEST | 01L/19R |
 | From the SOUTH and EAST | 01R/19L |
 
+### Independent Visual Approach Phraseology at Night
+*"CLEARED INDEPENDENT VISUAL APPROACH RUNWAY (number), NOT BELOW (altitude) UNTIL ESTABLISHED ON THE VASIS (or PAPI) (or GLIDEPATH)"*
+
 ## AF ADC Offline
 Due to the low level of CTA (`A015`) in the AF CTR when **AF ADC** is offline, it is best practice to give airways clearance to aircraft at the holding point, to ensure departing aircraft can have uninterrupted climb.
 
@@ -56,8 +60,7 @@ Due to the low level of CTA (`A015`) in the AF CTR when **AF ADC** is offline, i
     **ABC**: "Cleared to YBSU via BN, Flight Planned Route. Make Visual right turn DCT BN, Climb to A030, ABC"
 
 ## Airspace Division
-
-The divisions of the airspace between **BAN**, **BAS**, **BDS**, **BDN**, **BAC** and **BMN** change based on the Runway Mode.
+The divisions of the airspace between **BAN**, **BAS**, **BDS**, **BDN**, and **BAC** change based on the Runway Mode.
 
 !!! note
     The following diagrams do not include non BN TCU areas of responsibility such as AF CTR or CG ADC
@@ -85,7 +88,7 @@ The divisions of the airspace between **BAN**, **BAS**, **BDS**, **BDN**, **BAC*
 #### Departures
 The Standard Assignable level for YBBN departures from BN TCU to **INL(All)** is the lower of `F180` or the `RFL`, and tracking via a **Procedural** SID terminus.  
 The Standard Assignable level for YBCG departures from BN TCU to **GOL/SDY** is the lower of `F120` or the `RFL`, and tracking via **APAGI**.  
-The Standard Assignable level for YBCG departures from BN TCU to **NSA/BUR/DOS** is the lower of `F180` or the `RFL`and tracking via a **Procedural** SID terminus.  
+The Standard Assignable level for YBCG departures from BN TCU to **NSA/BUR/DOS** is the lower of `F180` or the `RFL`, and tracking via a **Procedural** SID terminus.  
 The Standard Assignable level for YBSU arrivals from BN TCU to **NSA** is `F130`, and tracking via **ITIDE**.  
 
 Any aircraft not meeting the above criteria must be prior coordinated to ENR.

--- a/docs/terminal/brisbane.md
+++ b/docs/terminal/brisbane.md
@@ -45,7 +45,7 @@ Aircraft shall be assigned the following runways for arrival when PROPS are in p
 | From the SOUTH and EAST | 01R/19L |
 
 ### Independent Visual Approach Phraseology at Night
-*"CLEARED INDEPENDENT VISUAL APPROACH RUNWAY (number), NOT BELOW (altitude) UNTIL ESTABLISHED ON THE VASIS (or PAPI) (or GLIDEPATH)"*
+*"CLEARED INDEPENDENT VISUAL APPROACH RUNWAY (number), NOT BELOW (altitude) UNTIL ESTABLISHED ON THE PAPI (or GLIDEPATH)"*
 
 ## AF ADC Offline
 Due to the low level of CTA (`A015`) in the AF CTR when **AF ADC** is offline, it is best practice to give airways clearance to aircraft at the holding point, to ensure departing aircraft can have uninterrupted climb.

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -96,6 +96,7 @@ All aircraft should be assigned no lower than `A060` until clear of the active r
 
 Be mindful of departures from YSBK which may also impact aircraft on downwind for RWY 16R at YSSY.  Do not assign lower than `A040` until the aircraft is north/east of the BK CTR and clear of any departing traffic (who are assigned `A030` by default).
 ## Parallel Runway Operations
+Refer to [Parallel Runway Separation Standards](../../separation-standards/parallelapps) for more information
 
 ### Runway Selection
 Unless operationally required, aircraft shall be assigned the following runways for arrival when PROPS are in progress:
@@ -130,13 +131,11 @@ SFW/SFE may provide distance to touchdown, when transferring an aircraft to towe
     "QFA490, 8 miles to touchdown, contact tower 120.5"
 
 ### Instrument Approach
-
 Aircraft joining parallel instrument approaches must remain separated from aircraft on the adjacent approach until they are established. This usually involves keeping aircraft vertically separated and may require aircraft to intercept the localiser/final approach course and maintain their assigned level, only allowing descent on the approach once they are established.  
 
 Two aircraft established on adjacent parallel approaches require `1nm` lateral separation as opposed to the 3nm standard required in the TMA generally.
 
 ### Independent Visual Approach
-
 When conducting IVAs, aircraft shall not be transferred to **SY ADC** until established on final.
 
 !!! example
@@ -145,6 +144,9 @@ When conducting IVAs, aircraft shall not be transferred to **SY ADC** until esta
       
     **SFW:** "BNZ444, Contact Sydney Tower 120.5"  
     **BNZ444:** "120.5, BNZ444"
+
+#### Phraseology at Night
+*"CLEARED INDEPENDENT VISUAL APPROACH RUNWAY (number), NOT BELOW (altitude) UNTIL ESTABLISHED ON THE VASIS (or PAPI) (or GLIDEPATH)"*
 
 ## Sydney Harbour Scenic Flights
 Flights may be cleared for one of two standard scenic flight routes at `A015`, **Harbour Scenic One** or **Harbour Scenic Two**, which are described below. Pilot preference should be accommodated where traffic permits.

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -146,7 +146,7 @@ When conducting IVAs, aircraft shall not be transferred to **SY ADC** until esta
     **BNZ444:** "120.5, BNZ444"
 
 #### Phraseology at Night
-*"CLEARED INDEPENDENT VISUAL APPROACH RUNWAY (number), NOT BELOW (altitude) UNTIL ESTABLISHED ON THE VASIS (or PAPI) (or GLIDEPATH)"*
+*"CLEARED INDEPENDENT VISUAL APPROACH RUNWAY (number), NOT BELOW (altitude) UNTIL ESTABLISHED ON THE PAPI (or GLIDEPATH)"*
 
 ## Sydney Harbour Scenic Flights
 Flights may be cleared for one of two standard scenic flight routes at `A015`, **Harbour Scenic One** or **Harbour Scenic Two**, which are described below. Pilot preference should be accommodated where traffic permits.

--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -59,7 +59,6 @@
 *[BAS]: Brisbane Approach South
 *[BDN]: Brisbane Departures North
 *[BDS]: Brisbane Departures South
-*[BMN]: Brisbane Finals
 *[CSA]: Cairns Approach
 *[CSD]: Cairns Departures
 *[CBW]: Canberra Approach West


### PR DESCRIPTION
- Removal of BMN (Brisbane Finals) position
- Fixed broken links for BN TCU airspace diagrams
- Minor typos/formatting fixes throughout SOPs
- Minor expansions/clarifications in Sep Assurance, Parallel apps, Annotations pages