### PR TITLE
Improve PH procedures

### DIFF
--- a/docs/aerodromes/Perth.md
+++ b/docs/aerodromes/Perth.md
@@ -32,13 +32,15 @@ With the Southwest Plan active, departures should be assigned either runway 21 o
 | GRENE | 24 |
 | SOLUS | 24 |
 
+The ATIS shall notify `EXPECT ILS APCH`.
+
 ### Northeast Plan
 With the Northeast Plan active, departures via `AVNEX`, `OTLED`, `MANDU`, `SOLUS`, and `KEELS` shall be assigned runway 03. All other departures shall be assigned runway 06. All arrivals will be processed to runway 03.
 
 When both Runway 03 and Runway 06 are nominated as departure runways, broadcast the following: `RWY 03 FOR DEP VIA OTLED, AVNEX, MANDU, SOLUS AND KEELS. RWY 06 FOR ALL OTHER DEP.`
 
-In the following conditions, ATIS shall notify `EXPECT ILS APPROACH`:
-    - By night; and/or
+In the following conditions, ATIS shall notify `EXPECT ILS APCH`:  
+    - By night; and/or  
     - Cloud base of `A032` or below
 
 ## Circuit Training

--- a/docs/aerodromes/Perth.md
+++ b/docs/aerodromes/Perth.md
@@ -96,5 +96,5 @@ b) Aircraft using a runway not on the ATIS
     <span class="coldline">**PH TCU** -> **PH ACD**</span>: "ABC, cleared Victor 65, 1,500ft"  
     <span class="coldline">**PH ACD** -> **PH TCU**</span>: "Cleared Victor 65, 1,500ft, ABC"   
      
-    **PH ACD**: "ABC, cleared victor 65, climb 1,500ft, squawk 0442"  
-    **ABC**: "Cleared for a victor 65, climb 1,500ft, squawk 0442, ABC"  
+    **PH ACD**: "ABC, cleared Victor 65, climb to 1,500ft, squawk 0442"  
+    **ABC**: "Cleared Victor 65, climb to 1,500ft, squawk 0442, ABC"  

--- a/docs/aerodromes/Perth.md
+++ b/docs/aerodromes/Perth.md
@@ -21,7 +21,7 @@ PH ADC is not responsible for any airspace by default.
 ## Runway Selection
 
 ### Southwest Plan
-With the Southwest Plan active, departures should be assigned either runway 21 or 24 (depending on parking position and operational requirements). Arrivals will be processed to either runway 21 or 24 based on their feeder fix, as per the table below:
+With the Southwest Plan active, all departures shall be assigned runway 21. Arrivals will be processed to either runway 21 or 24 based on their feeder fix, as per the table below:
 
 | Feeder Fix | Assigned Runway |
 | --- | --- |

--- a/docs/aerodromes/Perth.md
+++ b/docs/aerodromes/Perth.md
@@ -89,12 +89,12 @@ a) VFR Departures
 b) Aircraft using a runway not on the ATIS
 
 !!! example
-    **ABC**: "Perth Delivery, ABC, request Victor 65 scenic."  
+    **ABC**: "Perth Delivery, ABC, request Victor 65"  
     **PH ACD**: "ABC, Perth Delivery, standby"  
 
-    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "ABC, requesting Victor 65 scenic"  
-    <span class="coldline">**PH TCU** -> **PH ACD**</span>: "ABC, cleared Victor 65 scenic, not above 1,500ft"  
-    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "Cleared Victor 65 scenic not above 1,500ft, ABC"   
+    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "ABC, requesting Victor 65"  
+    <span class="coldline">**PH TCU** -> **PH ACD**</span>: "ABC, cleared Victor 65, 1,500ft"  
+    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "Cleared Victor 65, 1,500ft, ABC"   
      
-    **PH ACD**: "ABC, cleared victor 65 scenic not above 1,500ft, squawk 0442"  
-    **ABC**: "Cleared for a victor 65 scenic, not above 1,500ft, squawk 0442, ABC"  
+    **PH ACD**: "ABC, cleared victor 65, climb 1,500ft, squawk 0442"  
+    **ABC**: "Cleared for a victor 65, climb 1,500ft, squawk 0442, ABC"  

