### PR TITLE
AIRAC 2312 (Do not merge until 30/11)

### DIFF
--- a/docs/aerodromes/Cairns.md
+++ b/docs/aerodromes/Cairns.md
@@ -67,7 +67,7 @@ d) Aircraft departing to the Western VFR Corridor from all arriving aircrafton o
 ### IFR Departures
 IFR aircraft shall be processed via one of the following SIDs:
 
-a) RWY 15, Jets via SWIFT: SWIFT SID. Non-Jets via NONUM: NONUM SID  
+a) RWY 15, Jets via AKROM: AKROM SID. Non-Jets via NONUM: NONUM SID  
 b) RWY 33, All Jets: EAZEE SID, Radar Transition  
 c) All others: CS (RADAR) SID  
 

--- a/docs/aerodromes/Hobart.md
+++ b/docs/aerodromes/Hobart.md
@@ -29,9 +29,9 @@ South of the Runway Centreline: `SFC` to `A025`
 Refer to [Class D Tower Skills](../../controller-skills/classdtwr) for more information.
 
 ## SID Selection
-Jet Aircraft planned via **CLARK**, **LATUM**, or **LAVOP**, shall be assigned the **Procedural SID** that terminates at the appropriate waypoint.
+Jet Aircraft planned via **RIBLI**, **LATUM**, or **LAVOP**, shall be assigned the **Procedural SID** that terminates at the appropriate waypoint.
 
-Non-Jet Aircraft planned via **CLARK**, **KANLI**, or **LAVOP**, shall be assigned the **Procedural SID** that terminates at the appropriate waypoint.
+Non-Jet Aircraft planned via **RIBLI**, **KANLI**, or **LAVOP**, shall be assigned the **Procedural SID** that terminates at the appropriate waypoint.
 
 Other aircraft shall be assigned an appropriate **Procedural SID** or a visual departure.
 

--- a/docs/aerodromes/Launceston.md
+++ b/docs/aerodromes/Launceston.md
@@ -26,7 +26,13 @@ LT ADC is responsible for the Class D airspace in the LT CTR `SFC` to `A015`.
 Refer to [Class D Tower Skills](../../controller-skills/classdtwr) for more information.
 
 ## SID Selection
-Aircraft planned via **IRSOM**, **ONAGI**, **NUNPA**, **MOTRA**, **IRONS**, **MORGO**, **KAREN**, **TASUM**, or **NOLAN**, shall be assigned the appropriate **Procedural SID**.
+Aircraft planned via **MIKIS**, **TASUM**, or **VEKLO** shall be assigned the relevant Procedural SID.
+
+Aircraft planned via **IRSOM**, **ONAGI**, **VIMAP**, **NUNPA**, **MOTRA**, or **MORGO** shall be assigned the relevant **ALPHA** Procedural SID.
+
+Aircraft planned via **ONAGI**, **VIMAP**, **NUNPA**, or **MOTRA** may be assigned the relevant **BRAVO** Procedural SID *on pilot request*.
+
+**Non-Jet** Aircraft planned via **IRSOM**, **ONAGI**, or **MORGO** may be assigned the relevant **CHARLIE** Procedural SID *on pilot request*.
 
 Aircraft **not** planned via any of the above waypoints, shall be recleared via the most appropriate one, and assigned the **Procedural SID**.
 

--- a/docs/aerodromes/Perth.md
+++ b/docs/aerodromes/Perth.md
@@ -26,8 +26,8 @@ With the Southwest Plan active, all departures shall be assigned runway 21. Arri
 | Feeder Fix | Assigned Runway |
 | --- | --- |
 | JULIM | 21 |
-| CONNI | 21 |
-| WAVES | 21 |
+| SAPKO | 21 |
+| IPMOR | 21 |
 | BEVLY | 24 (or 21 if operationally required) |
 | GRENE | 24 |
 | SOLUS | 24 |
@@ -35,9 +35,9 @@ With the Southwest Plan active, all departures shall be assigned runway 21. Arri
 The ATIS shall notify `EXPECT ILS APCH`.
 
 ### Northeast Plan
