### PR TITLE
Add PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+A brief description of the changes in this PR will be added here...
+
+## Changes
+**Fixes**:
+- Remove whole section if no fixes in PR
+
+**Additions**:
+- Remove whole section if no additions in PR
+
+**Removals**:
+- Remove whole section if no removals in PR

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,9 @@ A brief description of the changes in this PR will be added here...
 **Fixes**:
 - Remove whole section if no fixes in PR
 
+**Changes**:
+- Remove whole section if no changes in PR
+
 **Additions**:
 - Remove whole section if no additions in PR
 


### PR DESCRIPTION
In order to eventually support automatic notifications to Discord when the SOPs are updated, this PR adds a template file for pull request descriptions that will automatically be loaded into the editor when opening a new PR.

The template I've put in is based upon what was mentioned in the `#atc-sops` channel, but if there are any other suggestions for what would be useful to have displayed, please let me know or make the change directly.

The image below shows what the Discord notifications would look like using this template. The top one is just a plaintext notification, while the bottom one uses an "embed" to display the info. If people can give me an indication toward what they think is better too, that would be great!

<img width="428" alt="image" src="https://github.com/vatpac-technology/sops/assets/25076205/562596b6-aa84-45fb-ab45-e7e99381bf49">