--- a/docs/aerodromes/Perth.md
+++ b/docs/aerodromes/Perth.md
@@ -21,49 +21,41 @@ PH ADC is not responsible for any airspace by default.
 ## Runway Selection
 
 ### Southwest Plan
-- Any combination of Runway 21 and/or 24.
-- The ATIS shall notify `EXPECT ILS APPROACH`
+With the Southwest Plan active, departures should be assigned either runway 21 or 24 (depending on parking position and operational requirements). Arrivals will be processed to either runway 21 or 24 based on their feeder fix, as per the table below:
 
-
-**Runway Assignment**
-
-| Feeder Fix | Runway |
-| ---------- | ------ |
+| Feeder Fix | Assigned Runway |
+| --- | --- |
 | JULIM | 21 |
 | CONNI | 21 |
 | WAVES | 21 |
-| BEVLY | 24, 21 (if operationally required) | 
+| BEVLY | 24 (or 21 if operationally required) |
 | GRENE | 24 |
 | SOLUS | 24 |
 
 ### Northeast Plan
-- Runway 03 for arrivals.
-- Runway 03 for departures via:  
-    - AVNEX
-    - OTLED
-    - MANDU
-    - SOLUS
-    - KEELS
-- Runway 06 for all other departures.
+With the Northeast Plan active, departures via `AVNEX`, `OTLED`, `MANDU`, `SOLUS`, and `KEELS` shall be assigned runway 03. All other departures shall be assigned runway 06. All arrivals will be processed to runway 03.
 
-- In the following conditions, ATIS shall notify `EXPECT ILS APPROACH`
+When both Runway 03 and Runway 06 are nominated as departure runways, broadcast the following: `RWY 03 FOR DEP VIA OTLED, AVNEX, MANDU, SOLUS AND KEELS. RWY 06 FOR ALL OTHER DEP.`
+
+In the following conditions, ATIS shall notify `EXPECT ILS APPROACH`:
     - By night; and/or
     - Cloud base of `A032` or below
 
-## Miscellaneous
-
-### Circuit Training
+## Circuit Training
 Circuit training traffic shall be issued SSR code and clearance to operate within circuit area not above `A015`. Circuit training is typically conducted on Runway 03/21.
 
 All circuits are to be conducted to the east of Runway 03/21 (right-hand circuit Runway 03).
 
-### Scenic Flights
-When traffic permits, VFR scenic flights over Perth are cleared via VICTOR 65 route (CTE-PCTY-HKE).
+## Helicopter Operations
+There are no helipad facilities at YPPH. Helicopters should be issued an airways clearance in accordance with the fixed-wing operation applicable to their flight rules (i.e. SID for IFR helicopters, VFR departure via appropriate VFR route if necessary for VFR helicopters). Helicopters should be cleared to takeoff/land from runways or taxiways, as deemed appropriate by ADC. The point of takeoff/landing must be specified by ADC.
 
-### ATIS Notification of Departure Runway
-When both Runway 03 and Runway 06 are nominated as departure runways, broadcast the following:
+!!! example
+    **PH ADC:** "YOE, taxiway Romeo, cleared to land"  
 
-`RWY 03 FOR DEP VIA OTLED, AVNEX, MANDU, SOLUS AND KEELS. RWY 06 FOR ALL OTHER DEP.`
+    **PH ADC:** "HWD, runway 21, cleared for takeoff"
+
+## Scenic Flights
+When traffic permits, VFR scenic flights over Perth are cleared via VICTOR 65 route (`CTE-PCTY-HKE`). Coordination with PH TCU is required prior to issuing this clearance, see [ACD to PH TCU](#acd-to-ph-tcu).
 
 ## Coordination
 ### Auto Release
@@ -84,7 +76,7 @@ All other aircraft require a 'Next' call to PH TCU.
 
 The PH TCU controller can suspend/resume Auto Release at any time, with the concurrence of **PH ADC**.
 
-The Standard Assignable level from PH ADC to PH TCU is the lower of `A050` or the `RFL`
+The Standard Assignable level from PH ADC to PH TCU is the lower of `A050` or the `RFL`.
 
 ### Departures Controller
 Refer to [Perth TCU Airspace Division](../../terminal/perth/#airspace-division) for information on airspace divisions when **PHD** is online.
@@ -95,12 +87,12 @@ a) VFR Departures
 b) Aircraft using a runway not on the ATIS
 
 !!! example
