### PR TITLE
Wake Turbulence Separation Standards

### DIFF
--- a/docs/separation-standards/runway.md
+++ b/docs/separation-standards/runway.md
@@ -76,13 +76,4 @@ title: Runway
 - Landing aircraft may not cross the runway threshold until a preceding departing or landing aircraft on an intersecting runway has either crossed the intersection or stopped short
 
 ## Wake Turbulence
-
-| Lead Aircraft | Following Aircraft | Time (min) | Distance (nm)|
-| ------------- | ------------------ | ---------- | ---------- |
-| Super (A388/A225) | Heavy | 2 | 6 |
-|  | Medium | 3 | 7 |
-|  | Light | 3 | 8 |
-| Heavy | Heavy | - | 4 |
-|  | Medium | 2 | 5 |
-|  | Light | 2 | 6 |
-| Medium | Light | 2 | 5 |
+Refer to [Wake Turbulence Separation Standards](../waketurb)

--- a/docs/separation-standards/surveillance.md
+++ b/docs/separation-standards/surveillance.md
@@ -39,17 +39,4 @@ title: Surveillance
 - When at least one aircraft is supersonic
 
 ## Wake Turbulence
-
-| Lead Aircraft | Following Aircraft | Distance (NM) |
-| ------------- | ------------------ | ------------- |
-| Super (A380) | Super | - | 
-|  | Heavy | 6* |
-|  | Medium | 7* |
-|  | Light | 8* |
-| Heavy | Heavy | 4 |
-|  | Medium | 5 |
-|  | Light | 6* |
-| Medium | Heavy | - |
-|  | Medium | - |
-|  | Light | 5 |
-|  |  | * = Relevant to Enroute |
+Refer to [Wake Turbulence Separation Standards](../waketurb)

--- a/docs/separation-standards/visual.md
+++ b/docs/separation-standards/visual.md
@@ -5,7 +5,8 @@ title: Visual
 --8<-- "includes/abbreviations.md"
 
 ## ATC Responsibility
-ADC controllers can conduct "pseudo-visual" separation between aircraft under the following conditions:  
+ADC controllers can conduct "pseudo-visual" separation between aircraft under the following conditions:
+
 - ADC controllers only  
 - Projected flight paths do not conflict  
 - Within 5nm of AD  
