### PR TITLE
Multi-engine ops at YPJT

### DIFF
--- a/docs/aerodromes/Jandakot.md
+++ b/docs/aerodromes/Jandakot.md
@@ -64,10 +64,20 @@ The circuit direction changes depending on tower opening hours and runway being 
 
 Circuits to be flown at `A010`
 
+## Multi Engine Aircraft
+When runway 06L is operational, all multi engine aircraft are to be given full length for departure.
+This means holding short on runway 12/30 opposed to the normal B1.
+The same applies for 24R, all multi engine are to be given B6. Single engine should be given B5.
+
 ## IFR Inbound Procedures
 Aircraft arriving from the Perth Class C in VMC will track via CNB. These aircraft will contract **JT ADC** approaching CNB and will be issued circuit joining instructions.  
 Aircraft in IMC will track inbound via an instrument approach.  
 **PH TCU** will coordinate all IFR arrivals in accordance with coordination procedures.
+
+## IFR Outbound Procedures
+Aircraft departing will call **PH TCU** for clearance. They will assign Squawk code, SID and initial altitude.
+It is **JT ADC** role to assign runway, as per ATIS.
+**JT ADC** will coordinate all IFR departures in accordance with coordination procedures.
 
 ## Helicopter Operations
 ### General

--- a/docs/terminal/perth.md
+++ b/docs/terminal/perth.md
@@ -106,6 +106,10 @@ All aircraft transiting between internal PH TCU boundaries must be heads-up coor
 
 ### PH TCU / JT ADC
 
+### Clearance
+It is the responsibility of **PH TCU** to provide clearance to IFR aircraft on the ground at Jandakot.
+Clearance should contain squawk code, initial altitude (normally `A015`) and SID. It is **JT ADC** responsibility to assign runway.
+
 ### Next Call
 When the aircraft is ready for departure, JT ADC will coordinate with the relevant PH TCU controller above them for permission to release the aircraft into their CTA.
 
@@ -114,7 +118,7 @@ When the aircraft is ready for departure, JT ADC will coordinate with the releva
     <span class="hotline">**PH TCU** -> **JT ADC**</span>: "FD420, Unrestricted"  
     <span class="hotline">**JT ADC** -> **PH TCU**</span>: "FD420"  
 
-The Standard Assignable level from JT ADC to PH TCU is the lower of `A030` or the `RFL`, any other level must be prior coordinated.
+The Standard Assignable level from JT ADC to PH TCU is the lower of `A015` or the `RFL`, any other level must be prior coordinated.
 
 ### Arrivals/Overfliers
 PH TCU will heads-up coordinate arrivals/overfliers from Class C to JT ADC prior to **5 mins** from the boundary.  


### PR DESCRIPTION
Added information on runway requirement lengths for multi-engine aircraft at jandakot.
Changed standard assignable from ADC to TCU to A015