-With the Northeast Plan active, departures via `AVNEX`, `OTLED`, `MANDU`, `SOLUS`, and `KEELS` shall be assigned runway 03. All other departures shall be assigned runway 06. All arrivals will be processed to runway 03.
+With the Northeast Plan active, departures via `AVNEX`, `OTLED`, `MANDU`, `SOLUS`, and `OPEGA` shall be assigned runway 03. All other departures shall be assigned runway 06. All arrivals will be processed to runway 03.
 
-When both Runway 03 and Runway 06 are nominated as departure runways, broadcast the following: `RWY 03 FOR DEP VIA OTLED, AVNEX, MANDU, SOLUS AND KEELS. RWY 06 FOR ALL OTHER DEP.`
+When both Runway 03 and Runway 06 are nominated as departure runways, broadcast the following: `RWY 03 FOR DEP VIA OTLED, AVNEX, MANDU, SOLUS AND OPEGA. RWY 06 FOR ALL OTHER DEP.`
 
 In the following conditions, ATIS shall notify `EXPECT ILS APCH`:  
     - By night; and/or  

--- a/docs/aerodromes/sydney.md
+++ b/docs/aerodromes/sydney.md
@@ -315,7 +315,7 @@ Sydney Coordinator is activated when required to reduce frequency congestion on 
 !!! example
     **VOZ543**: "Sydney Delivery, VOZ543, PDC read back"  
     **SY ACD**: "VOZ543, go ahead the read back"  
-    **VOZ543**: "OLSEM5 departure, squawk 1336, bay 33, VOZ543"  
+    **VOZ543**: "OLSEM1 departure, squawk 1336, bay 33, VOZ543"  
     **SY ACD**: "VOZ543, contact Coordinator 127.6 for pushback"  
     **VOZ543**: "127.6 for push, VOZ543"
 

--- a/docs/aerodromes/sydney.md
+++ b/docs/aerodromes/sydney.md
@@ -206,38 +206,78 @@ Unless operationally required, aircraft shall be assigned the following runways 
 | via WOL | 16R/34L |
 | via RIC| 16R/34L |
 | via PEGSU| 16R/34L |
-| via ENTRA | 16L/34R |
+| via OLSEM | 16L/34R |
 | via KAMBA | 16L/34R |
 | Other aircraft: |
 | To the NORTH and EAST | 16L/34R |
 | To the SOUTH and WEST | 16R/34L |
 
 !!! note
-    During times of heavy traffic, crossing domestic departures over Runway 34L can cause delays. In these situations, it may be beneficial for ACD to balance the load between Runways 34L and 34R for domestic jet departures via WOL. Non-jets departures via WOL should still be processed on 34L. The same principle may be applied to the Runway 16 direction when the 16R holding points are becoming congested and a large amount of heavy, international aircraft are planned to depart during a given window.  
+    During times of heavy traffic, crossing domestic departures over Runway 34L can cause delays. In these situations, it may be beneficial for ACD to balance the load between Runways 34L and 34R for domestic jet departures via WOL. Non-jet departures via WOL should still be processed on 34L. The same principle may be applied to the Runway 16 direction when the 16R holding points are becoming congested and a large amount of heavy, international aircraft are planned to depart during a given window.  
 
     Where the traffic levels are normal, preference should be given to departing aircraft in accordance with the runway selection table above.
 
