### PR TITLE
Updated Policy References, other minor fixes

### DIFF
--- a/docs/aerodromes/classc/Adelaide.md
+++ b/docs/aerodromes/classc/Adelaide.md
@@ -80,8 +80,7 @@ With **Runway 23** in use for arrivals and the cloud base above `A024` but below
 This allows aircraft on the Victor STAR from the west to join a visual right base without the need to conduct an instrument approach, while keeping aircraft from the east clear of the higher terrain near the Adelaide Hills.
 
 ### Curfew Mode
-
-Between the hours of 1330-2030 UTC (1230-1930 UTC HDS), AD ADC may elect to simulate Curfew operations, ie: **Runway 23 for arrivals, Runway 05 for departures**. When this is in operation, the ATIS shall include `CURFEW IN OPERATION UNTIL (time) ZULU`.
+Between the hours of 1330-2030 UTC (1230-1930 UTC HDS), AD ADC may elect to simulate Curfew operations, ie: **Runway 05 for arrivals, Runway 23 for departures**. When this is in operation, the ATIS shall include `CURFEW IN OPERATION UNTIL (time) ZULU`.
 
 ## SID Selection
 Jet Aircraft planned via **PANKI**, **BENDO**, **GILES**, **HAWKY**, **ORBUN**. or **SEDAN**, shall be assigned the **Procedural SID** that terminates at the appropriate waypoint. Jet Aircraft **not** planned via any of these waypoints shall receive amended routing via the most appropriate SID terminus, unless the pilot indicates they are unable to accept a Procedural SID.

--- a/docs/aerodromes/classc/Brisbane.md
+++ b/docs/aerodromes/classc/Brisbane.md
@@ -16,7 +16,7 @@
 | **Brisbane ACD**         | **Brisbane Delivery**| **118.850**          | **BN_DEL**                                   |
 | Brisbane ATIS        |                | 126.250          | YBBN_ATIS                                |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 BN ADC is not responsible for any airspace by default.

--- a/docs/aerodromes/classc/Melbourne.md
+++ b/docs/aerodromes/classc/Melbourne.md
@@ -67,17 +67,22 @@ If winds are too great, single runway operations may be necessary (eg, Runway 16
 !!! note
     See [Runway Mode Formatting](#runway-mode-formatting) for details on how to format each runway mode in the ATIS.
 
-#### SID Selection
+### SID Selection
 Jet Aircraft planned via **MNG**, **NONIX**, **DOSEL**, **CORRS**, **KEPPA**, **NEVIS**, **SUNTI**, **ESDIG**, or **CRENA**, shall be assigned the **Procedural SID** that terminates at the appropriate waypoint. Jet Aircraft **not** planned via any of these waypoints shall receive amended routing via the most appropriate SID terminus, unless the pilot indicates they are unable to accept a Procedural SID.
 
 !!! example
     Jet Aircraft planned via DOSEL, assigned runway 27, shall be given the DOSEL SID.
+
+#### Off Mode Departures
+During the 16A27D Runway Mode, some aircraft may operationally require Runway 16 for departure.  
+Aircraft departing Runway 16 and assigned the Standard Assignable Heading would conflict with departures from Runway 27, so the **ISPEG** SID must be used instead.
 
 Jet aircraft planned via **MNG**, **NONIX**, **DOSEL**, **KEPPA**, or **NEVIS**, using Runway 16 for departure **Off Mode**, shall be assigned the **ISPEG** SID.
 
 !!! definition
     **Off Mode:** Aircraft departing from a runway not prescribed as active for departures on the ATIS. For example, a heavy aircraft that operationally requires Runway 16 for departure during the 16A/27D Mode.
 
+#### RADAR SID
 a) Jet aircraft departing **Off Mode** that don't meet the above critera; or  
 b) Non-Jet Aircraft; or  
 c) All aircraft using Runway 09; or  
@@ -129,7 +134,8 @@ In light of this, the use of this operational info should be avoided.
     a) Departing from a runway nominated on the ATIS; and  
     b) Assigned `A050`; and  
     c) Assigned a **Procedural** SID; or  
