### PR TITLE
Additional Voiceless Coord Routes

### DIFF
--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -150,8 +150,11 @@ All other aircraft coming from ARL CTA must be **Heads-up** Coordinated to SY TC
 #### Departures
 Voiceless for all aircraft:
 
-- Tracking via a Procedural SID terminus; and  
-- Assigned the lower of `F280` or the `RFL`
+- Assigned the lower of `F280` or the `RFL`; and
+- Tracking from **SDN** or **SDS** [airspace](#airspace-division); and
+- Tracking via any of the following:
+    - a Procedural SID terminus
+    - **KAMBA**
 
 All other aircraft going to ARL CTA will be **Heads-up** Coordinated by SY TCU.
 

--- a/docs/enroute/Melbourne Centre/BIK.md
+++ b/docs/enroute/Melbourne Centre/BIK.md
@@ -144,8 +144,8 @@ All other aircraft coming from BIK CTA must be **Heads-up** Coordinated to SY TC
 #### Departures
 Voiceless for all aircraft:
 
-- Tracking via the WOL NDB; and  
-- Assigned the lower of `F280` or the `RFL`
+- Assigned the lower of `F280` or the `RFL`; and  
+- Tracking via **WOL NDB** or **PEGSU**
 
 All other aircraft going to BIK CTA will be **Heads-up** Coordinated by SY TCU.
 

--- a/docs/enroute/Melbourne Centre/YWE.md
+++ b/docs/enroute/Melbourne Centre/YWE.md
@@ -98,8 +98,13 @@ All other aircraft coming from YWE/WON CTA must be **Heads-up** Coordinated to M
 #### Departures
 Voiceless to all surrounding Enroute sectors for all aircraft:
  
-- Tracking via a Procedural SID terminus; and  
-- Assigned the lower of `F240` or the `RFL`
+- Assigned the lower of `F240` or the `RFL`; and
+- Tracking via any of the following:
+    - a Procedural SID terminus
+    - **MENOG**
+    - **DOTPA**
+    - **OMKON**
+    - **AV**
 
 All other aircraft going to YWE/WON CTA will be **Heads-up** Coordinated by ML TCU.
 

--- a/docs/terminal/melbourne.md
+++ b/docs/terminal/melbourne.md
@@ -217,8 +217,13 @@ The times assume there is *Nil wind*. The data is for **Jets**, although there a
 #### Departures
 Voiceless to all surrounding Enroute sectors for all aircraft:
  
-- Tracking via a Procedural SID terminus; and  
-- Assigned the lower of `F240` or the `RFL`
+- Assigned the lower of `F240` or the `RFL`; and
+- Tracking via any of the following:
+    - a Procedural SID terminus
+    - **MENOG**
+    - **DOTPA**
+    - **OMKON**
+    - **AV**
 
 All other aircraft going to Enroute CTA must be **Heads-up** Coordinated by ML TCU prior to the boundary.
 

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -389,9 +389,12 @@ It is based on a few key assumptions:
 #### Departures
 Voiceless to all surrounding Enroute sectors for all aircraft:
 
-- Assigned the lower of `F280` or the `RFL`; and  
-- Tracking from **SDN** or **SDS** [airspace](#airspace-division); and  
-- Tracking via a Procedural SID terminus
+- Assigned the lower of `F280` or the `RFL`; and
+- Tracking from **SDN** or **SDS** [airspace](#airspace-division); and
+- Tracking via any of the following:
+    - a Procedural SID terminus
+    - **KAMBA**
+    - **PEGSU**
 
 All other aircraft going to Enroute CTA must be **Heads-up** Coordinated to the relevant sector as soon as practical.
 


### PR DESCRIPTION
**Additions**:
- **KAMBA** and **PEGSU** now available for Voiceless Coordination from **Sydney TCU** to **ARL** and **BIK** respectively
- **DOTPA**, **MENOG**, **OMKON** and **AV** now available for Voiceless Coordination from **Melbourne TCU** to **YWE**