-#### SID Selection
-Jet Aircraft planned via **KADOM**, **WOL**, **RIC**, or **ENTRA**, shall be assigned the **Procedural SID** that terminates at the appropriate waypoint.
-
-!!! example
-    Jet Aircraft planned via ENTRA, assigned runway 16L, shall be given KEVIN SID, ENTRA transition.
-
-Jet Aircraft **not** planned via **KADOM**, **WOL**, **RIC**, or **ENTRA**, and **not** using Runway 25, shall be assigned the **Procedural SID** appropriate to their runway, with the **RADAR** transition.
-
-!!! example
-    Jet Aircraft planned via EVONN, assigned runway 34R, shall be given MARUB SID, RADAR transition.
-
-!!! note
-    Heavier aircraft on long-haul flights may not be able to achieve the Climb Gradient required of the Procedural SIDs. In this instance, they shall be assigned the **SY (RADAR) SID**, as it has a shallower minimum Climb Gradient. If in doubt, ask the pilot.
-
-All other aircraft (non-jet aircraft, aircraft requiring a shallow climb gradient, and all aircraft using runway 25) shall be assigned the **SY (RADAR) SID**.
-
-!!! example
-    Non-Jet Aircraft planned via PEGSU, assigned runway 16R, shall be given the SY (RADAR) SID.
+## SID Selection
 
 !!! tip
     A radar SID (e.g. **SY (RADAR) SID**) is distinct from a procedural SID with a RADAR transition (eg, **RIC SID, RADAR transition**). A radar SID can be identified in the [DAPs](https://www.airservicesaustralia.com/aip/current/dap/AeroProcChartsTOC.htm) as having a *"(RADAR)"* at the end of the name.
+
+### Runway 07
+
+| Type  | Via  | SID     |
+| ------| ---- | --------|
+| Jet  | OLSEM<br>WOL | **FISHA** SID, Relevant Transition |
+| Jet  | All others | **FISHA** SID, RADAR Transition |
+| Non-Jet| All       | **RADAR** SID |
+
+### Runway 16L
+
+| Type  | Via  | SID     |
+| ------| ---- | --------|
+| Jet  | OLSEM<br>NOBAR<br>DIPSO<br>EVONN<br>CAWLY<br>OPTIC | **KEVIN** SID, Relevant Transition |
+| Jet  | WOL | **ABBEY** SID, WOL Transition |
+| Jet  | All others | **KEVIN** SID, RADAR Transition |
+| Non-Jet | All | **RADAR** SID |
+
+### Runway 16R
+
+| Type  | Via  | SID     |
+| ------| ---- | --------|
+| Jet  | RIC<br>KADOM<br>WOL | **KAMPI** SID, Relevant Transition |
+| Jet  | All others | **KAMPI** SID, RADAR Transition |
+| Non-Jet | All | **RADAR** SID |
+
+!!! note
+    Some aircraft will be unable to meet Climb Gradient Requirements on the **KAMPI** SID (6.7% to EXUGI), but still able to meet the requirements of the **DEENA** SID (4.7% to 1000ft). As above, the pilot will advise their capabilities. Aircraft that can accept the **DEENA** SID shall be assigned it as preference to the **RADAR** SID
+
+### Runway 25
+
+| Type  | Via  | SID     |
+| ------| ---- | --------|
+| All  | All | **RADAR** SID |
+
+### Runway 34L
+
+| Type  | Via  | SID     |
+| ------| ---- | --------|
+| Jet  | WOL | **WOL** SID |
+| Jet  | KADOM | **KADOM** SID |
+| Jet  | RIC | **RIC** SID, RIC Transition |
+| Jet  | All others | **RIC** SID, RADAR Transition |
+| Non-Jet | All | **RADAR** SID |
+
+### Runway 34R
+
+| Type  | Via  | SID     |
+| ------| ---- | --------|
+| Jet  | OLSEM | **OLSEM** SID |
+| Jet  | WOL | **MARUB** SID, WOL Transition |
+| Jet  | All others | **MARUB** SID, RADAR Transition |
+| Non-Jet | All | **RADAR** SID |
+
+### Climb Gradient Requirements
+Climb Gradient Requirements apply to all Procedural SIDs. It is the pilot's responsibility to advise if they are unable to meet these requirements. Pilots that advise this can be assigned a **RADAR** SID instead.
+
 ## ATIS
 #### Approach Types
 
@@ -275,7 +315,7 @@ Sydney Coordinator is activated when required to reduce frequency congestion on 
 !!! example
     **VOZ543**: "Sydney Delivery, VOZ543, PDC read back"  
     **SY ACD**: "VOZ543, go ahead the read back"  
-    **VOZ543**: "ENTRA5 departure, squawk 1336, bay 33, VOZ543"  
+    **VOZ543**: "OLSEM5 departure, squawk 1336, bay 33, VOZ543"  
     **SY ACD**: "VOZ543, contact Coordinator 127.6 for pushback"  
     **VOZ543**: "127.6 for push, VOZ543"
 

--- a/docs/enroute/Brisbane Centre/KEN.md
+++ b/docs/enroute/Brisbane Centre/KEN.md
@@ -77,7 +77,7 @@ The Standard assignable level from SWY to **MKA** is `A070`, and assigned the DA
 
 All other aircraft must be voice coordinated to **MKA** prior to **20nm** from the boundary.
 
-The Standard Assignable level from **MKA** to KPL is `F150`, and tracking via CLIFT or POONA.
+The Standard Assignable level from **MKA** to KPL is `F150`, and tracking via CLIFT or MUNAR.
 #### Airspace
 When **MKA** is online, they own up to `F150` in the **shaded** are shown below:
 <figure markdown>

--- a/docs/enroute/Melbourne Centre/PIY.md
+++ b/docs/enroute/Melbourne Centre/PIY.md
@@ -29,13 +29,13 @@ PIY will provide final sequencing actions to ensure aircraft comply with their F
 For aircraft overflying the PH TCU place `O/FLY` in the LABEL DATA field.
 
 ### Leeman (LEA)
-LEA is responsible for assigning and issuing STAR clearance to aircraft inbound to Perth via `WAVES`. See [Perth Runway Modes](#perth-runway-modes) for runway assignment.
+LEA is responsible for assigning and issuing STAR clearance to aircraft inbound to Perth via `IPMOR`. See [Perth Runway Modes](#perth-runway-modes) for runway assignment.
 
 !!! note
     Controllers should be aware that VHF coverage near the LEA/IND border may be limited. Controllers should strive to issue HF frequencies and transfer of communications instruction prior to 160 NM PH DME.
 
 ### Grove (GVE)
-GVE is responsible for assigning and issuing STAR clearance to Jet aircraft inbound to Perth via `JULIM` and `CONNI`.  See [Perth Runway Modes](#perth-runway-modes) for runway assignment.
+GVE is responsible for assigning and issuing STAR clearance to Jet aircraft inbound to Perth via `JULIM` and `SAPKO`.  See [Perth Runway Modes](#perth-runway-modes) for runway assignment.
 
 ### Hyden (HYD)
 HYD is responsible for assigning and issuing STAR clearance to Jet aircraft inbound to Perth via `BEVLY`, `DAYLR` and `GRENE`. See [Perth Runway Modes](#perth-runway-modes) for runway assignment.
@@ -56,8 +56,8 @@ With the Southwest Plan active, arrivals shall be processed to either runway 21 
 | Feeder Fix | Assigned Runway |
 | --- | --- |
 | JULIM | 21 |
-| CONNI | 21 |
-| WAVES | 21 |
+| SAPKO | 21 |
+| IPMOR | 21 |
 | BEVLY | 24 (or 21 if operationally required) |
 | GRENE | 24 |
 | SOLUS | 24 |

--- a/docs/terminal/cairns.md
+++ b/docs/terminal/cairns.md
@@ -53,7 +53,7 @@ Departing aircraft shall be transferred to TCU after ADC no longer has separatio
 
 IFR aircraft shall be processed via one of the following SIDs:
 
-a) RWY 15, Jets via SWIFT: SWIFT SID. Non-Jets via NONUM: NONUM SID  
+a) RWY 15, Jets via AKROM: AKROM SID. Non-Jets via NONUM: NONUM SID  
 b) RWY 33, All Jets: EAZEE SID, Radar Transition  
 c) All others: CS (RADAR) SID  
 
@@ -153,7 +153,7 @@ b) Aircraft using a runway not on the ATIS
 
 ### Enroute
 #### Departures
-Voiceless coordination is in place for any route (including SID and random direct tracks) to SWIFT, provided that the aircraft is:
+Voiceless coordination is in place for any route (including SID and random direct tracks) to AKROM, provided that the aircraft is:
 - Assigned the standard assignable level;  
 - Departed Cairns; and  
 - Is a Jet aircraft 

--- a/docs/terminal/perth.md
+++ b/docs/terminal/perth.md
@@ -26,14 +26,14 @@ With the Southwest Plan active, all departures shall be assigned runway 21 by **
 | Feeder Fix | Assigned Runway |
 | --- | --- |
 | JULIM | 21 |
-| CONNI | 21 |
-| WAVES | 21 |
+| SAPKO | 21 |
+| IPMOR | 21 |
 | BEVLY | 24 (or 21 if operationally required) |
 | GRENE | 24 |
 | SOLUS | 24 |
 
 ### Northeast Plan
-With the Northeast Plan active, departures via `AVNEX`, `OTLED`, `MANDU`, `SOLUS`, and `KEELS` shall be assigned runway 03 by **PH ACD**. All other departures shall be assigned runway 06. All arrivals shall be processed to runway 03.
+With the Northeast Plan active, departures via `AVNEX`, `OTLED`, `MANDU`, `SOLUS`, and `OPEGA` shall be assigned runway 03 by **PH ACD**. All other departures shall be assigned runway 06. All arrivals shall be processed to runway 03.
 
 ## Scenic Flights
 VFR aircraft may plan to conduct scenic flights within CTA in the PH TMA. A number of VFR routes exist to facilitate this, including:
@@ -64,7 +64,7 @@ IFR RNAV equipped arrivals to Jandakot planned via a fix listed shall be cleared
 
 | Perth Active Runway | 03/06 | 21/24 |
 | ------------------- | ----- | ----- |
-| **North**<br>JULIM (Jet)<br>CONNI (Non-Jet) | <br>JT 2G / WOORA | <br>DCT JT |
+| **North**<br>JULIM (Jet)<br>SAPKO (Non-Jet) | <br>JT 2G / WOORA | <br>DCT JT |
 | **East**<br>BEVLY (Jet)<br>GRENE (Non-Jet)<br>HAMTN (Non-Jet) | <br>JT 2G / BEVLY<br>JT 2G / GRENE<br>JT 2W / HAMTN | <br>JT 2R / BEVLY<br>JT 2R / GRENE<br>N/A 
 
 ### YPEA Arrivals

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -41,7 +41,7 @@ c) Departures assumes **SRI** airspace when the position is inactive
 d) **SRI** is **not permitted** to be logged on to, unless there are already at least **2 other active positions** (ie, SY APP and SY DEP, or SY APP and SY DIR) in the SY TCU.
 
 !!! note
