### PR TITLE
Various Fixes

### DIFF
--- a/docs/aerodromes/Adelaide.md
+++ b/docs/aerodromes/Adelaide.md
@@ -29,7 +29,7 @@ AD ADC is not responsible for any airspace by default.
     E.g. an aircraft taxiing from the terminal to runway 05 could be instructed to taxi "*via Alpha, cross runway 30, Foxtrot, to holding point Foxtrot Six runway 05*".
 
 ## Scenic Coastal Flights
-VFR aircraft may transit the control zone tracking coastal north or southbound, generally at `A005`. **AD TCU** is responsible for ensuring these aircraft remain separated from aircraft arriving/departing at YPAD and will likely delegate this responsibility to ADC, who may employ visual separation or other tools to ensure separation is maintained.  
+VFR aircraft may transit the control zone tracking coastal north or southbound, generally at `A005`. **AD TCU** is responsible for ensuring these aircraft remain separated from aircraft arriving/departing at YPAD and will likely delegate this responsibility to **ADC**, who may employ visual separation or other tools to ensure separation is maintained.  
 
 The TCU controller will coordinate these aircraft with ADC prior to issuing airways clearance, including the intended clearance limit. On receipt of this coordination, ADC should consider any possible conflict from arriving or departing aircraft at YPAD (including the missed approach to runway 23).  The clearance limits in the table below will ensure that coastal aircraft remain clear of the runway 05 approach path and runway 23 departure/missed approach path. 
 
@@ -48,14 +48,16 @@ The TCU controller will coordinate these aircraft with ADC prior to issuing airw
     <span class="hotline">**TCU** -> **ADC**</span>: "South of PNL, CNY, for coastal northbound, 500ft, clearance limit BTJ"  
     <span class="hotline">**ADC** -> **TCU**</span>: "CNY"
 
-If a delay is expected at the clearance limit, instruct the aircraft to hold there.  Once the conflict is no longer a threat, cancel the clearance limit and issue onwards clearance tracking coastal north/southbound at the desired level.
+If a delay is expected at the clearance limit, instruct the aircraft to hold there.
 
 !!! example 
     **CNY:** "Adelaide Tower, CNY, maintaining not above 500ft"  
     **AD ADC:** "CNY, Adelaide Tower, hold at the clearance limit, expect onwards clearance in 5 minutes due inbound traffic"  
     **CNY:** "Hold at the clearance limit, CNY"  
 
-    *Once conflict with YPAD traffic no longer exists:*  
+Once the conflict is no longer a threat (or if no holding was required in the first place), cancel the clearance limit and issue onwards clearance tracking coastal north/southbound at the desired level.
+
+!!! example 
     **AD ADC:** "CNY, cancel clearance limit, track coastal offshore northbound, not above 500ft"  
     **CNY:** "Cancel clearance limit, track coastal offshore northbound, not above 500ft, CNY"
 

--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -75,6 +75,12 @@ Non-jet aircraft for YSSY shall be assigned the **MEPIL** STAR.
 
     In this case, coordination should be conducted to ensure that both controllers agree and no additional conflicts are created as a result (particularly with aircraft inbound from the south/west).
 
+!!! example
+    **BIK:** "RXA6417, amended tracking and STAR available"  
+    **RXA6417:** "RXA6417, go ahead"  
+    **BIK:** "RXA6417, recleared direct BOREE for the BOREE3A arrival, runway 34L, maintain FL180"  
+    **RXA6417:** "Recleared direct BOREE for the BOREE3A arrival, runway 34L, maintain FL180, RXA6417"
+
 ## STAR Clearance Expectation
 ### Handoff
 Aircraft being transferred to the following sectors shall be told to Expect STAR Clearance on handoff:
@@ -121,6 +127,8 @@ That being said, due to their small sizes and frequent random-track traffic, it 
 #### Airspace
 When **TW ADC** is online, **ARL** owns the Class C airspace from `A065` upwards. **TW ADC** owns the Class D airspace `SFC` to `A045` and Class C airspace `A045` to `A065`.
 
+When **TW ADC** is closed, the Class C airspace `A085` and below is reclassified Class G.
+
 #### Departures
 Departures from YSTW in to ARL/MDE Class C will be coordinated when ready for departure.
 
@@ -142,7 +150,7 @@ The Standard Assignable level from ARL/MDE to **TW ADC** is `A080`, any other le
 
 ### CFS ADC
 #### Airspace
