### PR TITLE
SY TCU Flow times, other minor fixes

### DIFF
--- a/docs/controller-skills/airwork.md
+++ b/docs/controller-skills/airwork.md
@@ -16,6 +16,9 @@ Airwork can be conducted in any defined area specified by the pilot or ATC. This
     **KIY**: "PPB, No Reported IFR Traffic"  
     **PPB**: "PPB"
 
+<details markdown="1">
+<summary>Remarks</summary>
+
 ### Remarks
 An aircraft's Flight Plan Remarks can be the first sign that airwork will be occurring. It can help you as a controller start your planning nice and early, and stay ahead of the game. If the pilot has left detailed remarks, it also means you can spend less time on the frequency asking them what they're doing.
 #### STS/ (Status) field
@@ -45,6 +48,11 @@ A pilot intending to conduct Parachute Operations overhead Rockingham
 
 `RMK/SVY OPS WI MAP 420`  
 A pilot intending to conduct Aerial Survey Operations as per Map 420
+
+</details>
+
+<details markdown="1">
+<summary>General Operations</summary>
 
 ### General Operations
 
@@ -90,6 +98,11 @@ Not often that a "Checklist" is required in an ATC environment, but when Airwork
 
     Confirm an ops normal time if required
 
+</details>
+
+<details markdown="1">
+<summary>Search and Rescue (SAR) Operations</summary>
+
 ### Search and Rescue (SAR) Operations
 SAR Operations are conducted more or less as a standard airwork procedure. Handle the aircraft as any other normal aircraft transiting your airspace, with the airwork procedures shown above.
 