-    The default ownership of sectors within the SY TCU is merely a suggestion for starters. There are 7 executive controller positions within the SY TCU, plus a flow controller, and the ownership of these sectors can be delegated as desired based on the traffic disposition, when agreed between the controllers. For example, during a Milk Run event, if SY APP and SY DEP are online, SY APP may have a lot more work to do than SY DEP, and it would mostly be concentrated on the RIVET/ODALE corridor. In light of this, it might be wise for SY APP to take ownership of SAS, SFW and SFE airspace, whilst SY DEP take ownership of SAN, SDS, SDN, and SRI airspace.
+    The default ownership of sectors within the SY TCU is merely a suggestion for starters. There are 7 executive controller positions within the SY TCU, plus a flow controller, and the ownership of these sectors can be delegated as desired based on the traffic disposition, when agreed between the controllers. For example, during a Milk Run event, if SY APP and SY DEP are online, SY APP may have a lot more work to do than SY DEP, and it would mostly be concOLSEMted on the RIVET/ODALE corridor. In light of this, it might be wise for SY APP to take ownership of SAS, SFW and SFE airspace, whilst SY DEP take ownership of SAN, SDS, SDN, and SRI airspace.
 
 !!! note
     Unless there are 2 separate Director controllers online (during a Major event like Panic Stations, for example), it is **not recommended** that the SFW and SFE positions are held by 2 separate controllers, due to the tendency of some less experienced pilots to overshoot the runway centreline
