### PR TITLE
LT TCU: Add tracking route for arrivals via NUNPA

### DIFF
--- a/docs/terminal/tassie.md
+++ b/docs/terminal/tassie.md
@@ -47,7 +47,7 @@ Runway 32L is regularly the duty runway due to prevailing winds. To assist traff
 These routes keep arrivals within CTA and away from the departure stream(s).
 
 !!! note
-    Clearing aircraft to track via one of the above does **not** constitute a voiceless coordination route between LTA and LT ADC. Aircraft should still be heads-up coordinated to LT ADC prior to **5 minutes** to the boundary, unless coordinated otherwise.
+    Clearing aircraft to track via one of the above routes does **not** constitute a voiceless coordination route between LTA and LT ADC. Aircraft should still be heads-up coordinated to LT ADC prior to **5 minutes** to the boundary, unless coordinated otherwise.
 
 ## Coordination
 

--- a/docs/terminal/tassie.md
+++ b/docs/terminal/tassie.md
@@ -46,6 +46,9 @@ Runway 32L is regularly the duty runway due to prevailing winds. To assist traff
 
 These routes keep arrivals within CTA and away from the departure stream(s).
 
+!!! note
+    Clearing aircraft to track via one of the above does **not** constitute a voiceless coordination route between LTA and LT ADC. Aircraft should still be heads-up coordinated to LT ADC prior to **5 minutes** to the boundary, unless coordinated otherwise.
+
 ## Coordination
 
 ### TAS TCU / ENR

--- a/docs/terminal/tassie.md
+++ b/docs/terminal/tassie.md
@@ -37,7 +37,14 @@ All aircraft should be kept on SIDs and STARs. If due to operational requirement
 ## YMLT
 Visual approaches are preferred into YMLT. If due to operational requirements, an aircraft is unable to accept a visual approach, coordination with **LT ADC** may be required.  
 
-Runway 32L is regularly the duty runway due to prevailing winds. To assist traffic flow in and out of the TCU, ATC will instruct aircraft to track for runway 32L via `IRSOM, NODAS, MLTSC` which keeps the aircraft within CTA and away from the departures stream.
+Runway 32L is regularly the duty runway due to prevailing winds. To assist traffic flow in and out of the TCU, ATC will instruct aircraft to track for runway 32L via one of the following routes:
+
+| Via              | Routing      |
+| ------------------ | --------------|
+| IRSOM  | NODAS MLTSC |
+| NUNPA  | ELREL MLTSA |
+
+These routes keep arrivals within CTA and away from the departure stream(s).
 
 ## Coordination
 


### PR DESCRIPTION
## Summary
Added standard tracking route for arrivals via NUNPA to aid with CTA containment and TCU traffic flow when RWY 32L is in operation.

## LT TCU
**Changes**:
- Tabulate routes via IRSOM and NUNPA

**Additions**:
- Add tracking route ELREL MLTSA for arrivals via NUNPA