### PR TITLE
AIRAC 2405

### DIFF
--- a/docs/aerodromes/classc/Sydney.md
+++ b/docs/aerodromes/classc/Sydney.md
@@ -345,16 +345,16 @@ When Coordinator is online, the ATIS shall include `WHEN READY FOR PUSH BACK OR 
 'Next' coordination is **not** required for aircraft that are:   
     a) Departing from a runway nominated on the ATIS; and   
     b) Assigned the Standard assignable level; and  
-    c) Assigned a **Procedural SID** (except **ABBEY** SID during SODPROPS); or  
+    c) Assigned a **Procedural SID** (except **ABBEY** SID); or  
     d) Assigned a [Standard Assignable Heading](#standard-assignable-departure-headings)
 
 All other aircraft require a 'Next' call to SY TCU.
 
-"Next" coordination is additionally required for:  
+'Next' coordination is additionally required for:  
     a) Visual departures  
     b) Departures to YSBK  
     c) After a go around, the next departure from that runway  
-    d) Jets departing 16L via WOL
+    d) Jets departing 16L via WOL  
     e) All aircraft during the Curfew Runway Mode
 
 !!! example

--- a/docs/aerodromes/classd/Hobart.md
+++ b/docs/aerodromes/classd/Hobart.md
@@ -143,13 +143,14 @@ The HBA controller can suspend/resume Auto Release at any time, with the concurr
 !!! Note
     "Next" Coordination to HBA is not required for aircraft assigned a **Procedural SID** and the Standard Assignable Level.
 
-The controller assuming responsibility of **HB ACD** shall give heads-up coordination to HBA controller prior to the issue of the following clearances:  
+**HB SMC** shall give heads-up coordination to HBA controller prior to the issue of the following clearances:  
 a) VFR Departures  
 b) Aircraft using a runway not on the ATIS
 
 The Standard Assignable level from HB ADC to HBA is:  
-For Jets: `A080`  
-For Non-Jets: The lower of `A045` or the `RFL`.
+For IFR Aircraft: `A080`  
+For VFR Aircraft: The lower of `A045` or the `RFL`.
+
 ### Arrivals/Overfliers
 HBA will heads-up coordinate arrivals/overfliers from Class C to HB ADC.  
 IFR aircraft will be cleared for the coordinated approach (Instrument or Visual) prior to handoff to HB ADC, unless HB ADC nominates a restriction.  

--- a/docs/aerodromes/classd/Launceston.md
+++ b/docs/aerodromes/classd/Launceston.md
@@ -72,16 +72,16 @@ All other aircraft require a 'Next' call to LTA.
 
 The LTA controller can suspend/resume Auto Release at any time, with the concurrence of **LT ADC**.
 
-The controller assuming responsibility of **LT ACD** shall give heads-up coordination to LTA controller prior to the issue of the following clearances:  
+LT ADC shall give heads-up coordination to LTA controller prior to the issue of the following clearances:  
 a) VFR Departures  
 b) Aircraft using a runway not on the ATIS  
 
 The Standard Assignable level from LT ADC to LTA is:  
-For Jets: `A080`  
-For Non-Jets: The lower of `A045` or the `RFL`.
+For IFR Aircraft: `A080`  
+For VFR Aircraft: The lower of `A045` or the `RFL`.
 
 ### Arrivals/Overfliers
-LTA will heads-up coordinate arrivals/overfliers from Class C to LT ADC.  
+LTA will heads-up coordinate arrivals/overfliers from LTA CTA to LT ADC.  
 IFR aircraft will be cleared for the coordinated approach (Instrument or Visual) prior to handoff to LT ADC, unless LT ADC nominates a restriction.  
 VFR aircraft require a level readback.
 

--- a/docs/enroute/Brisbane Centre/TRT.md
+++ b/docs/enroute/Brisbane Centre/TRT.md
@@ -11,6 +11,7 @@
 | Kimberley† | Brisbane Centre | 133.400 | BN-KIY_CTR |
 
 † *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies)
+
 ## Airspace
 
 <figure markdown>
@@ -19,6 +20,10 @@
 </figure>
 
 TRT is responsible for **KIY** when they are offline.  
+
+### Reclassifications
+#### BRM CTR
+When **BRM ADC** is offline, BRM CTR (Class D/E `SFC` to `A055`) reverts to Class G, and is administered by KIY. Alternatively, KIY may provide a [top-down procedural service](../../../aerodromes/Karratha) if they wish.
 
 ## Sector Responsibilities
 TRT is responsible for sequencing, issuing STAR Clearances, and issuing descent for aircraft bound for YPDN.  
@@ -85,7 +90,7 @@ Departures from YBRM in to KIY CTA will be coordinated when ready for departure.
 !!! example
     <span class="hotline">**BRM ADC** -> **KIY**</span>: "Next, ANO333"  
     <span class="hotline">**KIY** -> **BRM ADC**</span>: "ANO333, Unrestricted"  
-    <span class="hotline">**BRM ADC** -> **KIY**</span>: "Unrestricted, ANO333"  
+    <span class="hotline">**BRM ADC** -> **KIY**</span>: "ANO333"  
 
 The Standard Assignable level from BRM ADC to TRT(KIY) is the lower of `A050` or the `RFL`, any other level must be prior coordinated.
 
@@ -114,6 +119,9 @@ The Standard Assignable level from CIN TCU to TRT(KIY) is `F190`, and tracking v
 When CIN TCU is offline, coordination is not required between TRT(KIY) and CIN ADC. Aircraft entering CIN ADC airspace shall be handed off, and instructed to contact CIN ADC for onwards clearance.
 
 CIN ADC owns the Class C airspace within the CIN MIL CTR from `SFC` to `A015`.
+
+### TN TCU
+Reserved.
 
 ### IND(INE) (Oceanic)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.

--- a/docs/enroute/Melbourne Centre/ASP.md
+++ b/docs/enroute/Melbourne Centre/ASP.md
@@ -27,7 +27,7 @@
 **AS ADC** is responsible for the Class D airspace `SFC` to `A045`, as well as the Class C airspace `A045` to `A065`, within the AS CTR.
 
 ### Reclassifications
-
+#### AS CTR
 When **AS ADC** is offline, AS CTR (Class D and C `SFC` to `F125`) within 80 DME AS reverts to Class G, and AS CTR (Class C `F125` to `F245`) within 80 DME AS reverts to Class E, and both are administered by ASP. Alternatively, ASP may provide a [top-down procedural service](../../../aerodromes/Alice) if they wish.
 
 ## Extending

--- a/docs/enroute/Melbourne Centre/TBD.md
+++ b/docs/enroute/Melbourne Centre/TBD.md
@@ -52,7 +52,7 @@ Aircraft being transferred from the following sectors shall be given STAR Cleara
 #### Airspace
 The Vertical limits of the AD TCU are `SFC` to `F245`.
 
-Refer to [Adelaide TCU Airspace Division](../../../terminal/adelaide/#airspace-division) for information on airspace divisions when **AAE** is online.
+Refer to [Adelaide TCU Airspace Division](../../../terminal/adelaide/#airspace-division) for information on airspace divisions when **AAW** is online.
 
 #### Arrivals/Overfliers
 Voiceless for all aircraft:

--- a/docs/terminal/adelaide.md
+++ b/docs/terminal/adelaide.md
@@ -8,8 +8,8 @@
 
 | Name               | ID      | Callsign       | Frequency        | Login Identifier              |
 | ------------------ | --------------| -------------- | ---------------- | --------------------------------------|
-| **Adelaide Approach West**    |**AAW**| **Adelaide Approach**   | **124.200**         | **AD_APP**                                   |
-| Adelaide Approach East†    |AAE| Adelaide Departures  | 118.200         | AD_DEP          |
+| **Adelaide Approach East**    |**AAE**| **Adelaide Approach**   | **118.200**         | **AD_APP**                                   |
+| Adelaide Approach West†    |AAW| Adelaide Approach  | 124.200         | AD-W_APP          |
 | Adelaide Flow†        |AFL|                |          | AD_FMP                              |
 
 † *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}
@@ -80,6 +80,58 @@ Due to the low level of CTA at YPPF, it is best practice to give airways clearan
     **ABC**: "Cleared to YPAG via DOLVU, flight planned route, PARAFIELD1 departure, climb via SID to A040, ABC"  
     **AD TCU**: "ABC, assigned heading right 360, report airborne"  
     **ABC**: "Assigned right 360, wilco, ABC"
+
+## Flow
+The tables below give an estimated time **in minutes** from the **Feeder Fix** to the **Threshold**, which can be used to plan sequencing actions within the TCU.
+
+The times assume there is *Nil wind*.
+
+### Jets
+
+| Feeder Fix | 05Z | 05V/W/X | 23A/Z | 23V |
+| ---------- | --- | ------- | ----- | --- |
+| ALEXI      | 14  | 13      | -     | -   |
+| DRINA      | -   | -       | 14    | 13  |
+| BLACK      | 15  | 14      | 12^   | -   |
+| KLAVA      | 15  | 14      | 13    | 12  |
+| ERITH      | -   | -       | 13    | 12  |
+| MARGO      | 13  | 12      | 14    | 12  |
+| RIKAB      | 13  | 12^     | 16    | 14  |
+
+- **GULLY** - Threshold is **5 minutes**  
+- **PADSI** - Threshold is **3.5 minutes**  
+- Add **1 minute** for aircraft assigned a reduced speed, Except ^  
+- Subtract **1 minute** for MX or CSR
+- For **Non-Jets** (except **DH8D**) tracking via Jet STAR;
+    - Add **2 minutes** (Except ^)
+    - Add only **1 minute** for ^
+
+### Non-Jets
+
+This table assumes that aircraft will be assigned:
+
+- The appropriate *Non-Jet STAR* (**ATPIP**, **ELROX**, **GULFS**, **PAMMY**, **RUSSL**, **SURGN**), or if none is available:
+- *No STAR*
+
+Thence track via a **5nm final** for the assigned runway.
+
+For Non-Jets tracking via the *full Jet STARs*, see [table above](#jets)
+
+| Feeder Fix | 05  | 12  | 23  | 30  |
+| ---------- | --- | --- | --- | --- |
+| ALEXI      | 11  | 13  | 11  | 10  |
+| DRINA      | 13  | 15  | 13  | 12  |
+| BLACK      | 15  | 14  | 12  | 12  |
+| RUSSL      | 16  | 14  | 13  | 14  |
+| KLAVA      | 14  | 12  | 12  | 15  |
+| ERITH      | -   | -   | -   | -   |
+| MARGO      | 12  | 11  | 12  | 14  |
+| RIKAB      | 12  | 12  | 14  | 15  |
+| ELROX      | 10  | 11  | 13  | 12  |
+
+- **5nm final** - Threshold is **2 minutes**  
+- Subtract **1 minute** for MX  
+- Subtract **1 minute** for **DH8D**
 
 ## Coordination
 ### Enroute

--- a/docs/terminal/adelaide.md
+++ b/docs/terminal/adelaide.md
@@ -92,11 +92,11 @@ The times assume there is *Nil wind*.
 | ---------- | --- | ------- | ----- | --- |
 | ALEXI      | 14  | 13      | -     | -   |
 | DRINA      | -   | -       | 14    | 13  |
-| BLACK      | 15  | 14      | 12^   | -   |
-| KLAVA      | 15  | 14      | 13    | 12  |
+| BLACK      | 16  | 15      | 12^   | -   |
+| KLAVA      | 16  | 15      | 13    | 12  |
 | ERITH      | -   | -       | 13    | 12  |
-| MARGO      | 13  | 12      | 14    | 12  |
-| RIKAB      | 13  | 12^     | 16    | 14  |
+| MARGO      | 14  | 13      | 15    | 13  |
+| RIKAB      | 13  | 12^     | 17    | 15  |
 
 - **GULLY** - Threshold is **5 minutes**  
 - **PADSI** - Threshold is **3.5 minutes**  
@@ -119,15 +119,15 @@ For Non-Jets tracking via the *full Jet STARs*, see [table above](#jets)
 
 | Feeder Fix | 05  | 12  | 23  | 30  |
 | ---------- | --- | --- | --- | --- |
-| ALEXI      | 11  | 13  | 11  | 10  |
-| DRINA      | 13  | 15  | 13  | 12  |
-| BLACK      | 15  | 14  | 12  | 12  |
-| RUSSL      | 16  | 14  | 13  | 14  |
-| KLAVA      | 14  | 12  | 12  | 15  |
+| ALEXI      | 12  | 14  | 12  | 11  |
+| DRINA      | 14  | 17  | 14  | 13  |
+| BLACK      | 16  | 15  | 13  | 13  |
+| RUSSL      | 17  | 15  | 14  | 13  |
+| KLAVA      | 15  | 13  | 13  | 16  |
 | ERITH      | -   | -   | -   | -   |
-| MARGO      | 12  | 11  | 12  | 14  |
-| RIKAB      | 12  | 12  | 14  | 15  |
-| ELROX      | 10  | 11  | 13  | 12  |
+| MARGO      | 13  | 12  | 13  | 15  |
+| RIKAB      | 13  | 13  | 15  | 16  |
+| ELROX      | 11  | 11  | 14  | 13  |
 
 - **5nm final** - Threshold is **2 minutes**  
 - Subtract **1 minute** for MX  

--- a/docs/terminal/cairns.md
+++ b/docs/terminal/cairns.md
@@ -9,7 +9,7 @@
 | Name               | ID      | Callsign       | Frequency        | Login Identifier              |
 | ------------------ | --------------| -------------- | ---------------- | --------------------------------------|
 | **Cairns Approach**    |**CS1**| **Cairns Approach**   | **118.400**         | **CS_APP**          |
-| Cairns Approach†    |CS2| Cairns Departures  | 126.100         | CS_DEP          |
+| Cairns Approach†    |CS2| Cairns Approach  | 126.100         | CS-W_APP          |
 | Cairns Flow†        |CSF|                |          | CS_FMP                              |
 
 † *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -559,13 +559,20 @@ Auto Release is used for virtually all fixed-wing departures at Sydney. Unlike s
 !!! tip
     If strong winds are present at altitude, TWR/DEP should discuss slight changes to these headings (+/- 5 degrees) to compensate for large crosswind components.
 
-Auto Release shall also be used from SY ADC for aircraft that are:     
-- Departing from a runway nominated on the ATIS; and  
-- Assigned the standard assignable level; and  
-- Assigned a Procedural SID; or  
-- Assigned a Radar SID with a Standard Assignable Heading
+'Next' coordination is **not** required for aircraft that are:   
+    a) Departing from a runway nominated on the ATIS; and   
+    b) Assigned the Standard assignable level; and  
+    c) Assigned a **Procedural SID** (except **ABBEY** SID); or  
+    d) Assigned a Standard Assignable Heading
 
-Any aircraft that don't meet these criteria must be coordinated by SY ADC with a "Next" Call.
+All other aircraft require a 'Next' call from SY ADC.
+
+'Next' coordination is additionally required for:  
+    a) Visual departures  
+    b) Departures to YSBK  
+    c) After a go around, the next departure from that runway  
+    d) Jets departing 16L via WOL  
+    e) All aircraft during the Curfew Runway Mode
 
 !!! example
     <span class="hotline">**SY ADC** -> **SY TCU**</span>: "Next, ADA4, runway 34R"  

--- a/docs/terminal/tassie.md
+++ b/docs/terminal/tassie.md
@@ -87,8 +87,8 @@ HB ADC owns the Class D airspace in the HB CTR `SFC` to `A015` north of the runw
   c) Assigned a **Procedural** SID
 
 The Standard Assignable level from HB ADC to HBA is:  
-For Jets: `A080`  
-For Non-Jets: The lower of `A045` or the `RFL`.
+For IFR Aircraft: `A080`  
+For VFR Aircraft: The lower of `A045` or the `RFL`.
 
 #### Arrivals
 HBA will coordinate all YMHB arrivals to HB ADC prior to **5 mins** from the boundary. This coordination shall be as per [Standard Heads-up format](../../controller-skills/coordination/#heads-up), with the addition of:
@@ -112,8 +112,8 @@ LT ADC owns the Class D airspace in the LT CTR `SFC` to `A015`. LTA owns the Cla
   c) Assigned a **Procedural** SID
 
 The Standard Assignable level from LT ADC to LTA is:  
-For Jets: `A080`  
-For Non-Jets: The lower of `A045` or the `RFL`.
+For IFR Aircraft: `A080`  
+For VFR Aircraft: The lower of `A045` or the `RFL`.
 
 #### Arrivals
 LTA will coordinate all YMLT arrivals to LT ADC prior to **5 mins** from the boundary. This coordination shall be as per [Standard Heads-up format](../../controller-skills/coordination/#heads-up), with the addition of:


### PR DESCRIPTION
## Summary
Changes to AD and CS TCU positions, addition of YPAD Flow times, and more

## Changes
**Fixes**:
- Fixed formatting and missing duplicated *Auto-Release* instructions between **SY ADC** and **SY TCU**
- Clarified that *Auto-Release* is **not available** for any *Jets departing 16L via WOL*
- Removed references to **HB and LT ACD** (Position does not exist) 
- Fixed missing **AS CTR** heading in *Reclassification* section of **ASP** page

**Changes**:
- *Standard Assignable level* from **HB and LT ADC** to **LTA/HBA** now changes based on *Flight Rules*, rather than *Jet/Non-Jet*
- *AAE* now Primary position in **AD TCU**, login identifier is now *AD_APP*, Callsign is now *"Adelaide Approach"*
- *AAW* login identifier now *AD-W_APP*
- *CS2* login identifier now *CS-W_APP*, Callsign is now *"Cairns Approach"*

**Additions**:
- **YPAD Flow Data** to **AD TCU** page
- *Reclassification* Section to **TRT** page
- Reserved *TN TCU* Coordination Section to **TRT** page