@@ -230,8 +230,8 @@ To reduce frequency congestion, several commonly used geographically defined are
 
 | Sector Name | Lateral Limits | Vertical Limits  |
 | --| ----------------| --------- |
-| City East | Bounded by Rushcutters Bay, Sydney Cricket Ground, Sydney Harbour Bridge South Pylon, Fort Denison, Clark Island, Rushcutters Bay   | Not above `A020`     |
-| CBD | Bounded by Rushcutters Bay, Sydney Cricket Ground, Cleveland Street, Regent Street, George Street, Sydney Harbour Bridge South Pylon, Fort Denison, Clarke Island, Rushcutters Bay | Not above `A020` |
+| City East | Bounded by Rushcutters Bay, Sydney Cricket Ground, Sydney Harbour Bridge South Pylon, Fort Denison, RIBLI Island, Rushcutters Bay   | Not above `A020`     |
+| CBD | Bounded by Rushcutters Bay, Sydney Cricket Ground, Cleveland Street, Regent Street, George Street, Sydney Harbour Bridge South Pylon, Fort Denison, RIBLIe Island, Rushcutters Bay | Not above `A020` |
 | North Harbour | The area northeast of a line St Ives Showground, Roseville Bridge, Sydney Harbour Bridge North Pylon then via the northern shore of Sydney Harbour to Middle Head then Manly | Not above `A015` |
 | Northern Beaches | The area east of a line Long Reef, Spit Bridge, Sydney Harbour Bridge North Pylon then via the northern shores of Sydney Harbour to Middle Head then Manly | Not above `A015` |
 | South Harbour | The area bounded by lines joining Sydney Harbour Bridge North Pylon, Sydney Harbour Bridge South Pylon, then via the southern shoreline of Sydney Harbour to South Head then Manly to Middle Head, then via the northern shoreline of Sydney Harbour to Sydney Harbour Bridge North Pylon | Not above `A015` |
