### PR TITLE
Fix failing CI job with old package version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material 
       - run: pip install -r requirements.txt
       - run: mkdocs gh-deploy --force

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs
-mkdocs-material==8.0.5
+mkdocs-material
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
Updated the pip requirements file to remove the pinned version for `mkdocs-material`. This change will resolve the CI error shown below when trying to deploy to GH pages.

![image](https://github.com/vatpac-technology/sops/assets/25076205/b25ade49-6094-4133-a52b-363cf35a6eeb)

An update to `mkdocs-material` caused the namespace for the emoji extension to change, and a mismatch of package versions between development and production environments meant that this was only occurring when building for release.