### PR TITLE
Adjust YBSU Standard Assignable Level

### DIFF
--- a/docs/aerodromes/procedural/Sunshinecoast.md
+++ b/docs/aerodromes/procedural/Sunshinecoast.md
@@ -40,7 +40,7 @@ A 'next' call is made for all aircraft when they are next to depart. SU ADC must
     <span class="hotline">**NSA** -> **SU ADC**</span>: "BNZ133, Unrestricted"  
     <span class="hotline">**SU ADC** -> **NSA**</span>: "BNZ133"
 
-The Standard Assignable level from SU ADC to INL(NSA/BUR) is the lower of `A050` or the `RFL`, any other level must be prior coordinated.
+The Standard Assignable level from SU ADC to INL(NSA/BUR) is the lower of `A040` or the `RFL`, any other level must be prior coordinated.
 
 ### Arrivals/Overfliers
 NSA will heads-up coordinate arrivals/overfliers from Class C to SU ADC. Aircraft will be cleared for the coordinated approach prior to handoff to SU ADC, unless SU ADC nominates a restriction.

--- a/docs/aerodromes/procedural/Sunshinecoast.md
+++ b/docs/aerodromes/procedural/Sunshinecoast.md
@@ -36,11 +36,16 @@ All other aircraft may be assigned a visual departure, or a standard IFR departu
 A 'next' call is made for all aircraft when they are next to depart. SU ADC must inform INL(NSA/BUR) if the aircraft does not depart within **2 minutes** of the next call.
 
 !!! example
-    <span class="hotline">**SU ADC** -> **NSA**</span>: "Next, BNZ133"  
-    <span class="hotline">**NSA** -> **SU ADC**</span>: "BNZ133, Unrestricted"  
+    <span class="hotline">**SU ADC** -> **NSA**</span>: "Next, BNZ133, runway 31"  
+    <span class="hotline">**NSA** -> **SU ADC**</span>: "BNZ133, unrestricted"  
     <span class="hotline">**SU ADC** -> **NSA**</span>: "BNZ133"
 
 The Standard Assignable level from SU ADC to INL(NSA/BUR) is the lower of `A040` or the `RFL`, any other level must be prior coordinated.
+
+Where operationally possible, INL(NSA/BUR) will assign a higher level to high performance aircraft during next coordination. This level assignment should be communicated to the aircraft during the takeoff clearance or when they provide a departure report after takeoff.
+
+!!! example
+    **SU ADC**: "VOZ924, climb to FL120, runway 31, cleared for takeoff"
 
 ### Arrivals/Overfliers
 NSA will heads-up coordinate arrivals/overfliers from Class C to SU ADC. Aircraft will be cleared for the coordinated approach prior to handoff to SU ADC, unless SU ADC nominates a restriction.

--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -25,7 +25,7 @@ The Primary Communication Method for ARL is Voice.
 The CPDLC Station Code is `YARL`.
 
 !!! tip
-        Even though ARL's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though ARL's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 

--- a/docs/enroute/Brisbane Centre/INL.md
+++ b/docs/enroute/Brisbane Centre/INL.md
@@ -26,7 +26,7 @@ The Primary Communication Method for INL is Voice.
 The CPDLC Station Code is `YINL`.
 
 !!! tip
-        Even though INL's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though INL's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 
 ## Airspace