@@ -364,7 +364,7 @@ Within 15 DME of SY, Departure controllers (**SDN** and **SDS**) can allow aircr
     SIDs from YSSY do not guarantee that aircraft will reach A100 by 15DME, so Departure controllers should be mindful of this and take action where necessary to expedite climb or coordinate with Approach.  
 
     Departure controllers should take extra caution when processing the following procedures to ensure they reach `A100` prior to entering REP airspace:  
-    <ul><li>RWY 34L: WOL SID & RIC SID with RADAR transition</li><li>RWY 16R: DEENA SID with RIC/KADOM transitions</li><li>YSBK departures via ENTRA/WOL</li></ul>
+    <ul><li>RWY 34L: WOL SID & RIC SID with RADAR transition</li><li>RWY 16R: DEENA SID with RIC/KADOM transitions</li><li>YSBK departures via OLSEM/WOL</li></ul>
 
 It is vital that Approach controllers ensure all arriving aircraft are established below `A090` no later than 20DME to avoid conflicting with departures utilising the airspace.  All STARs have height requirements which ensure this is achieved.  Aircraft inbound to YSBK or YSSY who are not cleared via a STAR should be instructed to reach `A090` by 20DME.
 
@@ -483,6 +483,8 @@ Aircraft departing YSBK in to SY TCU Class C will be coordinated from **BK ADC**
 
     **BK ADC** will then clear the aircraft to takeoff , and instruct them to contact SY TCU passing `A015`.
 
+The Standard Assignable level from BK ADC to SY TCU is `A030`.
+
 #### Arrivals
 SY TCU will heads-up coordinate arrivals/overfliers from Class C to BK ADC prior to **5 mins** from the boundary.  
 IFR aircraft will be cleared for the coordinated approach (Instrument or Visual) prior to handoff to BK ADC, unless BK ADC nominates a restriction.  
@@ -491,8 +493,6 @@ VFR aircraft require a level readback.
 !!! example
     <span class="hotline">**SY TCU** -> **BK ADC**</span>: "via GRB, UJN"  
     <span class="hotline">**BK ADC** -> **SY TCU**</span>: "UJN, A010"
-
-The Standard Assignable level from BK ADC to SY TCU is `A030`.
 
 !!! tip
     Ensure the aircraft's FDR is up-to-date in order to give **BK ADC** maximum situational awareness of the traffic picture. (eg. if the aircraft is doing the RNP approach, ensure the FDR has been rerouted via the appropriate points)

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -41,7 +41,7 @@ c) Departures assumes **SRI** airspace when the position is inactive
 d) **SRI** is **not permitted** to be logged on to, unless there are already at least **2 other active positions** (ie, SY APP and SY DEP, or SY APP and SY DIR) in the SY TCU.
 
 !!! note
