### PR TITLE
More Missing Standard Assignables

### DIFF
--- a/docs/aerodromes/Bankstown.md
+++ b/docs/aerodromes/Bankstown.md
@@ -129,6 +129,8 @@ When the aircraft is ready for departure, Tower will coordinate with the relevan
 
 The Standard Assignable level from BK ADC to SY TCU is `A030`, any other level must be prior coordinated.
 
+Aircraft shall be instructed to contact SY TCU passing `A015`.
+
 ### Arrivals/Overfliers
 SY TCU will heads-up coordinate arrivals/overfliers from Class C to BK ADC.  
 IFR aircraft will be cleared for the coordinated approach (Instrument or Visual) prior to handoff to BK ADC, unless BK ADC nominates a restriction.  

--- a/docs/aerodromes/Bankstown.md
+++ b/docs/aerodromes/Bankstown.md
@@ -127,7 +127,7 @@ When the aircraft is ready for departure, Tower will coordinate with the relevan
     <span class="hotline">**SY TCU** -> **BK ADC**</span>: "UJN, unrestricted"  
     <span class="hotline">**BK ADC** -> **SY TCU**</span>: "UJN"
 
-The Standard Assignable level from BK ADC to SY TCU is the lower of `A030` or the `RFL`, any other level must be prior coordinated.
+The Standard Assignable level from BK ADC to SY TCU is `A030`, any other level must be prior coordinated.
 
 ### Arrivals/Overfliers
 SY TCU will heads-up coordinate arrivals/overfliers from Class C to BK ADC.  

--- a/docs/terminal/adelaide.md
+++ b/docs/terminal/adelaide.md
@@ -101,6 +101,10 @@ The Standard assignable level from TBD/AUG to AD TCU is `A090`, and assigned a S
     <span class="hotline">**AD TCU** -> **AD ADC**</span>: "ABC, Track Extended Centreline, unrestricted"  
     <span class="hotline">**AD ADC** -> **AD TCU**</span>: "Track Extended Centreline, ABC"
 
+The Standard Assignable level from AD ADC to AD TCU is:  
+For Jets: `A050`  
+For Non-Jets: The lower of `A040` or the `RFL`
+
 ### AD TCU Internal
 All aircraft transiting between internal AD TCU boundaries must be heads-up coordinated.
 

--- a/docs/terminal/cairns.md
+++ b/docs/terminal/cairns.md
@@ -121,6 +121,8 @@ The following speeds apply from the Feeder Fix:
     <span class="hotline">**CS TCU** -> **CS ADC**</span>: "ABC, Heading 030, Unrestricted"  
     <span class="hotline">**CS ADC** -> **CS TCU**</span>: "Heading 030, Unrestriced, ABC"
 
+The Standard Assignable level from CS ADC to CS TCU is the lower of `A060` or the `RFL`.
+
 #### Missed Approach
 When weather conditions prevent the application of visual separation between a departure and a missed approach by tower:  
 a) ADC must advise TCU  

--- a/docs/terminal/canberra.md
+++ b/docs/terminal/canberra.md
@@ -49,6 +49,10 @@ The Standard assignable level from ENR to CB TCU is `F130`. All other levels mus
     <span class="hotline">**CB TCU** -> **CB ADC**</span>: "ABC, Track Extended Centreline, unrestricted"  
     <span class="hotline">**CB ADC** -> **CB TCU**</span>: "Track Extended Centreline, ABC"
 
+The Standard Assignable level from CB ADC to CB TCU is:  
+For IFR aircraft: `A100`  
+For VFR aircraft: The lower of `A040` or the `RFL`
+
 ### CB TCU Internal
 All aircraft transiting between internal CB TCU boundaries must be heads-up coordinated.
 

--- a/docs/terminal/coral.md
+++ b/docs/terminal/coral.md
@@ -44,7 +44,7 @@ The Standard assignable level from KEN(SWY) to MKA is `A070`, and assigned a STA
 
 ### MK/RK ADC
 #### Auto Release
-"Next" Coordination to TCU is required for all deps not assigned a SID.
+"Next" Coordination to TCU is required for all departures not assigned a SID.
 
 "Next" Coordination is a procedure where the **ADC** controller gives a heads-up to the TCU controller about an impending departure not on a SID. The TCU controller will respond by assigning a visual heading to the aircraft, for the **ADC** controller to pass on with their takeoff clearance.
 
@@ -57,6 +57,8 @@ The TCU controller can suspend/resume Auto Release at any time, with the concurr
 
 !!! Note
     "Next" Coordination to TCU is not required for aircraft assigned a **Procedural SID** and the Standard Assignable Level.