@@ -99,6 +112,11 @@ SAR Operations are most commonly flown in a circular area (eg Radius from a Fix,
     **DDU**: "DDU, Requesting Traffic for Search and Rescue operations for the next 90 minutes, within a 10nm Radius of 23 52 South, 136 01 East, Not above A060"  
     **ASP**: "DDU, No Reported IFR Traffic. Call Ops Normal time on the hour"  
     **DDU**: "Ops Normal on the hour, DDU"  
+
+</details>
+
+<details markdown="1">
+<summary>Practice Instrument Approaches</summary>
 
 ### Practice Instrument Approaches
 A Practice Instrument Approach is simply an aircraft conducting an Instrument Approach with no intention of a full-stop landing. This is pretty straight-forward outside controlled airspace, as the pilot will often just request a traffic statement for a given radius from a fix. In controlled airspace, however, there can be quite a few things to consider.
@@ -161,6 +179,11 @@ Conduct Coordination to any affected adjacent units as required
     **AAE**: "YNJ, Cleared VOR-A Approach, make Sector Entry. At the minima, Fly Published Missed Approach"  
     **YNJ**: "Cleared VOR-A Approach, make Sector Entry. At the minima, Fly Published Missed Approach, YNJ"
 
+</details>
+
+<details markdown="1">
+<summary>Aerial Surveys</summary>
+
 ### Aerial Surveys
 <figure markdown>
 ![Aerial Survey Example](img/svy.jpg){ width="800" }
@@ -215,6 +238,11 @@ Then when ready, clear the aircraft for the survey work
 
 !!! tip
     Continue to ask the pilot questions in order to know exactly what they are doing. For separation assurance with the departing YMML traffic, you could ask *"Confirm you will be able to remain outside 40 DME ML?"*. You could ask the pilot what kind of turn they will be making at the completion of each run. You could also instruct the pilot to maintain a heading on the completion of a run for separation purposes.
+
+</details>
+
+<details markdown="1">
+<summary>Parachute Operations</summary>
 
 ### Parachute Operations
 Pilots on the network may choose to simulate Parachute Operations (PJE).  
@@ -315,3 +343,5 @@ Most procedures are the same for IFR aircraft, just remember that the situation 
 
 #### OCTA Operations
 VFR PJE aircraft operating wholly within Class G or Class E airspace are still required to make broadcasts on frequency, and they are entitled to a traffic statement for Drop and Descent.
+
+</details>

--- a/docs/controller-skills/milkrun.md
+++ b/docs/controller-skills/milkrun.md
@@ -6,6 +6,9 @@ title: Milk Run Monday
 
 Milk Run Monday is a very busy event, that tests the limits of controllers at it's busiest. It is important to understand some processes that makes the event run as smooth as possible for all pilot and controllers involved. The information on this page is extracted from various Local Instructions and Controller Skills pages, collated to give all of the most relevant information to controlling the Milk Run event.
 
+<details markdown="1">
+<summary>ACD</summary>
+
 ## ACD
 The job of the ACD controller during Milk Run is a fairly straight-forward one, however there are a couple of things to be mindful of.
 
@@ -13,6 +16,11 @@ Ensure that all flight plans are correct, nothing like `DOSEL DCT RIVET`, `GPS D
 
 ### 16 Off Mode Departures at YMML
 A Reminder that [Off Mode Departures from Runway 16](../../aerodromes/classc/Melbourne/#off-mode-departures) to the North East and North West during the 16A27D Runway Mode must be assigned the **ISPEG** SID, **NOT** the DOSEL SID. The **ISPEG** SID deconflicts concurrent 16 and 27 departures, whereas the DOSEL SID does not.
+
+</details>
+
+<details markdown="1">
+<summary>SMC</summary>
 
 ## SMC
 ### Standard Taxi Routes
@@ -46,6 +54,11 @@ In order to protect common Runway Exit Taxiways, Consider instructing aircraft t
 
 !!! note
     Utilising these hold short instructions also opens up the availability of taxiways `J` and `Y` as alternative taxi routes on the International terminal side
+
+</details>
+
+<details markdown="1">
+<summary>ADC</summary>
 
 ## ADC
 ### Runway Modes
@@ -90,6 +103,11 @@ It is best practice for ADC to line-up aircraft on the runway as soon as possibl
 
 !!! suggestion
     Appending the phrase "Be ready immediate" to the end of a line up instruction can ensure the pilot has all checklists completed, and is ready to commence takeoff roll as soon as the clearance is given. This reduces airborne delays, and potential go-around situations
+
+</details>
+
+<details markdown="1">
+<summary>TMA</summary>
 
 ## TMA
 In theory, aircraft should already be nicely sequenced when they enter your airspace, however, this is not always the case. There can also be additional aircraft that come in from other directions that need to be added to the sequence, which can make things challenging.
@@ -137,6 +155,11 @@ When there is a go-around in the middle of a bumper-to-bumper sequence, a fair b
 !!! example
     <span class="hotline">**MAE** -> **ELW**</span>: "We've had a Go around. Additional 2 minute delay for all aircraft in this sequence please."  
     <span class="hotline">**ELW** -> **MAE**</span>: "Copy, additional 2 minute delay for all aircraft in this sequence."  
+
+</details>
+
+<details markdown="1">
+<summary>Enroute</summary>
 
 ## Enroute
 ### Early Handoffs
@@ -198,6 +221,11 @@ Although this action may be beneficial to the arrival flow for both Enroute and 
 
 In order to reduce this coordination, GUN/BIK and SFL/SAS may organise blanket coordination to allow this rerouting at the discretion of the GUN/BIK controller.
 
+</details>
+
+<details markdown="1">
+<summary>Workload Management</summary>
+
 ## Workload Management
 ### Splitting
 Never ever ever ever ever (ever) deny an offer to split up your sector! It could be someone offering to take:  
@@ -233,3 +261,5 @@ Regular Coordination with your peers is critical to the efficient operation of a
 - (As the TMA Controller) Ask the Enroute controller for an additional **2 minute delay for all aircraft**, due to a **go-around**
 
 It is also important to not accept aircraft that are in conflict! If the TMA controller is trying to handoff two aircraft pointed at each other at the same level, give them a call on the Hotline, and ask them to fix it before handing off to you. Of course you may offer/suggest a solution, but it should not be your conflict to solve.
+
+</details>

--- a/docs/controller-skills/vatsys.md
+++ b/docs/controller-skills/vatsys.md
@@ -6,6 +6,9 @@ title: vatSys Setup
 
 Although much of the detailed setup is up to personal preference, the following setttings are **strongly** recommended to help best execute the appropriate role.
 
+<details markdown="1">
+<summary>Enroute</summary>
+
 ## Enroute
 ### Display
 ATC List: **ON**
@@ -39,6 +42,11 @@ Extended Labels: **ON**
 **TFMS** (if airport is busy, eg during events)  
 **AIS DISPLAY** for major airports in your airspace
 
+</details>
+
+<details markdown="1">
+<summary>TCU</summary>
+
 ## TCU
 ### Display
 ATC List: **ON**
@@ -71,6 +79,11 @@ Extended Labels: **OFF** (Toggled on for aircraft not arriving at main airport)
 **TFMS** (if airport is busy, eg during events)  
 **AIS DISPLAY** for major airports in your airspace
 
+</details>
+
+<details markdown="1">
+<summary>Tower</summary>
+
 ## Tower
 ### Display
 ATC List: **ON**
@@ -101,3 +114,5 @@ FPASD: **ON**
 Extended Labels: **OFF** (Toggled on for aircraft not arriving at main airport)  
 ### Info
 **AIS DISPLAY**
+
+</details>

--- a/docs/enroute/Brisbane Centre/ISA.md
+++ b/docs/enroute/Brisbane Centre/ISA.md
@@ -14,7 +14,7 @@
 | Warrego† | Brisbane Centre | 132.450 | BN-WEG_CTR |
 | Carnarvon† | Brisbane Centre | 133.800 | BN-CVN_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}
 
 ## Airspace
 

--- a/docs/enroute/Melbourne Centre/ASP.md
+++ b/docs/enroute/Melbourne Centre/ASP.md
@@ -15,7 +15,7 @@
 | Bourke† | Melbourne Centre | 128.200 | ML-BKE_CTR |
 | Esperance† | Melbourne Centre | 123.950 | ML-ESP_CTR |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}
 
 ## Airspace
 

--- a/docs/oceanic/index.md
+++ b/docs/oceanic/index.md
@@ -5,7 +5,7 @@
 --8<-- "includes/abbreviations.md"
 
 ## Airspace
-The following oceanic FIRs are owned by VATPAC and are covered under the [Pacific Oceanic Agreement.](https://drive.google.com/file/d/1xRWTTwpDOek2mkRbXQx53ee2uuot0ofB/view)
+The following oceanic FIRs are owned by VATPAC and are covered under the [Pacific Oceanic Letter of Agreement](https://vatpac.org/publications/policies){target=new}
 
 YBBB - Brisbane Oceanic  
 YMMM - Melbourne Oceanic  

--- a/docs/separation-standards/procedural.md
+++ b/docs/separation-standards/procedural.md
@@ -29,6 +29,11 @@ title: Procedural
 ![10 min Departure Standard Diagram](img/dep7a.png){ width="600" }
 </figure> |
 
+</details>
+
+<details markdown="1">
+<summary>Arrivals</summary>
+
 ## Arrivals
 ### 10nm
 | Conditions | |

--- a/docs/separation-standards/procedural.md
+++ b/docs/separation-standards/procedural.md
@@ -4,6 +4,9 @@ title: Procedural
 
 --8<-- "includes/abbreviations.md"
 
+<details markdown="1">
+<summary>Departures</summary>
+
 ## Departures
 ### 2 min
 | Conditions | |
@@ -33,6 +36,11 @@ title: Procedural
 | a) Both aircraft are inbound and the leading aircraft is within 20 NM of a controlled aerodrome with DME or a published waypoint; and<br>b) The aircraft are assigned vertically separated levels. | <figure markdown>
 ![10nm Arrival Standard Diagram](img/d5.png){ width="600" }
 </figure> |
+
+</details>
+
+<details markdown="1">
+<summary>Longitudinal</summary>
 
 ## Longitudinal
 
@@ -109,6 +117,11 @@ Distance checks must be conducted as per the following table:
 ![Opposite sides of visual fix Standard Diagram](img/t7b.png){ width="600" }
 </figure> |
 
+</details>
+
+<details markdown="1">
+<summary>Lateral</summary>
+
 ## Lateral
 
 ### Time-based crossing track
@@ -121,6 +134,9 @@ Where a difference 15 minutes does not exist at the crossing point, vertical sep
 <figure markdown>
 ![Both](../oceanic/assets/Both.png)
 </figure>
+
+<details markdown="1">
+<summary>Conflict Area</summary>
 
 ### Conflict Area
 The Quickest and easiest way to assess lateral conflict scenarios is with the *Conflict Area tool*. Unfortunately, whilst its quick and easy to *use*, it's fairly complex and long to understand the rules and concepts.  
@@ -209,6 +225,11 @@ Use BRL to measure a distance to/from a waypoint that is outside of the conflict
     "Climb to reach (vertically separated level) by (GNSS distance outside entry of conflict area)"  
     "Report (GNSS distance outside exit of conflict area) for requested level"  
 
+</details>
+
+<details markdown="1">
+<summary>Lat Sep Table</summary>
+
 ### Lat Sep Table
 Lateral Separation works off the basis off establishing a *Lateral Separation Point* (Lat Sep point). That is, when given an angle that 2 tracks intersect at, a distance at which lateral separation is considered to exist procedurally. These figures are detailed in the table below:
 
@@ -228,6 +249,12 @@ In a more visual form, ABC can be considered to be laterally separated from airc
 
 This can be used to plan restrictions as required when surveillance coverage cannot be assured.
 
+</details>
+</details>
+
+<details markdown="1">
+<summary>Vertical</summary>
+
 ## Vertical
 
 ### 1000ft
@@ -243,3 +270,5 @@ This can be used to plan restrictions as required when surveillance coverage can
 
 ### 3000ft
 - When at least one aircraft is supersonic
+
+</details>

--- a/docs/stylesheets/navigation.css
+++ b/docs/stylesheets/navigation.css
@@ -24,6 +24,11 @@
   color: var(--md-primary-fg-color);
   height: -webkit-fill-available;
 }
+.md-tabs__item--active {
+  border-bottom: 1.5px solid #b5b6b3;
+  color: #344767;
+  height: -webkit-fill-available;
+}
 
 .md-tabs__link:hover {
   border-bottom: 1.5px solid #3447679f;

--- a/docs/terminal/adelaide.md
+++ b/docs/terminal/adelaide.md
@@ -12,7 +12,7 @@
 | Adelaide Approach East†    |AAE| Adelaide Departures  | 118.200         | AD_DEP          |
 | Adelaide Flow†        |AFL|                |          | AD_FMP                              |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}
 
 ## Airspace
 The Vertical limits of the AD TCU are `SFC` to `F245`.

--- a/docs/terminal/brisbane.md
+++ b/docs/terminal/brisbane.md
@@ -15,7 +15,7 @@
 | Gold Coast Approach† |BAC| Brisbane Approach  | 123.500          | BN-C_APP       |
 | Brisbane Flow†        |BFL|                |          | BN_FMP                              |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}
 
 ## Airspace
 The Vertical limits of the BN TCU are `SFC` to `F180`, except in BAC airspace, where it is `SFC` to `A075` in the North West, and `SFC` to `F125` in the South East.

--- a/docs/terminal/cairns.md
+++ b/docs/terminal/cairns.md
@@ -12,7 +12,7 @@
 | Cairns Approach†    |CS2| Cairns Departures  | 126.100         | CS_DEP          |
 | Cairns Flow†        |CSF|                |          | CS_FMP                              |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}
 
 ## Airspace
 The Vertical limits of the CS TCU are `SFC` to `F180`.  

--- a/docs/terminal/canberra.md
+++ b/docs/terminal/canberra.md
@@ -12,7 +12,7 @@
 | Canberra Approach West†   |CBW| Canberra Approach   | 125.900          | CB-W_APP    |
 | Canberra Flow†        |CBF|                |          | CB_FMP                              |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}
 
 ## Airspace
 The Vertical limits of the CB TCU are `SFC` to `F245`.

--- a/docs/terminal/perth.md
+++ b/docs/terminal/perth.md
@@ -10,7 +10,7 @@
 | Perth Departures†  |PHD| Perth Departures  | 118.700 | PH_DEP |
 | Perth Flow† | PFL |   |    | PH_FMP  |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}
 
 ## Airspace
 The PH TCU is responsible for the airspace within 36 DME of the PH VOR, `SFC` to `F245`.  

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -4,6 +4,9 @@
 
 --8<-- "includes/abbreviations.md"
 
+<details markdown="1">
+<summary>Positions</summary>
+
 ## Positions
 
 | Name               | ID      | Callsign       | Frequency        | Login Identifier              |
@@ -17,8 +20,13 @@
 | Sydney Radar†* |SRI| Sydney Centre  | 124.550          | SY-C_DEP                               |
 | Sydney Flow†        |SFL|                |          | SY_FMP                              |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies).  
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}  
 * [Additional requirements](#airspace-structural-arrangements) must be met prior to opening SRI as a stand-alone position.
+
+</details>
+
+<details markdown="1">
+<summary>Airspace</summary>
 
 ## Airspace
 The Vertical limits of the SY TCU are `SFC` to `F285`.  
@@ -28,6 +36,7 @@ SY TCU is responsible for the Sydney TMA, except:
 - R470 Restricted Area, when RIC ADC is online (or as negotiated)  
 
 ### Reclassifications
+
 #### BK CTR
 BK CTR reverts to Class G when **BK ADC** is offline, and is administered by the relevant SY TCU controller.
 
@@ -100,6 +109,10 @@ The divisions of the airspace between **SAN**, **SAS**, **SDS**, **SDN**, **SFW*
 ![SODPROPS TCU Structure](img/sySODPROPS.png){ width="700" }
   <figcaption>SODPROPS TCU Structure</figcaption>
 </figure>
+</details>
+
+<details markdown="1">
+<summary>Arrival Procedures</summary>
 
 ## Arrival Procedures
 ### STAR and Runway Assignment
@@ -147,6 +160,11 @@ All aircraft should be assigned no lower than `A060` until clear of the active r
     For an aircraft inbound from the north on the BOREE3A arrival to runway 34R, assign no lower than `A080` until any adjacent aircraft are maintaing `A060`, then `A070` until the aircraft are laterally clear.  The arrival should then be assigned `A060` until south of the field.
 
 Be mindful of departures from YSBK which may also impact aircraft on downwind for RWY 16R at YSSY.  Do not assign lower than `A040` until the aircraft is north/east of the BK CTR and clear of any departing traffic (who are assigned `A030` by default).
+</details>
+
+<details markdown="1">
+<summary>Parallel Runway Operations</summary>
+
 ## Parallel Runway Operations
 Refer to [Parallel Runway Separation Standards](../../separation-standards/parallelapps) for more information
 
@@ -199,6 +217,10 @@ When conducting IVAs, aircraft shall not be transferred to **SY ADC** until esta
 
 #### Phraseology at Night
 *"CLEARED INDEPENDENT VISUAL APPROACH RUNWAY (number), NOT BELOW (altitude) UNTIL ESTABLISHED ON THE PAPI (or GLIDEPATH)"*
+</details>
+
+<details markdown="1">
+<summary>Sydney Harbour Scenic Flights</summary>
 
 ## Sydney Harbour Scenic Flights
 Flights may be cleared for one of two standard scenic flight routes at `A015`, **Harbour Scenic One** or **Harbour Scenic Two**, which are described below. Pilot preference should be accommodated where traffic permits.
@@ -230,6 +252,10 @@ These can be displayed on vatSys using the `SY_VFR` map.
 
 !!! note
     Remember that VFR aircraft are **not** separated from other VFR aircraft in class C airspace.  If other VFR aircraft are operating over the harbour, you are not required to provide a separation standard between them, however you must pass traffic information to both aircraft.
+</details>
+
+<details markdown="1">
+<summary>Helicopter Operations</summary>
 
 ## Helicopter Operations
 ### Inbound/Outbound Routes
@@ -295,6 +321,10 @@ Helicopters should be identified and then provided the clearance where traffic p
     **HWD:** "Sydney Departures gday, helicopter HWD, passing 800ft on the Harbour Bridge 5 outbound, request South Harbour Sector"  
     **SY TCU:** "HWD, Departures, identified, onwards clearance South Harbour Sector"  
     **HWD:** "Onwards clearance South Harbour Sector, HWD"
+</details>
+
+<details markdown="1">
+<summary>BK ADC Offline</summary>
 
 ## BK ADC Offline
 Due to the low level of CTA (`A015`) in the BK CTR when **BK ADC** is offline, it is best practice to give airways clearance to aircraft at the holding point, to ensure departing aircraft can have uninterrupted climb.
@@ -307,6 +337,52 @@ Due to the low level of CTA (`A015`) in the BK CTR when **BK ADC** is offline, i
     **ABC**: "LOA, ready Runway 11C"  
     **SY TCU**: "LOA, cleared to YSHL via ANKUB, flight planned route, Bankstown 8 Departure, climb via SID A030"  
     **LOA**: "Cleared to YSHL via ANKUB, flight planned route, Bankstown 8 Departure, climb via SID A030, LOA"
+
+</details>
+
+<details markdown="1">
+<summary>Flow</summary>
+
+## Flow
+The tables below give an estimated time **in minutes** from the **Feeder Fix** to the **Threshold**, which can be used to plan sequencing actions within the TCU.
+
+It is based on a few key assumptions:  
+- Nil wind  
+- Aircraft for the *opposite* parallel runway (eg, RIVET > 16L/34R) will overfly the field, then join a mid-field downwind  
+- All aircraft are tracking via the ILS Initial Approach fix
+
+### Jets
+
+| Feeder Fix | 07  | 16L | 16R | 25  | 34L | 34R |
+| ---------- | --- | --- | --- | --- | --- | --- |
+| BOREE      | 16  | 11 | 11 | 15  | 17  | 17  |
+| MEPIL†     | -   | 9  | -   | -   | -   | 15  |
+| MARLN      | 16  | 17  | 20  | 13 | 18  | 14  |
+| RIVET      | 11 | 19  | 17  | 17  | 15  | 19  |
+| ODALE†     | -   | 16  | -   | -   | -   | 17  |
+
+- IAF to Threshold is **4 minutes**  
+- Add **1 minute** for aircraft assigned a reduced speed
+- †MEPIL and ODALE STARs only available to Jets for 16L/34R
+- Subtract **1 minute** for MX or CSR
+
+### Non-Jets
+
+| Feeder Fix | 07  | 16L | 16R | 25  | 34L | 34R |
+| ---------- | --- | --- | --- | --- | --- | --- |
+| MEPIL      | 15  | 10^ | 10^ | 13  | 20  | 19  |
+| MARLN      | 17  | 20  | 22  | 13  | 20  | 19  |
+| ODALE      | 10^ | 19  | 17  | 16  | 16  | 19  |
+
+- IAF to Threshold is **4 minutes** for Runway 07/25. **5 minutes** all other Runways.  
+- Subtract **2 minutes** for **DH8D**, Except ^
+- ^ Subtract **1 minute** for **DH8D**
+- Subtract **1 minute** for MX
+
+</details>
+
+<details markdown="1">
+<summary>Coordination</summary>
 
 ## Coordination
 ### Enroute
@@ -551,3 +627,5 @@ SY TCU will **NOT** clear the aircraft for the approach.
 
 ### RIC ADC
 Reserved.
+
+</details>

--- a/docs/terminal/williamtown.md
+++ b/docs/terminal/williamtown.md
@@ -11,7 +11,7 @@
 | **Williamtown Approach (High)**    | **Willy Approach**   | **133.300**         | **WLM_APP**                                   |
 | Williamtown Approach (Low)†    | Willy Approach   | 135.700         | WLM-L_APP                                   |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies).  
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new} 
 
 ## Airspace
 ### Default

--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -269,3 +269,5 @@
 *[AYPM]: Port Moresby FIR
 *[NWWW]: Noumea FIR
 *[NVVV]: Port Vila FIR
+*[MX]: Maximum Speed
+*[CSR]: Cancel Speed Restrictions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,8 +123,8 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.emoji: # Allows emoji style inline embeds for icons
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - md_in_html #enables the use of image figures
   - abbr
   - pymdownx.snippets
@@ -135,3 +135,6 @@ extra_javascript:
   - javascripts/mathjax.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+
+validation:
+  unrecognized_links: ignore


### PR DESCRIPTION
## Summary
Addition of an Estimated Flow time table to the Sydney TCU page. Also, many other minor changes

## Changes
**Fixes**:
- Links to Policies on various pages now open in new tab
- Fixed outdated link to Pacific Oceanic Agreement in Oceanic Overview page

**Changes**:
- Extendable Sections in various pages to reduce clutter, including:
   - Sydney TCU
   - Airwork / Special Operations
   - vatSys Setup
   - Milk Run Monday
   - Procedural Separation Standards
- Updated MkDocs to latest version

**Additions**:
- Flow Table to Sydney TCU Page
- Abbreviations for MX and CSR