### PR TITLE
Add ATIS Zulu messages

### DIFF
--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -25,7 +25,7 @@ The Primary Communication Method for ARL is Voice.
 The CPDLC Station Code is `YARL`.
 
 !!! tip
-        Even though ARL's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though ARL's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 
@@ -38,11 +38,17 @@ The CPDLC Station Code is `YARL`.
 #### TW CTR
 When **TW ADC** is offline, TW CTR (Class D and C `SFC` to `A085`) reverts to Class G, and is administered by ARL and MDE. Alternatively, ARL (not MDE) may provide a [top-down procedural service](../../../aerodromes/tamworth) if they wish (not recommended).  
 
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+
 #### CFS CTR
 When **CFS ADC** is offline, CFS CTR (Class D `SFC` to `A045`) reverts to Class G, and is administered by MNN and INL. MNN is **not permitted** to provide a [top-down procedural service](../../../aerodromes/Coffs), only INL can do this, and they must coordinate with MNN if they are doing so.
 
 #### WLM CTR
 When **WLM TCU** is offline, WLM MIL CTR (Class C `SFC` to `A065`) reverts to Class G, and WLM MIL CTR (Class C `A065` to `F125`) reverts to Class E. This airspace is administered by the appropriate ARL subsector. Alternatively, ARL(MLD) may provide a [top-down service](../../../military/williamtown) if they wish.  
+
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
 
 ## Sector Responsibilities
 ### Armidale (ARL) / Manning (MNN)

--- a/docs/enroute/Brisbane Centre/INL.md
+++ b/docs/enroute/Brisbane Centre/INL.md
@@ -26,7 +26,7 @@ The Primary Communication Method for INL is Voice.
 The CPDLC Station Code is `YINL`.
 
 !!! tip
-        Even though INL's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though INL's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 
 ## Airspace
@@ -44,13 +44,22 @@ INL is responsible for **DOS**, **GOL**, **SDY**, **BUR**, **NSA**, and **KPL** 
 #### SU CTR
 When **SU ADC** is offline, SU CTR (Class D `SFC` to `A045`) reverts to Class G, and is administered by NSA and BUR. Alternatively, NSA may provide a [top-down procedural service](../../../aerodromes/sunshinecoast) if they wish (not recommended), and this must be coordinated to BUR.
 
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+
 #### CFS CTR
 When **CFS ADC** is offline, CFS CTR (Class D `SFC` to `A045`) reverts to Class G, and is administered by MNN and INL. Alternatively, INL may provide a [top-down procedural service](../../../aerodromes/Coffs) if they wish (not recommended), and this must be coordinated to ARL(MNN).
 
 Due to the low ceiling of CTA, when CFS ADC is offline, INL shall instruct aircraft departing into CTA to report lined up on the runway and issue an airways clearance (traffic pending) at that time.
 
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+
 #### RK CTR
 Whilst the **RKA** controller is expected to provide a [top-down service](../../../aerodromes/Rockhampton) to YBRK when **RK ADC** is offline, this is not expected of a KPL controller when both **RKA** and **RK ADC** are offline. If electing not to provide a top-down service to YBRK, the RK CTR Class D is reclassified to Class G `SFC` to `A007`, and Class E `A007` to `A045`.
+
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
 
 ## Sector Responsibilities
 

--- a/docs/enroute/Brisbane Centre/KEN.md
+++ b/docs/enroute/Brisbane Centre/KEN.md
@@ -24,7 +24,7 @@ The Primary Communication Method for KEN is Voice.
 The CPDLC Station Code is `YKEN`.
 
 !!! tip
-        Even though KEN's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though KEN's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 
@@ -41,11 +41,20 @@ BAR is responsible for the [CS TCU](../../../terminal/cairns) when **CS TCU** is
 #### TL CTR
 When **TL TCU** is offline, TL CTR (Class C `SFC` to `A085`) reverts to Class G, and is administered by TBP. Alternatively, TBP may provide a [top-down approach service](../../../military/townsville) if they wish.
 
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+
 #### HM CTR
 When **HM ADC** is offline, HM CTR (Class D `SFC` to `A045`) reverts to Class G, and is administered by SWY. Alternatively, SWY may provide a [top-down procedural service](../../../aerodromes/Hammo) if they wish (not recommended).  
 
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+
 #### MK CTR
 Whilst the **MKA** controller is expected to provide a [top-down service](../../../aerodromes/Mackay) to YBMK when **MK ADC** is offline, this is not expected of a SWY controller when both **MKA** and **MK ADC** are offline. If electing not to provide a top-down service to YBMK, the RK CTR Class D is reclassified to Class G `SFC` to `A007`, and Class E `A007` to `A045`.