-    d) Assigned the **ML (RADAR) SID** and a [Standard Assignable Heading](#standard-assignable-departure-headings)
+    d) Assigned the **ISPEG** SID for **Off Mode** Runway 16 departures; or  
+    e) Assigned the **ML (RADAR) SID** and a [Standard Assignable Heading](#standard-assignable-departure-headings)
 
 All other aircraft require a 'Next' call to ML TCU.
 

--- a/docs/aerodromes/classc/Perth.md
+++ b/docs/aerodromes/classc/Perth.md
@@ -13,7 +13,7 @@
 | **Perth ACD** | **Perth Delivery** | **118.550** | **PH_DEL** |
 | Perth ATIS | N/A | 123.800 | YPPH_ATIS |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 PH ADC is not responsible for any airspace by default.

--- a/docs/aerodromes/classc/Sydney.md
+++ b/docs/aerodromes/classc/Sydney.md
@@ -16,7 +16,7 @@
 | **Sydney ACD**         | **Sydney Delivery**| **133.800**          | **SY_DEL**                                   |
 | Sydney ATIS        |                | 126.250          | YSSY_ATIS                                |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)  
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)  
 
 ## Airspace
 SY ADC is responsible for the Class C airspace in the SY CTR `SFC` to `A005` as shown below.
@@ -307,7 +307,7 @@ When SODPROPS are in operation, the ATIS OPR INFO shall include:
 Sydney Coordinator is activated when required to reduce frequency congestion on SMC and to ensure compliance with pre-determined slot times as necessary. The position is rarely used on VATSIM and is only beneficial with the large amounts of traffic only seen during annual events like WorldFlight. When Coordinator is online, all departures are first directed to them prior to contacting SMC.
 
 !!! important
-    Sydney Coordinator is a non-standard position which may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies).
+    Sydney Coordinator is a non-standard position which may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies).
 
 !!! example
     **VOZ543**: "Sydney Delivery, VOZ543, PDC read back"  

--- a/docs/controller-skills/callsigns.md
+++ b/docs/controller-skills/callsigns.md
@@ -23,7 +23,6 @@ This page lists some of the most commonly used callsigns in Australia.
 | BNZ | BONZA |
 | CFH  | CAREFLIGHT |
 | FD | FLYDOC |
-| HM | HM |
 | HND | HINTERLAND |
 | JTE  | JETEX |
 | JST | JETSTAR |

--- a/docs/controller-skills/extending.md
+++ b/docs/controller-skills/extending.md
@@ -4,7 +4,7 @@ title: Extending
 
 --8<-- "includes/abbreviations.md"
 
