### PR TITLE
Setup draft Discord update notifications

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,21 @@
+name: Send Discord Notification
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  if_merged:
+    if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'notify')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord Notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: '## {{ EVENT_PAYLOAD.pull_request.title }}\n{{ EVENT_PAYLOAD.pull_request.body }}'
+  


### PR DESCRIPTION
## Summary
As requested by ATS, this PR adds an action to send a notification to the #sop-updates Discord channel when completing PRs with the "notify" tag attached. Further work is likely necessary to improve the formatting, so this is only a functional prototype at this stage.