+
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
 
 ## Sector Responsibilities
 All Subsectors are responsible for issuing STAR Clearances for YBMK, YBTL and YBCS on first contact.

--- a/docs/enroute/Brisbane Centre/TRT.md
+++ b/docs/enroute/Brisbane Centre/TRT.md
@@ -33,6 +33,9 @@ TRT is responsible for **KIY** when they are offline.
 #### BRM CTR
 When **BRM ADC** is offline, BRM CTR (Class D/E `SFC` to `A055`) reverts to Class G, and is administered by KIY. Alternatively, KIY may provide a [top-down procedural service](../../../aerodromes/Broome) if they wish.
 
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+
 ## Sector Responsibilities
 TRT is responsible for sequencing, issuing STAR Clearances, and issuing descent for aircraft bound for YPDN.  
 KIY is responsible for issuing descent and ascertaining arrival intentions for aircraft bound for YBRM.

--- a/docs/enroute/Melbourne Centre/ASP.md
+++ b/docs/enroute/Melbourne Centre/ASP.md
@@ -36,7 +36,10 @@ Voice may be used in lieu when applicable.
 
 ### Reclassifications
 #### AS CTR
-When **AS ADC** is offline, AS CTR (Class D and C `SFC` to `F125`) within 80 DME AS reverts to Class G, and AS CTR (Class C `F125` to `F245`) within 80 DME AS reverts to Class E, and both are administered by ASP. Alternatively, ASP may provide a [top-down procedural service](../../../aerodromes/Alice) if they wish.
+When **AS ADC** is offline, AS CTR (Class D and C `SFC` to `F125`) within 80 DME AS reverts to Class G, and AS CTA (Class C `F125` to `F245`) within 80 DME AS reverts to Class E, and both are administered by ASP. Alternatively, ASP may provide a [top-down procedural service](../../../aerodromes/Alice) if they wish.
+
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
 
 ## Extending
 !!! Warning

--- a/docs/enroute/Melbourne Centre/ELW.md
+++ b/docs/enroute/Melbourne Centre/ELW.md
@@ -22,7 +22,7 @@ The Primary Communication Method for ELW is Voice.
 The CPDLC Station Code is `YELW`.
 
 !!! tip
-        Even though ELW's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though ELW's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 
@@ -35,8 +35,14 @@ The CPDLC Station Code is `YELW`.
 #### CB CTR
 When **CB TCU** is offline, CB TCU (Class C `SFC` to `A085`) reverts to Class G, and is administered by BLA. Alternatively, BLA may provide a [top-down approach service](../../../terminal/canberra) if they wish.
 
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+
 #### AY CTR
 When **AY ADC** is offline, AY CTR (Class D and C `SFC` to `A085`) reverts to Class G, and is administered by BLA. Alternatively, BLA may provide a [top-down procedural service](../../../aerodromes/Albury) if they wish.
+
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
 
 ## Sector Responsibilities
 ### Eildon Weir (ELW)

--- a/docs/enroute/Melbourne Centre/HUO.md
+++ b/docs/enroute/Melbourne Centre/HUO.md
@@ -18,7 +18,7 @@ The Primary Communication Method for HUO is Voice.
 The CPDLC Station Code is `YHUO`.
 
 !!! tip
-        Even though HUO's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though HUO's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 
@@ -37,6 +37,9 @@ If HUO chooses to operate top down to either aerodrome, they must administer all
 
 !!! important
     Ensure you are familiar with the aerodrome procedures for [Launceston](../../../aerodromes/Launceston) and [Hobart](../../../aerodromes/Hobart) before extending top down, and are aware of the limited surveillence coverage available in the lower levels of the TMA.
+
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for each aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
 
 ## Responsibilities
 HUO is reponsible for issuing STAR clearances, sequencing, and descent for aircraft bound for YMLT and YMHB.