@@ -14,10 +15,16 @@ ADC controllers can conduct "pseudo-visual" separation between aircraft under th
 
 This separation technique can be supplemented with Tower View linked to a flight simulator. More info on that can be found [here](https://forums.vatsim.net/topic/29161-tips-and-tricks/){target=new}
 
-This technique is useful for situations such as:<ul><li>Procedural towers processing aircraft at altitudes below usable surveillance</li><li>Making more efficient use of runways at major aerodromes by allowing departures to roll with aircraft on final</li><li>Processing VFR aircraft arriving or departing during a busy established sequence (e.g. helicopter operations at Sydney)</li></ul><li>To assist the TCU controller in separating aircraft close to the airfield</li>
+This technique is useful for situations such as:
+
+- Procedural towers processing aircraft at altitudes below usable surveillance
+- Making more efficient use of runways at major aerodromes by allowing departures to roll with aircraft on final
+- Processing VFR aircraft arriving or departing during a busy established sequence (e.g. helicopter operations at Sydney)
+- To assist the TCU controller in separating aircraft close to the airfield
 
 ## Pilot Responsibility
-Pilots can be given responsibility to maintain own separation with other aircraft provided:  
+Pilots can be given responsibility to maintain own separation with other aircraft provided:
+
 - Both aircraft are operated at or below `A100`; and  
 - One pilot reports the other aircraft in sight; and  
 - That pilot accepts responsibility for maintaining own separation with that aircraft
@@ -26,7 +33,11 @@ Pilots will continue to follow ATC instructions but the controller will no longe
 
 Where an aircraft is instructed to maintain own separation with an IFR aircraft, traffic information should be passed to the IFR aircraft, including advice of assignment of separation responsibility to the other aircraft. 
 
-This technique is useful for situations such as:<ul><li>VFR aircraft manoeuvring behind another aircraft on approach to land (e.g. helicopter operations at Sydney)</li><li>Allowing aircraft to conduct airwork in a position which would normally conflict with other aircraft</li><li>Providing track shortening or expedited clearances where a delay would normally occur due to other aircraft</li></ul>
+This technique is useful for situations such as:
+
+- VFR aircraft manoeuvring behind another aircraft on approach to land (e.g. helicopter operations at Sydney)
+- Allowing aircraft to conduct airwork in a position which would normally conflict with other aircraft
+- Providing track shortening or expedited clearances where a delay would normally occur due to other aircraft
 
 !!! example
     *RSCU203 is a VFR helicopter who wishes to depart from Royal Prince Alfred Hospital, which sits directly under the YSSY RWY 16L approach path.*  

--- a/docs/separation-standards/waketurb.md
+++ b/docs/separation-standards/waketurb.md
@@ -1,0 +1,92 @@
+---
+title: Wake Turbulence
+---
+
+--8<-- "includes/abbreviations.md"
+
+## Categories
+
+| Category | MTOW |
+| ------------- | ------------------ |
+| Super **(J)** | **A388** and **A225** |
+| Heavy **(H)** | **136,000kg** or Greater *(Excluding A388 and A225)* |
+| Medium **(M)** | Between **7,000kg** and **136,000kg** |
+| Light **(L)** | **7,000kg** or Less |
+
+## Exceptions
+Wake Turbulence Separation is **not required**:
+
+- When the following aircraft has the same or heavier wake turbulence category as the preceding aircraft;
+    - Except **Heavy** following **Heavy**
+- Between an aircraft landing behind an aircraft taking-off on the same runway;
+- For airborne VFR aircraft (**Runway** Wake Turbulence still applies);
+- For aircraft that have accepted responsibility for visual separation with another aircraft; or
+- For a helicopter conducting an air taxi
+
+## Runways
+### Departures
+#### Full length or Crossing Runway Operations
+Apply to departing aircraft when:
+
+- Both aircraft are using the same runway for take-off; or
+- An aircraft is taking off behind a preceding departing or arriving
+aircraft on a crossing runway
+
+| Lead Aircraft | Following Aircraft | Time (min) | Distance (nm)|
+| ------------- | ------------------ | ---------- | ---------- |
+| Super (A388/A225) | Heavy | 2 | 6 |
+|  | Medium | 3 | 7 |
+|  | Light | 3 | 8 |
+| Heavy | Heavy | - | 4 |
+|  | Medium | 2 | 5 |
+|  | Light | 2 | 6 |
+| Medium | Light | 2 | 5 |
+
+#### Intermediate Departures
+Apply to departing aircraft from a non-full-length intersection when:
+
+- The following aircraft will depart; or
+- The following aircraft will conduct a touch-and-go
+
+| Lead Aircraft | Following Aircraft | Time (min) |
+| ------------- | ------------------ | ---------- |
+| Super (A388/A225) | Heavy | 4 |
+|  | Medium | 4 |
+|  | Light | 4 |
+| Heavy | Medium | 3 |
+|  | Light | 3 |
+| Medium | Light | 3 |
+
+### Arrivals
+#### Full length or Crossing Runway Operations
+Apply to arriving aircraft when:
+
+- Both aircraft are using the same runway for landing; or
+- An aircraft will fly/land through the approach/landing path of an aircraft on a crossing runway
+
+| Lead Aircraft | Following Aircraft | Time (min) | Distance (nm)|
+| ------------- | ------------------ | ---------- | ---------- |
+| Super (A388/A225) | Heavy | 3 | 6 |
+|  | Medium | 3 | 7 |
+|  | Light | 4 | 8 |
+| Heavy | Heavy | - | 4 |
+|  | Medium | 2 | 5 |
+|  | Light | 3 | 6 |
+| Medium | Light | 3 | 5 |
+
+## Airspace
+Apply to aircraft operating **directly behind** and within **760m laterally** of another aircraft
+
+| Lead Aircraft | Following Aircraft | Distance (NM) |
+| ------------- | ------------------ | ------------- |
+| Super (A380) | Super | - | 
+|  | Heavy | 6* |
+|  | Medium | 7* |
+|  | Light | 8* |
+| Heavy | Heavy | 4 |
+|  | Medium | 5 |
+|  | Light | 6* |
+| Medium | Heavy | - |
+|  | Medium | - |
+|  | Light | 5 |
+|  |  | * = Relevant to Enroute |

--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -56,6 +56,7 @@
 *[SIS]: Surveillance Information Service (Flight Following)
 *[ARP]: Aerodrome Reference Point
 *[SVFR]: Special VFR
+*[MTOW]: Maximum Takeoff Weight
 *[AAW]: Adelaide Approach West
 *[AAE]: Adelaide Approach East
 *[BAC]: Brisbane (Gold Coast) Approach


### PR DESCRIPTION
## Summary
Introduction of more detailed Wake Turbulence Separation Standards

## Changes
**Additions**:
- **MTOW** Abbreviation
- Consolidated Wake Turbulence info from _Runway_ and _Surveillance_ pages in to a new **Wake Turbulence** page, with the addition of standards for:
    - Airspace
    - Arrivals
    - Departures
    - Crossing Runways
    - Exceptions