-As per [VATPAC Ratings and Controller Positions Policy](https://cdn.vatpac.org/documents/policy/Controller+Positions+and+Ratings+Policy+v5.2.pdf), Enroute controllers are permitted to *extend* to any adjacent sector, with the exception of:
+As per [VATPAC Air Traffic Services Policy](https://cdn.vatpac.org/documents/policy/Controller+Positions+and+Ratings+Policy+v5.2.pdf), Enroute controllers are permitted to *extend* to any adjacent sector, with the exception of:
 
 - ASP, which can only extend to adjacent YMMM (Melbourne Centre) sectors.
 - ISA, which can only extend to adjacent YBBB (Brisbane Centre) sectors.

--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -14,7 +14,7 @@
 | Maitland† | Brisbane Centre | 132.350 | BN-MLD_CTR |
 | Ocean† | Brisbane Centre | 128.600 | BN-OCN_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 ## Airspace
 
 <figure markdown>

--- a/docs/enroute/Brisbane Centre/INL.md
+++ b/docs/enroute/Brisbane Centre/INL.md
@@ -15,7 +15,7 @@
 | Noosa† | Brisbane Centre | 124.100 | BN-NSA_CTR |
 | Keppel† | Brisbane Centre | 125.900 | BN-KPL_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 

--- a/docs/enroute/Brisbane Centre/ISA.md
+++ b/docs/enroute/Brisbane Centre/ISA.md
@@ -14,7 +14,7 @@
 | Warrego† | Brisbane Centre | 132.450 | BN-WEG_CTR |
 | Carnarvon† | Brisbane Centre | 133.800 | BN-CVN_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 
@@ -28,7 +28,7 @@ ISA is responsible for **ARA**, **STR**, **WEG**, and **CVN** when they are offl
 ## Extending
 
 !!! Warning
-    As per [VATPAC Ratings and Controller Positions Policy](https://cdn.vatpac.org/documents/policy/Controller+Positions+and+Ratings+Policy+v5.2.pdf), BN-ISA_CTR is only permitted to extend to adjacent **YBBB** sectors.
+    As per [VATPAC Air Traffic Services Policy](https://cdn.vatpac.org/documents/policy/Controller+Positions+and+Ratings+Policy+v5.2.pdf), BN-ISA_CTR is only permitted to extend to adjacent **YBBB** sectors.
 
 ## Sector Responsibilities
 ISA and its subsectors are purely Classes A, E and G of airspace. [Standard separation procedures](../../../separation-standards) apply.

--- a/docs/enroute/Brisbane Centre/KEN.md
+++ b/docs/enroute/Brisbane Centre/KEN.md
@@ -13,7 +13,7 @@
 | Tabletop† | Brisbane Centre | 120.550 | BN-TBP_CTR |
 | Swampy† | Brisbane Centre | 133.200 | BN-SWY_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 

--- a/docs/enroute/Brisbane Centre/TRT.md
+++ b/docs/enroute/Brisbane Centre/TRT.md
@@ -10,7 +10,7 @@
 | **Territory** | **Brisbane Centre** | **133.200** | **BN-TRT_CTR** |
 | Kimberley† | Brisbane Centre | 133.400 | BN-KIY_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 ## Airspace
 
 <figure markdown>

--- a/docs/enroute/Melbourne Centre/ASP.md
+++ b/docs/enroute/Melbourne Centre/ASP.md
@@ -15,7 +15,7 @@
 | Bourke† | Melbourne Centre | 128.200 | ML-BKE_CTR |
 | Esperance† | Melbourne Centre | 123.950 | ML-ESP_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 
@@ -32,7 +32,7 @@ When **AS ADC** is offline, AS CTR (Class D and C `SFC` to `F125`) within 80 DME
 
 ## Extending
 !!! Warning
-    As per [VATPAC Ratings and Controller Positions Policy](https://cdn.vatpac.org/documents/policy/Controller+Positions+and+Ratings+Policy+v5.2.pdf), ML-ASP_CTR is only permitted to extend to adjacent **YMMM** sectors.
+    As per [VATPAC Air Traffic Services Policy](https://cdn.vatpac.org/documents/policy/Controller+Positions+and+Ratings+Policy+v5.2.pdf), ML-ASP_CTR is only permitted to extend to adjacent **YMMM** sectors.
 
 ## STAR Clearance Expectation
 ### Handoff

--- a/docs/enroute/Melbourne Centre/BIK.md
+++ b/docs/enroute/Melbourne Centre/BIK.md
@@ -11,7 +11,7 @@
 | Wollongong† | Melbourne Centre | 125.000 | ML-WOL_CTR |
 | Gundagai† | Melbourne Centre | 128.400 | ML-GUN_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 

--- a/docs/enroute/Melbourne Centre/ELW.md
+++ b/docs/enroute/Melbourne Centre/ELW.md
@@ -11,7 +11,7 @@
 | Benalla† | Melbourne Centre | 132.200 | ML-BLA_CTR |
 | Snowy† | Melbourne Centre | 124.000 | ML-SNO_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 

--- a/docs/enroute/Melbourne Centre/OLW.md
+++ b/docs/enroute/Melbourne Centre/OLW.md
@@ -15,7 +15,7 @@
 | Mount† | Melbourne Centre | 133.700 | ML-MTK_CTR |
 | Menzies† | Melbourne Centre | 134.300 | ML-MZI_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 ## Airspace
 
 <figure markdown>

--- a/docs/enroute/Melbourne Centre/PIY.md
+++ b/docs/enroute/Melbourne Centre/PIY.md
@@ -15,7 +15,7 @@
 | Grove† | Melbourne Centre | 133.800 | ML-GVE_CTR |
 | Geraldton† | Melbourne Centre | 134.200 | ML-GEL_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 ## Airspace
 <figure markdown>
 ![Pingelly Airspace](../assets/piy.png){ width="700" }

--- a/docs/enroute/Melbourne Centre/TBD.md
+++ b/docs/enroute/Melbourne Centre/TBD.md
@@ -10,7 +10,7 @@
 | **Tailem Bend** | **Melbourne Centre** | **123.050** | **ML-TBD_CTR** |
 | Augusta† | Melbourne Centre | 127.050 | ML-AUG_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 

--- a/docs/enroute/Melbourne Centre/YWE.md
+++ b/docs/enroute/Melbourne Centre/YWE.md
@@ -14,7 +14,7 @@
 | Griffith† | Melbourne Centre | 122.750 | ML-GTH_CTR |
 | Katoomba† | Melbourne Centre | 133.500 | ML-KAT_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 

--- a/docs/oceanic/index.md
+++ b/docs/oceanic/index.md
@@ -57,7 +57,7 @@ NTTT - Tahiti Oceanic
 | Indian East† | Brisbane Radio | 123.650 | ML-INE_FSS |
 | Indian South† | Brisbane Radio | 123.200 | ML-INS_FSS |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 COL, FLD, and HWE can be split off from TSN. INE and INS can be split off from IND.
     

--- a/docs/pacific/New-Caledonia/TCU.md
+++ b/docs/pacific/New-Caledonia/TCU.md
@@ -12,7 +12,7 @@
 | Tontouta Approach (TMA 1.1)†|NWWWT| Tontouta Approach  | 119.700         | NWWW-T_APP          |
 
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies){target=new}
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}
 
 ## Airspace
 The vertical limits of the Tontouta TCU are `SFC` to `F245`.

--- a/docs/terminal/adelaide.md
+++ b/docs/terminal/adelaide.md
@@ -10,9 +10,9 @@
 | ------------------ | --------------| -------------- | ---------------- | --------------------------------------|
 | **Adelaide Approach West**    |**AAW**| **Adelaide Approach**   | **124.200**         | **AD_APP**                                   |
 | Adelaide Approach East†    |AAE| Adelaide Departures  | 118.200         | AD_DEP          |
-| Adelaide Flow†        |AFL|                |          | AD-FLW_CTR                               |
+| Adelaide Flow†        |AFL|                |          | AD_FMP                              |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 The Vertical limits of the AD TCU are `SFC` to `F245`.

--- a/docs/terminal/brisbane.md
+++ b/docs/terminal/brisbane.md
@@ -13,9 +13,9 @@
 | Brisbane Departures North†    |BDN| Brisbane Departures  | 133.450         | BN_DEP          |
 | Brisbane Departures South†   |BDS| Brisbane Departures | 118.450          | BN-S_DEP         |
 | Gold Coast Approach† |BAC| Brisbane Approach  | 123.500          | BN-C_APP       |
-| Brisbane Flow†        |BFL|                |          | BN-FLW_CTR                               |
+| Brisbane Flow†        |BFL|                |          | BN_FMP                              |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 The Vertical limits of the BN TCU are `SFC` to `F180`, except in BAC airspace, where it is `SFC` to `A075` in the North West, and `SFC` to `F125` in the South East.
@@ -32,7 +32,7 @@ If BN TCU elects not to provide top-down to YBCG, The CG CTR Class C airspace `S
 See also: [CG ADC Offline](#cg-adc-offline).
   
 ### Airspace Structural Arrangements
-Pursuant to Section 3 of the [VATPAC Ratings and Controller Positions Policy](https://cdn.vatpac.org/documents/policy/Controller+Positions+and+Ratings+Policy+v5.2.pdf), **“North”**/**”West”** positions shall assume the airspace of corresponding **“South”**/**”East”** positions when the latter are inactive (e.g. **BAN** assumes **BAS** airspace), and vice versa.
+Pursuant to Section 3 of the [VATPAC Air Traffic Services Policy](https://cdn.vatpac.org/documents/policy/Controller+Positions+and+Ratings+Policy+v5.2.pdf), **“North”**/**”West”** positions shall assume the airspace of corresponding **“South”**/**”East”** positions when the latter are inactive (e.g. **BAN** assumes **BAS** airspace), and vice versa.
 
 ## Parallel Runway Operations
 Refer to [Parallel Runway Separation Standards](../../separation-standards/parallelapps) for more information

--- a/docs/terminal/cairns.md
+++ b/docs/terminal/cairns.md
@@ -10,9 +10,9 @@
 | ------------------ | --------------| -------------- | ---------------- | --------------------------------------|
 | **Cairns Approach**    |**CS1**| **Cairns Approach**   | **118.400**         | **CS_APP**          |
 | Cairns Approach†    |CS2| Cairns Departures  | 126.100         | CS_DEP          |
-| Cairns Flow†        |  |                |          | CS-FLW_CTR                               |
+| Cairns Flow†        |  |                |          | CS_FMP                              |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 The Vertical limits of the CS TCU are `SFC` to `F180`.  

--- a/docs/terminal/canberra.md
+++ b/docs/terminal/canberra.md
@@ -10,8 +10,9 @@
 | ------------------ | --------------| -------------- | ---------------- | --------------------------------------|
 | **Canberra Approach East**    |**CBE**| **Canberra Approach**   | **124.500**         | **CB_APP**     |
 | Canberra Approach West†   |CBW| Canberra Approach   | 125.900          | CB-W_APP    |
+| Canberra Flow†        |  |                |          | CB_FMP                              |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 The Vertical limits of the CB TCU are `SFC` to `F245`.

--- a/docs/terminal/darwin.md
+++ b/docs/terminal/darwin.md
@@ -11,7 +11,8 @@
 | **Darwin Approach East**    |**DAE**| **Darwin Approach**  | **125.200**         | **DN_APP**          |
 | Darwin Approach West†   |DAW| Darwin Approach   | 134.100         | DN-W_APP                                  |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies){target=new}
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}
+
 ## Airspace
 ### TCU
 DN TCU owns the airspace within a 40NM radius of the DN DME from `SFC`–`FL180`  

--- a/docs/terminal/melbourne.md
+++ b/docs/terminal/melbourne.md
@@ -11,9 +11,9 @@
 | **Melbourne Approach East**    |**MAE**| **Melbourne Approach**   | **132.000**         | **ML_APP**                                   |
 | Melbourne Departures North†    |MDN| Melbourne Departures  | 118.900         | ML_DEP          |
 | Melbourne Departures South†   |MDS| Melbourne Departures | 129.400          | ML-S_DEP         |
-| Melbourne Flow†        |MFL|                |          | ML-FLW_CTR                               |
+| Melbourne Flow†        |MFL|                |          | ML_FMP                             |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies){target=new}
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}
 
 ## Airspace
 The Vertical limits of the ML TCU are `SFC` to `F245`.  
@@ -35,11 +35,6 @@ c) The Coffin, when **EN ADC** is online, and the airspace has been released to 
 MB CTR reverts to Class G when **MB ADC** is offline, and is administered by the relevant ML TCU controller.
 
 See also: [MB ADC Offline](#mb-adc-offline).
-
-#### EN CTR
-EN CTR reverts to Class G when **EN ADC** is offline, and is administered by the relevant ML TCU controller.
-
-See also: [EN ADC Offline](#en-adc-offline).
 
 #### AV CTR
 AV CTR Class D `SFC` to `A007` reverts to Class G and `A007` to `A025` to Class E when **AV ADC** is offline, and is administered by the relevant ML TCU controller.

--- a/docs/terminal/perth.md
+++ b/docs/terminal/perth.md
@@ -8,9 +8,9 @@
 | -----| -- | -------- | --------- | ---------------- |
 | **Perth Approach** |**PHA**| **Perth Approach**  | **123.600** | **PH_APP**| 
 | Perth Departures†  |PHD| Perth Departures  | 118.700 | PH_DEP |
-| Perth Flow† | PHF |   |    | PH-FLW_CTR  |
+| Perth Flow† | PFL |   |    | PH_FMP  |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
 
 ## Airspace
 The PH TCU is responsible for the airspace within 36 DME of the PH VOR, `SFC` to `F245`.  

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -15,9 +15,9 @@
 | Sydney Director West† |SFW| Sydney Director   | 126.100          | SY-D_APP                               |
 | Sydney Director East† |SFE| Sydney Director   | 125.300          | SY-DE_APP                               |
 | Sydney Radar†* |SRI| Sydney Centre  | 124.550          | SY-C_DEP                               |
-| Sydney Flow†        |SFL|                |          | SY-FLW_CTR                               |
+| Sydney Flow†        |SFL|                |          | SY_FMP                              |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies).  
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies).  
 * [Additional requirements](#airspace-structural-arrangements) must be met prior to opening SRI as a stand-alone position.
 
 ## Airspace
@@ -37,7 +37,7 @@ See also: [BK ADC Offline](#bk-adc-offline).
 CN CTR reverts to Class G when **CN ADC** is offline, and is administered by the relevant SY TCU controller.
 
 ### Airspace Structural Arrangements
-Pursuant to Section 3 of the [VATPAC Ratings and Controller Positions Policy](https://cdn.vatpac.org/documents/policy/Controller+Positions+and+Ratings+Policy+v5.2.pdf), the following rules apply, in the order presented, to these controller positions, except **SFL**:  
+Pursuant to Section 3 of the [VATPAC Air Traffic Services Policy](https://cdn.vatpac.org/documents/policy/Controller+Positions+and+Ratings+Policy+v5.2.pdf), the following rules apply, in the order presented, to these controller positions, except **SFL**:  
 
 a) **“North”**/**”West”** positions shall assume the airspace of corresponding **“South”**/**”East”** positions when the latter are inactive (e.g. **SAN** assumes **SAS** airspace, **SFW** assumes **SFE** airspace)  
 

--- a/docs/terminal/williamtown.md
+++ b/docs/terminal/williamtown.md
@@ -11,7 +11,7 @@
 | **Williamtown Approach (High)**    | **Willy Approach**   | **133.300**         | **WLM_APP**                                   |
 | Williamtown Approach (Low)†    | Willy Approach   | 135.700         | WLM-L_APP                                   |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Ratings and Controller Positions Policy](https://vatpac.org/publications/policies).  
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies).  
 
 ## Airspace
 ### Default


### PR DESCRIPTION
## Summary
Updated references to the now outdated Controller Positions Policy, to now reflect the new Air Traffic Services Policy. As well as other minor changes

## Changes
**Fixes**:
- Fixed incorrect curfew mode at YPAD on YPAD Aerodrome page (Now correctly shows 05A23D)

**Changes**:
- **Controller Ratings & Positions Policy** references now updated to the new **Air Traffic Services Policy**
- Updated Flow positions callsigns to new "**_FMP**" formatting as per new GCAP Policy
- Auto-Release now available for Off Mode 16 departures at YMML assigned the **ISPEG** SID

**Additions**:
- Added more detail to the YMML Aerodrome page regarding the assignment of the **ISPEG** SID

**Removals**:
- Removed duplicated and incorrectly formatted "**HM**" callsign in Aircraft Callsigns page
- Removed incorrect reference to Airspace reclassification in the EN CTR when EN ADC is offline. Airspace no longer gets reclassified.
