### PR TITLE
YSCB Helicopter Ops & YCFS Tower Closed Procedures

### DIFF
--- a/docs/aerodromes/Canberra.md
+++ b/docs/aerodromes/Canberra.md
@@ -46,6 +46,7 @@ The circuit direction is not specified in the airways clearance, but with a take
 
 Military jet training circuits are conducted at `A035`, unless otherwise requested by the pilot. ADC shall notify the TCU of the beginning and end of the sortie.
 
+### City Scenic Flights
 City Scenic Flights are available by day and to the west of the aerodrome. Aircraft on these routes shall be cleared at `A045`.
 
 | Runway              | City Flight One      | City Flight Two       |
@@ -62,6 +63,44 @@ City Scenic Flights are available by day and to the west of the aerodrome. Aircr
 ![City Flight Two](img/CBCTY2.png){ width="500" }
   <figcaption>City Flight Two</figcaption>
 </figure>
+
+### Helicopter Operations
+The Canberra CTR contains the Southcare Helicopter Base (YXSB) as well as two hospitals (Calvary Hospital and Canberra Hospital). Helicopters operating to and from these pads require a clearance from **CB ADC**.
+
+#### Departing Aircraft
+Helicopters departing the pads require an airways clearance to do so, either taking the form of a clearance to transit the zone to the Class G airspace adjacent to the CTR (if the pilot has no intention to enter CTA) or as a normal airways clearance for a departure into the surrounding CTA. Ensure that no conflict exists with arriving or departing traffic and consider delegating separation responsibility to the VFR aircraft if required. It may also be required to coordination with the TMA controller to ensure no additional conflict exists in their sector.
+
+Departing aircraft should **not** be issued a takeoff clearance (as the helipads are outside the manoeuvring area). Instead, instruct aircraft to 'report airborne'.
+
+!!! example
+    *RSCU201 is a VFR AW139 helicopter intending to depart Southcare Base (YXSB) to the northwest at `A035` (below the base of the Class C steps).*  
+    **RSCU201**: "Canberra Tower, helicopter RSCU201, Southcase Base, for departure to the northwest, A035, received Juliet, ready"  
+    **CB ADC**: "RSCU201, Canberra Tower, transit approved not above A035, report OCTA"  
+    **RSCU201**: "Transit approved, not above A035, RSCU201"
+
+!!! example
+    *RSCU209 is an IFR AW139 helicopter intending to depart Canberra Hospital (YXCB) for Bankstown (YSBK) at `A090` (inside Class C CTA).*  
+    **RSCU209**: "Canberra Tower, helicopter RSCU209, on the pad at Canberra Hospital, for Bankstown, received Juliet, ready"  
+    **CB ADC**: "RSCU209, Canberra Tower, report sighting a Jetstar A320 on a 3nm final runway 35"  
+    **RSCU209**: "Traffic sighted, RSCU209"  
+    **CB ADC**: "RSCU209, pass behind the A320, maintain own separation, caution wake turbulence, cleared to Bankstown via AKMIR, flight planned route, climb A090, squawk 3762"  
+    **RSCU209**: "Cleared to Bankstown via AKMIR flight planned route, climb A090, squawk 3762, pass behind the A320 and maintain own separation, RSCU209"  
+
+    *Remember to pass traffic information to both aircraft.*  
+    **CB ADC**: "JST619, traffic is a helicopter becoming airborne from Canberra Hospital, approximately 5nm southwest of the field, maintaining own separation with you"  
+
+#### Arriving Aircraft
+Helicopters arriving to the pads will generally be coordinated by the TMA controller and should be cleared via a visual approach (when available) and instructed to report on the ground. Do **not** issue a landing clearance to these aircraft (as the helipads are outside the manoeuvring area). It may be necessary to instruct these helicopters to track via amended visual points or sight and pass other aircraft.
+
+!!! example
+    **RSCU203**: "Canberra Tower, gday, RSCU203"  
+    **CB ADC**: "RSCU203, Canberra Tower, report sighting a Qantas 737 lining up on runway 17"  
+    **RSCU203**: "Traffic sighted, RSCU203"  
+    **CB ADC**: "RSCU203, that aircraft will be departing upwind, maintain own separation, cleared visual approach, report on the ground"  
+    **RSCU203**: "Maintain own separation, cleared visual approach, RSCU203"  
+
+    *Remember to pass traffic information to both aircraft.*  
+    **CB ADC**: "QFA714, traffic is a helicopter 1nm south of the field tracking for Calvary Hospital, opposite direction to you and maintaining own separation, runway 17, cleared for takeoff"
 
 ## Coordination
 ### Auto Release