-    **ABC**: "Perth Delivery, ABC, Requesting a Victor 65 scenic."  
-    **PH ACD**: "ABC, Perth Delivery, Standby"  
+    **ABC**: "Perth Delivery, ABC, request Victor 65 scenic."  
+    **PH ACD**: "ABC, Perth Delivery, standby"  
 
-    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "ABC, Requesting Victor 65 scenic"  
-    <span class="coldline">**PH TCU** -> **PH ACD**</span>: "ABC, Cleared Victor 65 scenic"  
-    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "Cleared Victor 65 scenic, ABC"   
+    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "ABC, requesting Victor 65 scenic"  
+    <span class="coldline">**PH TCU** -> **PH ACD**</span>: "ABC, cleared Victor 65 scenic, not above 1,500ft"  
+    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "Cleared Victor 65 scenic not above 1,500ft, ABC"   
      
-    **PH ACD**: "ABC, Cleared for a victor 65 scenic"  
-    **ABC**: "Cleared for a victor 65 scenic, ABC"  
+    **PH ACD**: "ABC, cleared victor 65 scenic not above 1,500ft, squawk 0442"  
+    **ABC**: "Cleared for a victor 65 scenic, not above 1,500ft, squawk 0442, ABC"  

--- a/docs/enroute/Melbourne Centre/OLW.md
+++ b/docs/enroute/Melbourne Centre/OLW.md
@@ -27,6 +27,8 @@ OLW is responsible for **POT**, **PAR**, **NEW**, **MEK**, **MTK** and **MZI** w
 ## Sector Responsibilities
 OLW is responsible for issuing descent and ascertaining arrival intentions for aircraft bound for YPKA.
 
+Regardless of the status of KA ADC, OLW operates the Karratha Class E airspace `A055` and above. When KA ADC is offline, the Class D airspace below `A055` is reclassified Class G.
+
 ## STAR Clearance Expectation
 ### Handoff
 Aircraft being transferred to the following sectors shall be told to Expect STAR Clearance on handoff:

--- a/docs/enroute/Melbourne Centre/PIY.md
+++ b/docs/enroute/Melbourne Centre/PIY.md
@@ -24,28 +24,46 @@
 
 ## Sector Responsibilities
 ### Pingelly (PIY)
