### PR TITLE
Add Launceston and Hobart ATIS Identifier Restrictions

### DIFF
--- a/docs/aerodromes/Hobart.md
+++ b/docs/aerodromes/Hobart.md
@@ -36,7 +36,7 @@ Non-Jet Aircraft planned via **RIBLI**, **KANLI**, or **LAVOP**, shall be assign
 Other aircraft shall be assigned an appropriate **Procedural SID** or a visual departure.
 
 ## ATIS
-YMHB ATIS identifiers range from `N` to `Y`, as YMLT uses `A` through `N`. 
+YMHB ATIS identifiers range from `N` to `Y`, as YMLT uses `A` through `M`. 
 
 ## Cambridge (YCBG)
 Due to it's close proximity, HB ADC & SMC are responsible for clearances into and out of Cambridge (YCBG), which sits inside the Hobart Class D control zone.

--- a/docs/aerodromes/Hobart.md
+++ b/docs/aerodromes/Hobart.md
@@ -35,6 +35,9 @@ Non-Jet Aircraft planned via **RIBLI**, **KANLI**, or **LAVOP**, shall be assign
 
 Other aircraft shall be assigned an appropriate **Procedural SID** or a visual departure.
 
+## ATIS
+YMHB ATIS identifiers range from `N` to `Y`, as YMLT uses `A` through `N`. 
+
 ## Cambridge (YCBG)
 Due to it's close proximity, HB ADC & SMC are responsible for clearances into and out of Cambridge (YCBG), which sits inside the Hobart Class D control zone.
 

--- a/docs/aerodromes/Launceston.md
+++ b/docs/aerodromes/Launceston.md
@@ -38,6 +38,9 @@ Aircraft **not** planned via any of the above waypoints, shall be recleared via 
 
 Aircraft unable to accept a SID, or that cannot practically accept amended routing via the above points, shall be assigned the **RADAR SID**.
 
+## ATIS
+YMLT ATIS identifiers range from `A` to `M`, as YMHB uses `N` through `Y`.
+
 ## VFR Operations
 
 ### Circuit Direction


### PR DESCRIPTION
## Summary
Added YMLT and YMHB ATIS Identifiers which differentiate themselves from the adjacent aerodrome.

## Changes

**Additions**:
- YMLT and YMHB ATIS section
- YMLT utilizing A through M, YMHB utilizing N through Y.