-When **CFS ADC** is online, **INL** and **MNN** owns the Class C airspace from A045 upwards, and **CFS ADC** owns the Class D airspace SFC-A045.
+**INL** and **MNN** own the Class C airspace from **A045** upwards, and **CFS ADC** (when online) owns the Class D airspace **SFC-A045**.
 
 #### Departures
 Departures from YCFS in to MNN Class C will be coordinated when ready for departure.
@@ -172,7 +180,10 @@ Any aircraft that will enter CFS ADC airspace, and not landing at YCFS, must be 
 
 ### WLM TCU
 #### Airspace
-By default, **WLM TCU** owns the airspace within the **R578A-G** restricted areas, unless stated otherwise by ad-hoc release or NOTAM. It is the responsibility of the **WLM TCU** controller to inform ARL(All) of what airspace they are assuming.
+By default, **WLM TCU** (when online) owns the airspace within the **R578A-G** restricted areas, unless stated otherwise by ad-hoc release or NOTAM. It is the responsibility of the **WLM TCU** controller to inform ARL(All) of what airspace they are assuming.
+
+When WLM TCU is offline, **ARL** administers the Class E airspace (generally **A085** and above, or **A045** and above in some airspace steps) and the military Class C airspace is reclassified as Class G.
+
 #### Departures
 Departures from **WLM TCU** in to ARL(All) Class C will be heads-up coordinated.
 

--- a/docs/enroute/Melbourne Centre/BIK.md
+++ b/docs/enroute/Melbourne Centre/BIK.md
@@ -63,6 +63,12 @@ Non-jet aircraft for YSSY shall be assigned the **ODALE** STAR.
 
     In this case, coordination should be conducted to ensure that both controllers agree and no additional conflicts are created as a result (particularly with aircraft inbound from the north/east).
 
+!!! example
+    **BIK:** "JST421, amended tracking and STAR available"  
+    **JST421:** "JST421, go ahead"  
+    **BIK:** "JST421, recleared direct AKMIR thence WELSH, ODALE, for the ODALE7 arrival, runway 34R, maintain FL350"  
+    **JST421:** "Recleared direct AKMIR, WELSH, ODALE, for the ODALE7 arrival, runway 34R, maintain FL350, JST421"
+
 ## STAR Clearance Expectation
 ### Handoff
 Aircraft being transferred to the following sectors shall be told to Expect STAR Clearance on handoff:

--- a/docs/military/williamtown.md
+++ b/docs/military/williamtown.md
@@ -42,6 +42,9 @@ WLM APP can negotiate further airspace releases from surrounding ENR sectors of 
 - R587B (`F125`-`F600`)  
 - R596 (`SFC`-`F120`)
 
+!!! note
+    It is the responsibility of the WLM TCU controller to negotiate any airspace releases with ARL(All).
+
 ### Classification
 All airspace owned by WLM TCU when online is reclassified to **Class C**.
 

--- a/docs/terminal/adelaide.md
+++ b/docs/terminal/adelaide.md
@@ -52,8 +52,8 @@ Coordinate the aircraft with ADC, including the use of the appropriate clearance
     <span class="hotline">**TCU** -> **ADC**</span>: "South of PNL, CEY, for coastal northbound, 500ft, clearance limit BTJ"  
     <span class="hotline">**ADC** -> **TCU**</span>: "CEY"  
 
-    **AD TCU:** "CEY, identified, cleared coastal offshore northbound, not above 500ft"  
-    **CEY:** "Cleared coastal offshore northbound, not above 500ft, CEY"  
+    **AD TCU:** "CEY, identified, cleared coastal offshore northbound, not above 500ft, clearance limit BTJ"  
+    **CEY:** "Cleared coastal offshore northbound, not above 500ft, clearance limit BTJ, CEY"  
 
     *Before CEY reaches BTJ:*  
     **AD TCU:** "CEY, contact Adelaide Tower, 120.5"  


### PR DESCRIPTION
## Summary
Various example updates and additional notes covering coastal transits of Adelaide, tower closed procedures for ARL, and use of the adjacent STAR in Sydney.

## Changes
**Fixes**:
- Fixed Adelaide coastal flying examples to include clearance limit

**Additions**:
- Added radio phraseology examples to ARL and BIK demonstrating amended STAR
- Added WLM TCU closed notes to ARL