--- a/docs/enroute/Brisbane Centre/INL.md
+++ b/docs/enroute/Brisbane Centre/INL.md
@@ -185,11 +185,18 @@ Refer to [Reclassifications](#su-ctr) for operations when SU ADC is offline.
 Departures from YBSU in to NSA Class C will be coordinated when ready for departure.
 
 !!! example
-    <span class="hotline">**SU ADC** -> **NSA**</span>: "Next, BNZ123"  
-    <span class="hotline">**NSA** -> **SU ADC**</span>: "BNZ123, Unrestricted"  
+    <span class="hotline">**SU ADC** -> **NSA**</span>: "Next, BNZ123, runway 31"  
+    <span class="hotline">**NSA** -> **SU ADC**</span>: "BNZ123, unrestricted"  
     <span class="hotline">**SU ADC** -> **NSA**</span>: "BNZ123"
 
-The Standard Assignable level from **SU ADC** to NSA is the lower of `A040` or the `RFL`.
+The Standard Assignable level from **SU ADC** to INL(NSA/BUR) is the lower of `A040` or the `RFL`.
+
+Where possible (and no possible conflict exists), a higher level shall be assigned by INL(NSA/BUR) for high performance aircraft during next coordination.
+
+!!! example
+    <span class="hotline">**SU ADC** -> **NSA**</span>: "Next, VOZ924, runway 31"  
+    <span class="hotline">**NSA** -> **SU ADC**</span>: "VOZ924, F120"  
+    <span class="hotline">**SU ADC** -> **NSA**</span>: "F120, VOZ924"
 
 #### Arrivals
 NSA must ensure all YBSU arrivals have been assigned a STAR, unless the pilot is unable to accept one.  

--- a/docs/enroute/Brisbane Centre/INL.md
+++ b/docs/enroute/Brisbane Centre/INL.md
@@ -189,7 +189,7 @@ Departures from YBSU in to NSA Class C will be coordinated when ready for depart
     <span class="hotline">**NSA** -> **SU ADC**</span>: "BNZ123, Unrestricted"  
     <span class="hotline">**SU ADC** -> **NSA**</span>: "BNZ123"
 
-The Standard Assignable level from **SU ADC** to NSA is the lower of `A050` or the `RFL`.
+The Standard Assignable level from **SU ADC** to NSA is the lower of `A040` or the `RFL`.
 
 #### Arrivals
 NSA must ensure all YBSU arrivals have been assigned a STAR, unless the pilot is unable to accept one.  

--- a/docs/enroute/Brisbane Centre/KEN.md
+++ b/docs/enroute/Brisbane Centre/KEN.md
@@ -24,7 +24,7 @@ The Primary Communication Method for KEN is Voice.
 The CPDLC Station Code is `YKEN`.
 
 !!! tip
-        Even though KEN's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though KEN's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 

--- a/docs/enroute/Melbourne Centre/ELW.md
+++ b/docs/enroute/Melbourne Centre/ELW.md
@@ -22,7 +22,7 @@ The Primary Communication Method for ELW is Voice.
 The CPDLC Station Code is `YELW`.
 
 !!! tip
-        Even though ELW's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though ELW's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 

--- a/docs/enroute/Melbourne Centre/HUO.md
+++ b/docs/enroute/Melbourne Centre/HUO.md
@@ -18,7 +18,7 @@ The Primary Communication Method for HUO is Voice.
 The CPDLC Station Code is `YHUO`.
 
 !!! tip
-        Even though HUO's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though HUO's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 

--- a/docs/enroute/Melbourne Centre/PIY.md
+++ b/docs/enroute/Melbourne Centre/PIY.md
@@ -26,7 +26,7 @@ The Primary Communication Method for ELW is Voice.
 The CPDLC Station Code is `YPIY`.
 
 !!! tip
-        Even though PIY's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though PIY's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 <figure markdown>

--- a/docs/enroute/Melbourne Centre/TBD.md
+++ b/docs/enroute/Melbourne Centre/TBD.md
@@ -21,7 +21,7 @@ The Primary Communication Method for TBD is Voice.
 The CPDLC Station Code is `YTBD`.
 
 !!! tip
-        Even though TBD's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though TBD's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 

--- a/docs/enroute/Melbourne Centre/YWE.md
+++ b/docs/enroute/Melbourne Centre/YWE.md
@@ -25,7 +25,7 @@ The Primary Communication Method for YWE is Voice.
 The CPDLC Station Code is `YYWE`.
 
 !!! tip
-        Even though YWE's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though YWE's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -20,7 +20,7 @@
 | Sydney Radar†* |SRI| Sydney Centre  | 124.550          | SY-C_DEP                               |
 | Sydney Flow†        |SFL|                |          | SY_FMP                              |
 
-† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}
+† *Non-standard positions* may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}  
 * [Additional requirements](#airspace-structural-arrangements) must be met prior to opening SRI as a stand-alone position.
 
 </details>


### PR DESCRIPTION
## Summary
Changes the standard assignable level from Sunshine Coast Tower to the surrounding Brisbane Centre sectors from `A050` to `A040`, in line with real world procedures. Small formatting changes in SY TCU page & in enroute pages. 

## Changes
**Fixes**:
- Formatting in SY TCU Positions section
- Formatting in all enroute pages which reference the use of CPDLC

**Changes**:
- YBSU SAL from `A050` to `A040`
