### PR TITLE
Oceanic Handoff Notes

### DIFF
--- a/docs/client/towerstrips.md
+++ b/docs/client/towerstrips.md
@@ -177,6 +177,9 @@ When an aircraft arrives at their nominated parking position, [inhibit](#control
 #### Runway Crossings
 For aircraft who need to cross an active runway, first coordinate with ADC, then select the strip and use the [XX CROSS XX](#control-bar) button to highlight it as a runway crossing. ADC will place the `XXX CROSSING XXX` [bar](#control-bar) in the **Runway Bay** to prevent inadvertent takeoff or landing clearances from being issued. Once the aircraft is clear, remove the crossing highlight.
 
+!!! tip
+    You can quickly toggle the crossing highlight by selecting an aircraft and pressing `X`.
+
 <figure markdown>
 ![Runway Crossing](../controller-skills/img/ozstripsrunwaycrossing.png){ width="700" }
     <figcaption>BAW15 instructed to cross runway 27, with the **Runway Bay** blocked out</figcaption>
@@ -224,6 +227,9 @@ After the aircraft vacates the runway, move the strip to the **Taxi Bay**.
 
 #### Runway Crossings
 Aircraft who need to cross an active runway will be coordinated by SMC. When approval is given for the runway crossing, place the `XXX CROSSING XXX` [bar](#control-bar) in the **Runway Bay** to prevent inadvertent takeoff or landing clearances from being issued. SMC will highlight the aircraft's strip to denote it as a runway crossing. Once the aircraft is clear, remove the bar.
+
+!!! tip
+    You can quickly add a Crossing bar to the **Runway Bay** by pressing `ALT + X`. To remove the bar, select it, then press `BACKSPACE`.
 
 <figure markdown>
 ![Runway Crossing](../controller-skills/img/ozstripsrunwaycrossing.png){ width="700" }

--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -254,3 +254,8 @@ All other aircraft coming from ARL CTA must be **Heads-up** Coordinated to WLM T
 
 ### TSN/HWE (Oceanic)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
+
+Aircraft must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
+
+!!! example
+    **ARL**: "QFA121, identification terminated, report position to Brisbane Radio, 126.45"

--- a/docs/enroute/Brisbane Centre/INL.md
+++ b/docs/enroute/Brisbane Centre/INL.md
@@ -286,3 +286,8 @@ All aircraft transiting from INL(All) to **OK TCU** and **AMB TCU** must be head
 
 ### TSN(HWE/FLD) (Oceanic)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
+
+Aircraft must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
+
+!!! example
+    **INL**: "QFA121, identification terminated, report position to Brisbane Radio, 126.45"

--- a/docs/enroute/Brisbane Centre/ISA.md
+++ b/docs/enroute/Brisbane Centre/ISA.md
@@ -82,6 +82,11 @@ As per [Standard coordination procedures](../../../controller-skills/coordinatio
 ### TSN(COL) (Oceanic)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
 
+Aircraft must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
+
+!!! example
+    **ISA**: "QFA121, identification terminated, report position to Brisbane Radio, 126.45"
+
 ### International (AYPM)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
 

--- a/docs/enroute/Brisbane Centre/KEN.md
+++ b/docs/enroute/Brisbane Centre/KEN.md
@@ -237,3 +237,8 @@ The Standard Assignable level from KEN(SWY) to HM ADC is `A060`, any other level
 
 ### TSN(FLD) (Oceanic)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
+
+Aircraft must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
+
+!!! example
+    **ISA**: "QFA121, identification terminated, report position to Brisbane Radio, 126.45"

--- a/docs/enroute/Brisbane Centre/TRT.md
+++ b/docs/enroute/Brisbane Centre/TRT.md
@@ -139,6 +139,11 @@ Reserved.
 ### IND(INE) (Oceanic)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
 
+Aircraft must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
+
+!!! example
+    **ISA**: "QFA121, identification terminated, report position to Brisbane Radio, 129.25"
+
 ### International (WAAF)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#other-units), Heads-up Coordination required for all aircraft prior to **30 mins** from boundary.
 

--- a/docs/enroute/Melbourne Centre/ASP.md
+++ b/docs/enroute/Melbourne Centre/ASP.md
@@ -105,3 +105,8 @@ Coordination is not required between ASP(WRA) and WR ADC. Aircraft entering WR A
 
 ### IND(INS) (Oceanic)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
+
+Aircraft must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
+
+!!! example
+    **ASP**: "QFA121, identification terminated, report position to Brisbane Radio, 129.25"

--- a/docs/enroute/Melbourne Centre/BIK.md
+++ b/docs/enroute/Melbourne Centre/BIK.md
@@ -211,5 +211,10 @@ That being said, it is *advised* that BIK give **Heads-up Coordination** to the 
 #### TSN (Oceanic)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
 
+Aircraft must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
+
+!!! example
+    **BIK**: "QFA121, identification terminated, report position to Brisbane Radio, 124.65"
+
 ### BIK Internal
 Changes to the CFL are permitted up to the boundary for aircraft transiting BIK/GUN/WOL airspace internally. It is *advised* that BIK/WOL/GUN give **Heads-up Coordination** to the relevant sector, prior to **20nm** from the boundary, for **any aircraft not on the Q29, Y59, W113, or V169 airways**. 

--- a/docs/enroute/Melbourne Centre/ELW.md
+++ b/docs/enroute/Melbourne Centre/ELW.md
@@ -190,3 +190,8 @@ The Standard Assignable level from BLA to **AY ADC** is `A080`.
 
 ### TSN (Oceanic)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
+
+Aircraft must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
+
+!!! example
+    **ELW**: "QFA121, identification terminated, report position to Brisbane Radio, 124.65"

--- a/docs/enroute/Melbourne Centre/HUO.md
+++ b/docs/enroute/Melbourne Centre/HUO.md
@@ -101,3 +101,8 @@ As per [Standard coordination procedures](../../../controller-skills/coordinatio
 
 ### TSN/IND(INS) (Oceanic)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
+
+Aircraft must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
+
+!!! example
+    **HUO**: "QFA121, identification terminated, report position to Brisbane Radio, 129.25"

--- a/docs/enroute/Melbourne Centre/OLW.md
+++ b/docs/enroute/Melbourne Centre/OLW.md
@@ -104,3 +104,8 @@ LM ADC owns the Class C airspace within the LM CTR from `SFC` to `A015`.
 
 ### IND,INE (Oceanic)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
+
+Aircraft must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
+
+!!! example
+    **OLW**: "QFA121, identification terminated, report position to Brisbane Radio, 129.25"

--- a/docs/enroute/Melbourne Centre/PIY.md
+++ b/docs/enroute/Melbourne Centre/PIY.md
@@ -157,3 +157,8 @@ That being said, it is *advised* that PIY(All) gives **Heads-up Coordination** p
 
 ### IND (Oceanic)
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
+
+Aircraft must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
+
+!!! example
+    **PIY**: "QFA121, identification terminated, report position to Brisbane Radio, 129.25"

--- a/docs/oceanic/Positions/TSN.md
+++ b/docs/oceanic/Positions/TSN.md
@@ -65,5 +65,21 @@ As per [Standard coordination procedures](../../../controller-skills/coordinatio
 ### TSN Internal
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
 
+!!! important
+    Aircraft separated by a surveillance separation standard must be re-established at an applicable procedural standard prior to handoff to a procedural enroute sector. 
+
+Aircraft leaving HWE in it's surveillance configuration must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
+
+!!! example
+    **HWE**: "UAE845, identification terminated, report position to Brisbane Radio, 124.65"
+
 ### Pacific Oceanic + AYPM
 As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
+
+!!! important
+    Aircraft separated by a surveillance separation standard must be re-established at an applicable procedural standard prior to handoff to a procedural enroute sector. Aircraft entering VATNZ airspace on the same track must be either vertically separated or laterally separated by a 10 minute longitudinal standard prior to handoff.
+
+Aircraft leaving HWE in it's surveillance configuration must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
+
+!!! example
+    **HWE**: "QFA121, identification terminated, report position to Auckland Radio, 129.0"


### PR DESCRIPTION
## Summary
Updates requirements to handoff an aircraft to the VATNZ Oceanic sector. Adds examples of phraseology for domestic enroute sectors when handing aircraft to oceanic sectors. Adds keyboard shortcut notes to OzStrips workflow.

## Changes
**Changes**:
- Requirement to establish aircraft at 10 minute longitudinal procedural separation  standard prior to handing off from HWE (surveillance) to Auckland Radio (procedural)

**Additions**:
- Phraseology examples to each domestic enroute sector when handing an aircraft to an oceanic sector
- Keyboard shortcut notes to OzStrips workflow for runway crossings