### PR TITLE
Added the correct ATIS abbreviation for 'instrument' at Sydney YSSY

### DIFF
--- a/docs/aerodromes/classc/Sydney.md
+++ b/docs/aerodromes/classc/Sydney.md
@@ -280,8 +280,8 @@ Climb Gradient Requirements apply to all Procedural SIDs. It is the pilot's resp
 | Cloud Base             | Visibility     | Approach                             |
 | -----------------------| -------------- | -------------------------------------|
 | >3000FT                | >5000M         | `EXP INDEP VISUAL APCH` |
-| Between 2000FT & 3000FT| >5000M         | `EXP INST APCH THEN INDEP VISUAL APCH WHEN VISUAL`|
-| Below 2000FT **or**    | <5000M         | `EXP INST APCH`                |
+| Between 2000FT & 3000FT| >5000M         | `EXP INSTR APCH THEN INDEP VISUAL APCH WHEN VISUAL`|
+| Below 2000FT **or**    | <5000M         | `EXP INSTR APCH`                |
 
 When Independent Visual Approaches are run during PROPS, the APCH field must also include:  
 `DO NOT PASS THRU ASSIGNED RWY CL`


### PR DESCRIPTION
## Summary
Sydney YSSY is not an INTAS-equipped aerodrome and as such does not abbreviate 'instrument' to 'INST' in the ATIS (like Melbourne or Brisbane), rather instrument becomes 'INSTR'. This fix ensures correct information regarding the Sydney ATIS is reflected in the SOPs.

## Changes
**Fixes**:
- Replaced 'INST' abbreviations with 'INSTR' for the Sydney (YSSY) ATIS section.