### PR TITLE
Sequencing through Adjacent Feeder Fixes

### DIFF
--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -103,6 +103,9 @@ Non-jet aircraft for YSSY shall be assigned the **MEPIL** STAR.
     **BIK:** "RXA6417, recleared direct BOREE for the BOREE3A arrival, runway 34L, maintain FL180"  
     **RXA6417:** "Recleared direct BOREE for the BOREE3A arrival, runway 34L, maintain FL180, RXA6417"
 
+#### Adjacent Feeder Fixes
+Aircraft assigned the **same runway** inbound via **BOREE** and **MEPIL**, must be considered to be on the **same STAR** for sequencing purposes. That is, they must be at least **2 minutes** apart at their respective Feeder fixes.
+
 ## STAR Clearance Expectation
 ### Handoff
 Aircraft being transferred to the following sectors shall be told to Expect STAR Clearance on handoff:

--- a/docs/enroute/Brisbane Centre/KEN.md
+++ b/docs/enroute/Brisbane Centre/KEN.md
@@ -50,6 +50,14 @@ Whilst the **MKA** controller is expected to provide a [top-down service](../../
 ## Sector Responsibilities
 All Subsectors are responsible for issuing STAR Clearances for YBMK, YBTL and YBCS on first contact.
 
+#### Sequencing in to YBCS
+Aircraft assigned the **same runway** inbound via:
+
+- ANDOP and PUNIT  
+- OVLET, AVDAN and LOCKA
+
+Must be considered to be on the **same STAR** for sequencing purposes. That is, they must be at least **2 minutes** apart at their respective Feeder fixes.
+
 ## STAR Clearance Expectation
 ### Handoff
 Aircraft being transferred to the following sectors shall be told to Expect STAR Clearance on handoff:

--- a/docs/enroute/Melbourne Centre/BIK.md
+++ b/docs/enroute/Melbourne Centre/BIK.md
@@ -102,6 +102,9 @@ Non-jet aircraft for YSSY shall be assigned the **ODALE** STAR.
     **BIK:** "JST421, recleared direct AKMIR thence WELSH, ODALE, for the ODALE7 arrival, runway 34R, maintain FL350"  
     **JST421:** "Recleared direct AKMIR, WELSH, ODALE, for the ODALE7 arrival, runway 34R, maintain FL350, JST421"
 
+#### Adjacent Feeder Fixes
+Aircraft assigned the **same runway** inbound via **RIVET** and **ODALE**, must be considered to be on the **same STAR** for sequencing purposes. That is, they must be at least **2 minutes** apart at their respective Feeder fixes.
+
 ## STAR Clearance Expectation
 ### Handoff
 Aircraft being transferred to the following sectors shall be told to Expect STAR Clearance on handoff:

--- a/docs/enroute/Melbourne Centre/BIK.md
+++ b/docs/enroute/Melbourne Centre/BIK.md
@@ -105,6 +105,9 @@ Non-jet aircraft for YSSY shall be assigned the **ODALE** STAR.
 #### Adjacent Feeder Fixes
 Aircraft assigned the **same runway** inbound via **RIVET** and **ODALE**, must be considered to be on the **same STAR** for sequencing purposes. That is, they must be at least **2 minutes** apart at their respective Feeder fixes.
 
+### Sequencing into YSCB
+Aircraft assigned the **same runway** inbound via **LEECE** and **BUNGO**, must be considered to be on the **same STAR** for sequencing purposes. That is, they must be at least **2 minutes** apart at their respective Feeder fixes.
+
 ## STAR Clearance Expectation
 ### Handoff
 Aircraft being transferred to the following sectors shall be told to Expect STAR Clearance on handoff:

--- a/docs/enroute/Melbourne Centre/ELW.md
+++ b/docs/enroute/Melbourne Centre/ELW.md
@@ -60,6 +60,9 @@ When Runway 35 is in use at YSCB, by default, vatSys will select the POLLI STAR 
 ### Snowy (SNO)
 SNO is reponsible for issuing STAR clearances and initial descent for aircraft bound for YSCB.
 
+### Sequencing in to YMML
+Aircraft assigned the **same runway** inbound via **LIZZI** and **BOYSE**, must be considered to be on the **same STAR** for sequencing purposes. That is, they must be at least **2 minutes** apart at their respective Feeder fixes.
+
 ## STAR Clearance Expectation
 ### Handoff
 Aircraft being transferred to the following sectors shall be told to Expect STAR Clearance on handoff:

--- a/docs/enroute/Melbourne Centre/PIY.md
+++ b/docs/enroute/Melbourne Centre/PIY.md
@@ -61,6 +61,9 @@ JAR is responsible for assigning and issuing arrival clearance to aircraft inbou
 !!! note
     Controllers should be aware there may be limited ADS-B coverage around Albany (YABA). Expect some areas of Class E airspace to be outside surveillance coverage. [Procedural Standards](../../../separation-standards/procedural) may need to be used in these cases.
 
+### Sequencing in to YPPH
+Aircraft assigned the **same runway** inbound via **JULIM** and **SAPKO**, must be considered to be on the **same STAR** for sequencing purposes. That is, they must be at least **2 minutes** apart at their respective Feeder fixes.
+
 ## YPPH Runway Modes
 ### Southwest Plan
 With the Southwest Plan active, arrivals shall be processed to either runway 21 or 24 based on their feeder fix, as per the table below:

--- a/docs/enroute/Melbourne Centre/TBD.md
+++ b/docs/enroute/Melbourne Centre/TBD.md
@@ -33,6 +33,14 @@ The CPDLC Station Code is `YTBD`.
 ## Sector Responsibilities
 TBD and AUG are responsible for Sequencing, issuing STAR Clearances, and issuing descent for aircraft bound for YPAD and YPED.
 
+### Sequencing in to YPAD
+Aircraft assigned the **same runway** inbound via:
+
+- MARGO and AGROS 
+- ERITH and KLAVA
+
+Must be considered to be on the **same STAR** for sequencing purposes. That is, they must be at least **2 minutes** apart at their respective Feeder fixes.
+
 ### YPAD STARs
 Aircraft tracking via OJJAY and MARGO (ie *J251 WHA H84 MARGO*) from the North for Runway 23 shall be assigned:  
 **RAYNA** STAR with the **OJJAY** transition  


### PR DESCRIPTION
## Summary
Added requirements to provide a **2 minute sequencing** for aircraft assigned the **same runway**, through defined nearby **adjacent Feeder Fixes**

## Changes
**Additions**:
- Subsequent arrivals through the following Feeder Fixes must be given a 2 minute sequence
    - **Eildon Weir**
        - **LIZZI** and **BOYSE** in to **YMML**
    - Bindook
        - **RIVET** and **ODALE** in to **YSSY**
        - **LEECE** and **BUNGO** in to **YSCB**
    - Armidale
        - **BOREE** and **MEPIL** in to **YSSY**
    - Pingelly
        - **JULIM** and **SAPKO** in to **YPPH**
    - Kennedy
        - **ANDOP** and **PUNIT** in to **YBCS**
        - **OVLET**, **AVDAN** and **LOCKA** in to **YBCS**
    - Tailem Bend
        - **MARGO** and **AGROS** in to **YPAD**
        - **ERITH** and **KLAVA** in to **YPAD**