-    The default ownership of sectors within the SY TCU is merely a suggestion for starters. There are 7 executive controller positions within the SY TCU, plus a flow controller, and the ownership of these sectors can be delegated as desired based on the traffic disposition, when agreed between the controllers. For example, during a Milk Run event, if SY APP and SY DEP are online, SY APP may have a lot more work to do than SY DEP, and it would mostly be concOLSEMted on the RIVET/ODALE corridor. In light of this, it might be wise for SY APP to take ownership of SAS, SFW and SFE airspace, whilst SY DEP take ownership of SAN, SDS, SDN, and SRI airspace.
+    The default ownership of sectors within the SY TCU is merely a suggestion for starters. There are 7 executive controller positions within the SY TCU, plus a flow controller, and the ownership of these sectors can be delegated as desired based on the traffic disposition, when agreed between the controllers. For example, during a Milk Run event, if SY APP and SY DEP are online, SY APP may have a lot more work to do than SY DEP, and it would mostly be concentrated on the RIVET/ODALE corridor. In light of this, it might be wise for SY APP to take ownership of SAS, SFW and SFE airspace, whilst SY DEP take ownership of SAN, SDS, SDN, and SRI airspace.
 
 !!! note
     Unless there are 2 separate Director controllers online (during a Major event like Panic Stations, for example), it is **not recommended** that the SFW and SFE positions are held by 2 separate controllers, due to the tendency of some less experienced pilots to overshoot the runway centreline
@@ -230,8 +230,8 @@ To reduce frequency congestion, several commonly used geographically defined are
 
 | Sector Name | Lateral Limits | Vertical Limits  |
 | --| ----------------| --------- |
-| City East | Bounded by Rushcutters Bay, Sydney Cricket Ground, Sydney Harbour Bridge South Pylon, Fort Denison, RIBLI Island, Rushcutters Bay   | Not above `A020`     |
-| CBD | Bounded by Rushcutters Bay, Sydney Cricket Ground, Cleveland Street, Regent Street, George Street, Sydney Harbour Bridge South Pylon, Fort Denison, RIBLIe Island, Rushcutters Bay | Not above `A020` |
+| City East | Bounded by Rushcutters Bay, Sydney Cricket Ground, Sydney Harbour Bridge South Pylon, Fort Denison, Clark Island, Rushcutters Bay   | Not above `A020`     |
+| CBD | Bounded by Rushcutters Bay, Sydney Cricket Ground, Cleveland Street, Regent Street, George Street, Sydney Harbour Bridge South Pylon, Fort Denison, Clark Island, Rushcutters Bay | Not above `A020` |
 | North Harbour | The area northeast of a line St Ives Showground, Roseville Bridge, Sydney Harbour Bridge North Pylon then via the northern shore of Sydney Harbour to Middle Head then Manly | Not above `A015` |
 | Northern Beaches | The area east of a line Long Reef, Spit Bridge, Sydney Harbour Bridge North Pylon then via the northern shores of Sydney Harbour to Middle Head then Manly | Not above `A015` |
 | South Harbour | The area bounded by lines joining Sydney Harbour Bridge North Pylon, Sydney Harbour Bridge South Pylon, then via the southern shoreline of Sydney Harbour to South Head then Manly to Middle Head, then via the northern shoreline of Sydney Harbour to Sydney Harbour Bridge North Pylon | Not above `A015` |


### PR DESCRIPTION
## Summary
Changes to SOPs, Waypoint names, Procedures for AIRAC 2312

## Changes
**Fixes**:
- Moved BK ADC -> SY TCU to Departures Coordination section
- Minor typos in SY ADC page

**Changes**:
- Waypoint name changes
	- POONA > MUNAR
	- SWIFT > AKROM
	- CONNI > SAPKO
	- KEELS > OPEGA
	- WAVES > IPMOR
	- CLARK > RIBLI
	- IRONS > MIKIS
	- KAREN > VEKLO
	- NOLAN > VIMAP
- YSSY SID Selection changes
- YMLT SID Selection changes