--- a/docs/aerodromes/Canberra.md
+++ b/docs/aerodromes/Canberra.md
@@ -87,7 +87,7 @@ Departing aircraft should **not** be issued a takeoff clearance (as the helipads
     **RSCU209**: "Cleared to Bankstown via AKMIR flight planned route, climb A090, squawk 3762, pass behind the A320 and maintain own separation, RSCU209"  
 
     *Remember to pass traffic information to both aircraft.*  
-    **CB ADC**: "JST619, traffic is a helicopter becoming airborne from Canberra Hospital, approximately 5nm southwest of the field, maintaining own separation with you"  
+    **CB ADC**: "JST619, traffic is a helicopter becoming airborne from Canberra Hospital, approximately 5nm southwest of the field, maintaining own separation with you, runway 35, cleared to land"  
 
 #### Arriving Aircraft
 Helicopters arriving to the pads will generally be coordinated by the TMA controller and should be cleared via a visual approach (when available) and instructed to report on the ground. Do **not** issue a landing clearance to these aircraft (as the helipads are outside the manoeuvring area). It may be necessary to instruct these helicopters to track via amended visual points or sight and pass other aircraft.

--- a/docs/aerodromes/Canberra.md
+++ b/docs/aerodromes/Canberra.md
@@ -81,8 +81,8 @@ Departing aircraft should **not** be issued a takeoff clearance (as the helipads
 !!! example
     *RSCU209 is an IFR AW139 helicopter intending to depart Canberra Hospital (YXCB) for Bankstown (YSBK) at `A090` (inside Class C CTA).*  
     **RSCU209**: "Canberra Tower, helicopter RSCU209, on the pad at Canberra Hospital, for Bankstown, received Juliet, ready"  
-    **CB ADC**: "RSCU209, Canberra Tower, report sighting a Jetstar A320 on a 3nm final runway 35"  
-    **RSCU209**: "Traffic sighted, RSCU209"  
+    **CB ADC**: "RSCU209, Canberra Tower, report sighting a Jetstar A320 on a 3nm final runway 35 and advise able to maintain own separation with that aircraft"  
+    **RSCU209**: "Traffic sighted and affirm, RSCU209"  
     **CB ADC**: "RSCU209, pass behind the A320, maintain own separation, caution wake turbulence, cleared to Bankstown via AKMIR, flight planned route, climb A090, squawk 3762"  
     **RSCU209**: "Cleared to Bankstown via AKMIR flight planned route, climb A090, squawk 3762, pass behind the A320 and maintain own separation, RSCU209"  
 
@@ -94,8 +94,8 @@ Helicopters arriving to the pads will generally be coordinated by the TMA contro
 
 !!! example
     **RSCU203**: "Canberra Tower, gday, RSCU203"  
-    **CB ADC**: "RSCU203, Canberra Tower, report sighting a Qantas 737 lining up on runway 17"  
-    **RSCU203**: "Traffic sighted, RSCU203"  
+    **CB ADC**: "RSCU203, Canberra Tower, report sighting a Qantas 737 lining up on runway 17 and advise able to maintain own separation with that aircraft"  
+    **RSCU203**: "Traffic sighted and affirm, RSCU203"  
     **CB ADC**: "RSCU203, that aircraft will be departing upwind, maintain own separation, cleared visual approach, report on the ground"  
     **RSCU203**: "Maintain own separation, cleared visual approach, RSCU203"  
 

--- a/docs/enroute/Brisbane Centre/INL.md
+++ b/docs/enroute/Brisbane Centre/INL.md
@@ -146,7 +146,7 @@ All other aircraft must be voice coordinated to **RKA** prior to **20nm** from t
 The Standard Assignable level from **RKA** to KPL is `F150`, and tracking via BUDGI or TARES.
 ### CFS ADC
 #### Airspace
-When **CFS ADC** is online, **INL** and **MNN** owns the Class C airspace from `A045` upwards, and **CFS ADC** owns the Class D airspace `SFC` to `A045`.
+**INL** and **MNN** owns the Class C airspace above CFS from `A045` upwards. **CFS ADC** owns the Class D airspace `SFC` to `A045` when open.
 
 #### Departures
 Departures from YCFS in to INL Class C will be coordinated when ready for departure.

--- a/docs/enroute/Brisbane Centre/INL.md
+++ b/docs/enroute/Brisbane Centre/INL.md
@@ -35,6 +35,8 @@ When **SU ADC** is offline, SU CTR (Class D `SFC` to `A045`) reverts to Class G,
 #### CFS CTR
 When **CFS ADC** is offline, CFS CTR (Class D `SFC` to `A045`) reverts to Class G, and is administered by MNN and INL. Alternatively, INL may provide a [top-down procedural service](../../../aerodromes/Coffs) if they wish (not recommended), and this must be coordinated to ARL(MNN).
 
+Due to the low ceiling of CTA, when CFS ADC is offline, INL shall instruct aircraft departing into CTA to report lined up on the runway and issue an airways clearance (traffic pending) at that time.
+
 #### RK CTR
 Whilst the **RKA** controller is expected to provide a [top-down service](../../../aerodromes/Rockhampton) to YBRK when **RK ADC** is offline, this is not expected of a GOL controller when both **RKA** and **RK ADC** are offline. If electing not to provide a top-down service to YBRK, the RK CTR Class D is reclassified to Class G `SFC` to `A007`, and Class E `A007` to `A045`.
 

--- a/docs/terminal/canberra.md
+++ b/docs/terminal/canberra.md
@@ -53,6 +53,19 @@ The Standard Assignable level from CB ADC to CB TCU is:
 For IFR aircraft: `A100`  
 For VFR aircraft: The lower of `A040` or the `RFL`
 
+#### Helipads in the CB CTR
+The Canberra CTR contains the Southcare Helicopter Base (YXSB) as well as two hospitals (Calvary Hospital and Canberra Hospital). Helicopters inbound to these helipads should be coordinated with **CB ADC** who can use a visual separation techniques as required. ADC and the TMA controller should work together to determine the most appropriate clearance limit (if required due traffic) for the helicopter, before frequency transfer is issued. ADC will issue a visual approach clearance when it is available.
+
+!!! example
+    *RSCU201 is an IFR AW139 helicopter tracking from the east for Southcare Base (YXSB).*  
+    <span class="hotline">**CBE** -> **CB ADC**</span>: "To the east, RSCU201, for Southcare Base, are you able to separate with the arrival path to runway 35?"  
+    <span class="hotline">**CB ADC** -> **CBE**</span>: "Affirm, RSCU201 clearance limit Queanbeyan"  
+    <span class="hotline">**CBE** -> **CB ADC**</span>: "Clearance limit Queanbeyan, RSCU201"  
+
+    **CBE**: "RSCU201, clearance limit Queanbeyan, contact Tower 118.7"
+
+Departing helicopters may transit the CTR to Class G (under the direction of ADC) or be coordinated with the TCU to determine the availability of an airways clearance in CTA.
+
 ### CB TCU Internal
 All aircraft transiting between internal CB TCU boundaries must be heads-up coordinated.
 


### PR DESCRIPTION
## Summary
Adds SOPs for handling helicopter operations in and out of the various hospitals and helicopter bases in the Canberra CTR. Expands on YCFS tower closed procedures and clarifies airspace arrangement.

## Changes
**Fixes**:
- Reworded INL coordination section to better reflect airspace arrangement

**Additions**:
- Added brief notes on INL handling YCFS departures with tower closed
- Added procedures for CB ADC and CB TCU to handle helicopter operations in the CB CTR