+
+The Standard Assignable level from MK/RK ADC to MKA/RKA is the lower of `A060` or the `RFL`.
 
 The controller assuming responsibility of **SMC** shall give heads-up coordination to TCU controller prior to the issue of the following clearances:  
 

--- a/docs/terminal/melbourne.md
+++ b/docs/terminal/melbourne.md
@@ -276,6 +276,9 @@ Any aircraft that don't meet these criteria will be coordinated to ML TCU with a
     <span class="hotline">**AV ADC** -> **MDS**</span>: "Next, UJI, Runway 18"  
     <span class="hotline">**MDS** -> **AV ADC**</span>: "UJI, left 030, unrestricted"  
     <span class="hotline">**AV ADC** -> **MDS**</span>: "Left 030, UJI"
+
+The Standard Assignable level from AV ADC to ML TCU is the lower of `A040` or the `RFL`.
+
 #### Arrivals
 ML TCU will heads-up coordinate arrivals/overfliers from CTA to AV ADC prior to **5 mins** from the boundary.  
 IFR aircraft will be cleared for the coordinated approach (Instrument or Visual) prior to handoff to AV ADC, unless AV ADC nominates a restriction.  

--- a/docs/terminal/perth.md
+++ b/docs/terminal/perth.md
@@ -135,6 +135,8 @@ The Standard assignable level from ENR to PH TCU is `A090`. All other levels mus
 
 The PH TCU controller can suspend/resume Auto Release at any time, with the concurrence of PH ADC.
 
+The Standard Assignable level from PH ADC to PH TCU is the lower of `A050` or the `RFL`.
+
 #### Airways Clearances
 The controller assuming responsibility of ACD shall give heads-up coordination to the relevant PH TCU controller prior to the issue of the following clearances:  
 a) VFR Departures  

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -481,7 +481,7 @@ Aircraft departing YSBK in to SY TCU Class C will be coordinated from **BK ADC**
     <span class="hotline">**SY TCU** -> **BK ADC**</span>: "TFX12, Unrestricted"  
     <span class="hotline">**BK ADC** -> **SY TCU**</span>: "TFX12"  
 
-    **BK ADC** will then clear the aircraft to takeoff , and instruct them to contact SY TCU passing `A020`.
+    **BK ADC** will then clear the aircraft to takeoff , and instruct them to contact SY TCU passing `A015`.
 
 #### Arrivals
 SY TCU will heads-up coordinate arrivals/overfliers from Class C to BK ADC prior to **5 mins** from the boundary.  

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -492,6 +492,8 @@ VFR aircraft require a level readback.
     <span class="hotline">**SY TCU** -> **BK ADC**</span>: "via GRB, UJN"  
     <span class="hotline">**BK ADC** -> **SY TCU**</span>: "UJN, A010"
 
+The Standard Assignable level from BK ADC to SY TCU is the lower of `A030` or the `RFL`.
+
 !!! tip
     Ensure the aircraft's FDR is up-to-date in order to give **BK ADC** maximum situational awareness of the traffic picture. (eg. if the aircraft is doing the RNP approach, ensure the FDR has been rerouted via the appropriate points)
 

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -492,7 +492,7 @@ VFR aircraft require a level readback.
     <span class="hotline">**SY TCU** -> **BK ADC**</span>: "via GRB, UJN"  
     <span class="hotline">**BK ADC** -> **SY TCU**</span>: "UJN, A010"
 
-The Standard Assignable level from BK ADC to SY TCU is the lower of `A030` or the `RFL`.
+The Standard Assignable level from BK ADC to SY TCU is `A030`.
 
 !!! tip
     Ensure the aircraft's FDR is up-to-date in order to give **BK ADC** maximum situational awareness of the traffic picture. (eg. if the aircraft is doing the RNP approach, ensure the FDR has been rerouted via the appropriate points)


### PR DESCRIPTION
## Summary
Added all other missing ADC->TCU Standard Assignable levels on the TCU pages

## Changes
**Fixes**:
- Added missing AD ADC -> AD TCU Standard Assignable level on AD TCU page
- Added missing CS ADC -> CS TCU Standard Assignable level on CS TCU page
- Added missing CB ADC -> CB TCU Standard Assignable level on CB TCU page
- Added missing MK ADC -> MK TCU Standard Assignable level on Coral TCU page
- Added missing RK ADC -> RK TCU Standard Assignable level on Coral TCU page
- Added missing AV ADC ->  ML TCU Standard Assignable level on ML TCU page
- Added missing BK ADC -> SY TCU Standard Assignable level on SY TCU page
- Added missing BK ADC -> SY TCU Frequency Transfer altitude on BK ADC page

**Changes**:
- Changed BK ADC -> SY TCU Standard Assignable level to `A030` (no RFL if lower)
- Changed BK ADC -> SY TCU Frequency transfer altitude from `A020` to `A015`
