### PR TITLE
ELW/CB TCU Reclassification

### DIFF
--- a/docs/enroute/Melbourne Centre/ELW.md
+++ b/docs/enroute/Melbourne Centre/ELW.md
@@ -22,7 +22,7 @@
 
 ### Reclassifications
 #### CB CTR
-When **CB TCU** is offline, CB TCU (Class C `SFC` to `F245`) reverts to Class G, and is administered by BLA. Alternatively, BLA may provide a [top-down approach service](../../../terminal/canberra) if they wish.
+When **CB TCU** is offline, CB TCU (Class C `SFC` to `A085`) reverts to Class G, and is administered by BLA. Alternatively, BLA may provide a [top-down approach service](../../../terminal/canberra) if they wish.
 
 #### AY CTR
 When **AY ADC** is offline, AY CTR (Class D and C `SFC` to `A085`) reverts to Class G, and is administered by BLA. Alternatively, BLA may provide a [top-down procedural service](../../../aerodromes/Albury) if they wish.


### PR DESCRIPTION
## Summary
Change to CB TCU Offline Airspace Reclassification for ELW.

## Changes

**Changes**:
- When CB TCU is Offline, and ELW is not providing top-down, only SFC-**A085** reverts to Class G (was SFC-F245)