--- a/docs/enroute/Melbourne Centre/OLW.md
+++ b/docs/enroute/Melbourne Centre/OLW.md
@@ -38,6 +38,9 @@ OLW is responsible for **POT**, **PAR**, **NEW**, **MEK**, **MTK** and **MZI** w
 #### KA CTR
 When **KA ADC** is offline, KA CTR (Class D `SFC` to `A055`) reverts to Class G, and is administered by OLW. Alternatively, OLW may provide a [top-down procedural service](../../../aerodromes/Karratha) if they wish.
 
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+
 ## Sector Responsibilities
 OLW is responsible for issuing descent and ascertaining arrival intentions for aircraft bound for YPKA.
 OLW is also responsible for sequencing and issuing descent to aircraft bound for YPLM.

--- a/docs/enroute/Melbourne Centre/PIY.md
+++ b/docs/enroute/Melbourne Centre/PIY.md
@@ -26,7 +26,7 @@ The Primary Communication Method for ELW is Voice.
 The CPDLC Station Code is `YPIY`.
 
 !!! tip
-        Even though PIY's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though PIY's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 <figure markdown>

--- a/docs/enroute/Melbourne Centre/TBD.md
+++ b/docs/enroute/Melbourne Centre/TBD.md
@@ -21,7 +21,7 @@ The Primary Communication Method for TBD is Voice.
 The CPDLC Station Code is `YTBD`.
 
 !!! tip
-        Even though TBD's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though TBD's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 

--- a/docs/enroute/Melbourne Centre/YWE.md
+++ b/docs/enroute/Melbourne Centre/YWE.md
@@ -25,7 +25,7 @@ The Primary Communication Method for YWE is Voice.
 The CPDLC Station Code is `YYWE`.
 
 !!! tip
-        Even though YWE's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
+    Even though YWE's Primary Communication Method is Voice, CPDLC may be used for Overfliers.
 
 ## Airspace
 

--- a/docs/terminal/brisbane.md
+++ b/docs/terminal/brisbane.md
@@ -30,6 +30,9 @@ See also: [AF ADC Offline](#af-adc-offline).
 If BN TCU elects not to provide top-down to YBCG, The CG CTR Class C airspace `SFC` to `A035` reverts to Class G when **CG ADC** is offline, and is administered by the relevant BN TCU controller.
 
 See also: [CG ADC Offline](#cg-adc-offline).
+
+!!! tip
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
   
 ### Airspace Structural Arrangements
 Pursuant to Section 2 of the [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}, **“North”**/**”West”** positions shall assume the airspace of corresponding **“South”**/**”East”** positions when the latter are inactive (e.g. **BAN** assumes **BAS** airspace), and vice versa.

--- a/docs/terminal/coral.md
+++ b/docs/terminal/coral.md
@@ -25,6 +25,9 @@ MKA may extend to RKA and vice versa, callsigns remain the same. See [Controller
     ![Coral Combined Airspace](img/coraltcusetup.png){ width="1000" }
     </figure>
 
+!!! tip
+    If choosing *not* to extend to the adjacent TMA, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+
 ## Coordination
 
 ### Enroute

--- a/docs/terminal/melbourne.md
+++ b/docs/terminal/melbourne.md
@@ -29,6 +29,9 @@ AV CTR Class D `SFC` to `A007` reverts to Class G and `A007` to `A025` to Class 
 
 See also: [AV ADC Offline](#av-adc-offline).
 
+!!! tip
+    When AV ADC is not online, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+
 ### Airspace Division
 The divisions of the airspace between **MAE**, **MDN**, and **MDS** change based on the Runway Mode.
 
@@ -94,6 +97,9 @@ VFR YMEN Arrivals from ML TCU shall be cleared via any of the following arrival 
 - WES
 
 ## EN ADC Offline
+!!! tip
+    When EN ADC is offline, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+
 ### Arrivals
 The class C airspace surrounding YMEN extends to `SFC`.  This means that aircraft conducting approaches will remain inside controlled airspace until they land (and in the event of a go around).  These aircraft should be cleared for an appropriate approach, advised of any traffic taxiing at YMEN, and instructed to *'report clear of the runway'*.  The missed approach path must be protected until the aircraft reports clear.
 


### PR DESCRIPTION
## Summary
Adds notes to specific enroute positions to suggest they publish an ATIS Zulu (Tower closed ATIS message) for particular aerodromes when choosing not to extend top down to those locations. This allows pilots to clearly understand the airspace reclassification and plan accordingly. The *More ATIS* plugin has pre-formatted Zulu messages for these locations.

## Changes
**Fixes**:
- Enroute page CPDLC note format

**Additions**:
- ATIS Zulu messages to enroute pages when not extending top down to particular aerodromes