-PIY will provide final sequencing actions to ensure aircraft comply with their FF times prior to entering the Perth TCU. PIY is also responsible for issuing STAR Clearances for aircraft bound for YPJT, and Non-jets bound for YPPH and YPEA.  
+PIY will provide final sequencing actions to ensure aircraft comply with their FF times prior to entering the Perth TCU. PIY is also responsible for issuing STAR Clearances for aircraft bound for YPJT, and Non-jets bound for YPPH and YPEA. See [Perth Runway Modes](#perth-runway-modes) for runway assignment.
+
 For aircraft overflying the PH TCU place `O/FLY` in the LABEL DATA field.
 
 ### Leeman (LEA)
-LEA is responsible for assigning and issuing STAR clearance to aircraft inbound to Perth via `WAVES`.
+LEA is responsible for assigning and issuing STAR clearance to aircraft inbound to Perth via `WAVES`. See [Perth Runway Modes](#perth-runway-modes) for runway assignment.
 
 !!! note
     Controllers should be aware that VHF coverage near the LEA/IND border may be limited. Controllers should strive to issue HF frequencies and transfer of communications instruction prior to 160 NM PH DME.
+
 ### Grove (GVE)
-GVE is responsible for assigning and issuing STAR clearance to Jet aircraft inbound to Perth via `JULIM` and `CONNI`. 
+GVE is responsible for assigning and issuing STAR clearance to Jet aircraft inbound to Perth via `JULIM` and `CONNI`.  See [Perth Runway Modes](#perth-runway-modes) for runway assignment.
 
 ### Hyden (HYD)
-HYD is responsible for assigning and issuing STAR clearance to Jet aircraft inbound to Perth via `BEVLY`, `DAYLR` and `GRENE`.
+HYD is responsible for assigning and issuing STAR clearance to Jet aircraft inbound to Perth via `BEVLY`, `DAYLR` and `GRENE`. See [Perth Runway Modes](#perth-runway-modes) for runway assignment.
 
 ### Cross (CRS) / Geraldton (GEL)
 Just keeping them separated!
 
 ### Jarrah (JAR)
-JAR is responsible for assigning and issuing arrival clearance to aircraft inbound to Perth via `SOLUS`.
+JAR is responsible for assigning and issuing arrival clearance to aircraft inbound to Perth via `SOLUS`. See [Perth Runway Modes](#perth-runway-modes) for runway assignment.
 
 !!! note
     Controllers should be aware there may be limited ADS-B coverage around Albany (YABA). Expect some areas of Class E airspace to be outside surveillance coverage. [Procedural Standards](../../../separation-standards/procedural) may need to be used in these cases.
+
+### Perth Runway Modes
+#### Southwest Plan
+With the Southwest Plan active, arrivals shall be processed to either runway 21 or 24 based on their feeder fix, as per the table below:
+
+| Feeder Fix | Assigned Runway |
+| --- | --- |
+| JULIM | 21 |
+| CONNI | 21 |
+| WAVES | 21 |
+| BEVLY | 24 (or 21 if operationally required) |
+| GRENE | 24 |
+| SOLUS | 24 |
+
+#### Northeast Plan
+With the Northeast Plan active (runways 03 and 06 in use), all arrivals shall be processed to runway 03.
 
 ## STAR Clearance Expectation
 

--- a/docs/terminal/perth.md
+++ b/docs/terminal/perth.md
@@ -13,11 +13,23 @@
 † *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
-The Vertical limits of the PH TCU are `SFC` to `F245`.     
-PH TCU is responsible for the Perth TCU, except:      
-R155A & B when **PEA TCU** is online from `A020` to `F160`. When R155A is active to `F160`, PH TCU airspace above R155A shall be released to **PEA TCU**  
+The PH TCU is responsible for the airspace within 36 DME of the PH VOR, `SFC` to `F245`. 
+
+When **PEA TCU** is online R155A & B is released to them from `A020` to `F160`.  When R155A is active to `F160`, PH TCU airspace above R155A shall be released to **PEA TCU**.
 
 JT CTR reverts to Class G when **JT ADC** is offline, and is administered by the relevant PH TCU controller.      
+
+## Scenic Flights
+VFR aircraft may plan to conduct scenic flights within CTA in the PH TMA. A number of VFR routes exist to facilitate this, including:
+
+| Name | Route |
+| --- | --- |
+| Victor 65 | `CTE-PCTY-HKE` |
+| Victor 66 | `TLMI-HRR-CDM` |
+
+Aircraft wishing to conduct a scenic flight over the Perth CBD should be cleared via the Victor 65 route. **No lateral separation standard exists between Victor 65 and the extended centreline of runway 06/24**, so controllers must ensure that an alternative form of separation assurance exists.
+
+Aircraft departing YPPH and intending to conduct the Victor 65 route will be coordinated by **PH ACD**. See [Airways Clearances](#airways-clearances).
 
 ## Arrival Procedures
 ### YPJT Arrivals
@@ -78,7 +90,7 @@ Any aircraft not meeting the above criteria must be prior coordinated to ENR.
 #### Arrivals
 The Standard assignable level from ENR to PH TCU is `A090`. All other levels must be prior coordinated
 
-### PH TCU
+### PH ADC
 #### Auto Release
 
 "Next" Coordination is a procedure where the PH ADC controller gives a heads-up to the PH TCU controller about an impending departure. The PH TCU controller will respond by assigning a heading to the aircraft, for the PH ADC controller to pass on with their takeoff clearance.
@@ -88,13 +100,29 @@ The Standard assignable level from ENR to PH TCU is `A090`. All other levels mus
     <span class="hotline">**PH TCU** -> **PH ADC**</span>: "ABC, Heading 010, unrestricted"  
     <span class="hotline">**PH ADC** -> **PH TCU**</span>: "Heading 010, unrestricted, ABC"
 
+"Next" Coordination to PH TCU is not required for aircraft assigned a **Procedural SID** and the Standard Assignable Level.
+
 "Next" Coordination to PH TCU is additionally required for:   
     a) Aircraft on a non-standard level.  
     b) Aircraft departing from a runway not nominated in the ATIS.  
 
 The PH TCU controller can suspend/resume Auto Release at any time, with the concurrence of PH ADC.
 
-"Next" Coordination to PH TCU is not required for aircraft assigned a **Procedural SID** and the Standard Assignable Level.
+#### Airways Clearances
+The controller assuming responsibility of ACD shall give heads-up coordination to the relevant PH TCU controller prior to the issue of the following clearances:  
+a) VFR Departures  
+b) Aircraft using a runway not on the ATIS
+
+!!! example
+    **ABC**: "Perth Delivery, ABC, request Victor 65 scenic."  
+    **PH ACD**: "ABC, Perth Delivery, standby"  
+
+    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "ABC, requesting Victor 65 scenic"  
+    <span class="coldline">**PH TCU** -> **PH ACD**</span>: "ABC, cleared Victor 65 scenic, not above 1,500ft"  
+    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "Cleared Victor 65 scenic not above 1,500ft, ABC"   
+     
+    **PH ACD**: "ABC, cleared victor 65 scenic not above 1,500ft, squawk 0442"  
+    **ABC**: "Cleared for a victor 65 scenic, not above 1,500ft, squawk 0442, ABC"  
 
 ### PH TCU Internal
 

--- a/docs/terminal/perth.md
+++ b/docs/terminal/perth.md
@@ -19,6 +19,22 @@ When **PEA TCU** is online R155A & B is released to them from `A020` to `F160`. 
 
 JT CTR reverts to Class G when **JT ADC** is offline, and is administered by the relevant PH TCU controller.      
 
+## Runway Modes
+### Southwest Plan
+With the Southwest Plan active, all departures shall be assigned runway 21 by **PH ACD**. Arrivals shall be processed to either runway 21 or 24 based on their feeder fix, as per the table below:
+
+| Feeder Fix | Assigned Runway |
+| --- | --- |
+| JULIM | 21 |
+| CONNI | 21 |
+| WAVES | 21 |
+| BEVLY | 24 (or 21 if operationally required) |
+| GRENE | 24 |
+| SOLUS | 24 |
+
+### Northeast Plan
+With the Northeast Plan active, departures via `AVNEX`, `OTLED`, `MANDU`, `SOLUS`, and `KEELS` shall be assigned runway 03 by **PH ACD**. All other departures shall be assigned runway 06. All arrivals shall be processed to runway 03.
+
 ## Scenic Flights
 VFR aircraft may plan to conduct scenic flights within CTA in the PH TMA. A number of VFR routes exist to facilitate this, including:
 

--- a/docs/terminal/perth.md
+++ b/docs/terminal/perth.md
@@ -38,12 +38,23 @@ With the Northeast Plan active, departures via `AVNEX`, `OTLED`, `MANDU`, `SOLUS
 ## Scenic Flights
 VFR aircraft may plan to conduct scenic flights within CTA in the PH TMA. A number of VFR routes exist to facilitate this, including:
 
-| Name | Route |
-| --- | --- |
-| Victor 65 | `CTE-PCTY-HKE` |
-| Victor 66 | `TLMI-HRR-CDM` |
+| Name | Route | Preferred Altitude |
+| --- | --- | --- |
+| Victor 65 | `CTE-PCTY-HKE` | At or below `A015` |
+| Victor 66 | `TLMI-HRR-CDM` | At or below `A035` |
+
+Other levels are available at the discretion of the TCU controller but coordination may be required if adjacent TMA sectors are online. See [TCU Internal](#ph-tcu-internal) for coordination requirements.
 
 Aircraft wishing to conduct a scenic flight over the Perth CBD should be cleared via the Victor 65 route. **No lateral separation standard exists between Victor 65 and the extended centreline of runway 06/24**, so controllers must ensure that an alternative form of separation assurance exists.
+
+!!! example
+    **VH-CYF:** "Perth Approach, CYF, Cessna 172, overhead FREM, 1,500ft, received Bravo, request Victor 65"  
+    **PHA:** "CYF, squawk 0542, remain clear of class C airspace"  
+    **VH-CYF:** "Squawk 0542, remain OCTA, CYF"  
+
+    *When clearance (reference traffic into/out of YPPH) is available:*  
+    **PHA:** "CYF, cleared Victor 65, maintain 1,500ft"  
+    **VH-CYF:** "Cleared Victor 65, maintain 1,500ft, CYF"
 
 Aircraft departing YPPH and intending to conduct the Victor 65 route will be coordinated by **PH ACD**. See [Airways Clearances](#airways-clearances).
 
@@ -104,7 +115,7 @@ Any aircraft not meeting the above criteria must be prior coordinated to ENR.
     <span class="hotline">**PIY** -> **PH TCU**</span>: "PFY9916, concur F130"  
 
 #### Arrivals
-The Standard assignable level from ENR to PH TCU is `A090`. All other levels must be prior coordinated
+The Standard assignable level from ENR to PH TCU is `A090`. All other levels must be prior coordinated.
 
 ### PH ADC
 #### Auto Release
@@ -130,23 +141,25 @@ a) VFR Departures
 b) Aircraft using a runway not on the ATIS
 
 !!! example
-    **ABC**: "Perth Delivery, ABC, request Victor 65 scenic."  
-    **PH ACD**: "ABC, Perth Delivery, standby"  
-
-    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "ABC, requesting Victor 65 scenic"  
-    <span class="coldline">**PH TCU** -> **PH ACD**</span>: "ABC, cleared Victor 65 scenic, not above 1,500ft"  
-    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "Cleared Victor 65 scenic not above 1,500ft, ABC"   
-     
-    **PH ACD**: "ABC, cleared victor 65 scenic not above 1,500ft, squawk 0442"  
-    **ABC**: "Cleared for a victor 65 scenic, not above 1,500ft, squawk 0442, ABC"  
+    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "ABC, requesting Victor 65"  
+    <span class="coldline">**PH TCU** -> **PH ACD**</span>: "ABC, cleared Victor 65, 1,500ft"  
+    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "Cleared Victor 65, 1,500ft, ABC"
 
 ### PH TCU Internal
+Voiceless coordination is in place for all aircraft processed by the Victor 65 and 66 routes in accordance with the table below.
 
-All aircraft transiting between internal PH TCU boundaries must be heads-up coordinated.
+| Route | Non-Coordination Levels | Label Data |
+| --- | --- | --- |
+| Victor 65 | At or below `A015` | `V65` |
+| Victor 66 | At or below `A035` | `V66` |
+
+Other levels are available at the discretion of the TCU controller but coordination may be required if adjacent TMA sectors are online.
+
+All other aircraft transiting between internal PH TCU boundaries must be heads-up coordinated.
 
 !!! example
     <span class="hotline">**PHA** -> **PHD**</span>: "via PH, FD123"  
-    <span class="hotline">**PHD** -> **PHA**</span>: "FD123, A090"   
+    <span class="hotline">**PHD** -> **PHA**</span>: "FD123, A090"    
 
 ### JT ADC
 


### PR DESCRIPTION
## Summary
Improved YPPH Aerodrome and Terminal procedures, including standardising layout of various pages and supplementing existing docs with more info/examples.

## Changes
**Fixes**:
- Fixed PH TCU coordination heading (referencing TCU instead of ADC)

**Changes**:
- Adjusted display of PH TWR runway modes section

**Additions**:
- Victor 65 notes to PH TCU
- Coordination notes and example for VFR departures from YPPH to PH TCU
- Runway modes to PH TCU and ENR pages
- Airspace note to OLW page regarding YPKA Class E airspace