### PR TITLE
Fix typo in Worldflight Sops

### DIFF
--- a/docs/worldflight/Aerodromes/adelaide.md
+++ b/docs/worldflight/Aerodromes/adelaide.md
@@ -63,7 +63,7 @@ This must be changed to be ordered by **Time**, as shown below.
     <figcaption>Change to Time</figcaption>
 </figure>
 
-By default, the OzStrips Preactive bay will already be ordered by when the aircraft connected to VATSIM, from top to bottom.
+By default, the OzStrips Preactive bay will already be ordered by when the aircraft connected to VATSIM, from bottom to top.
 
 ### Runway Selection
 Aircraft that are unable to accept Runway 12/30 due to operational requirements shall be assigned Runway 05/23 (as appropriate based on Runway Mode).
@@ -80,7 +80,7 @@ Departures from Runway 12 shall be given the AAE frequency (118.2).
 ### PDCs
 PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
 
-Work through the OzStrips Preactive bay from *top to bottom* when sending PDCs.
+Work through the OzStrips Preactive bay from *bottom to top* when sending PDCs.
 
 ## Surface Movement Control (SMC)
 ### Areas of Responsibility

--- a/docs/worldflight/Aerodromes/brisbane.md
+++ b/docs/worldflight/Aerodromes/brisbane.md
@@ -77,7 +77,7 @@ Departures from Runway 01R and 19R shall be given the BDS frequency (118.45).
 ### PDCs
 PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
 
-Work through the OzStrips Preactive bay from *top to bottom* when sending PDCs.
+Work through the OzStrips Preactive bay from *bottom to top* when sending PDCs.
 
 ## Surface Movement Control (SMC)
 ### Pushback Delays

--- a/docs/worldflight/Aerodromes/darwin.md
+++ b/docs/worldflight/Aerodromes/darwin.md
@@ -55,7 +55,7 @@ Regardless of Runway in use, Departure frequency shall be DAE (**125.2**).
 ### PDCs
 PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
 
-Work through the OzStrips Preactive bay from *top to bottom* when sending PDCs.
+Work through the OzStrips Preactive bay from *bottom to top* when sending PDCs.
 
 ## Surface Movement Control (SMC)
 ### Pushback Delays

--- a/docs/worldflight/Aerodromes/perth.md
+++ b/docs/worldflight/Aerodromes/perth.md
@@ -88,7 +88,7 @@ Departures from Runway 03 and 21 will be assigned the standard **AVNEX5** SID.
 ### PDCs
 PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
 
-Work through the OzStrips Preactive bay from *top to bottom* when sending PDCs.
+Work through the OzStrips Preactive bay from *bottom to top* when sending PDCs.
 
 ## Surface Movement Control (SMC)
 ### Pushback Delays

--- a/docs/worldflight/Aerodromes/portmoresby.md
+++ b/docs/worldflight/Aerodromes/portmoresby.md
@@ -55,7 +55,7 @@ All aircraft shall be issued the **NUPTA1** SID.
 ### PDCs
 PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
 
-Work through the OzStrips Preactive bay from *top to bottom* when sending PDCs.
+Work through the OzStrips Preactive bay from *bottom to top* when sending PDCs.
 
 ## Surface Movement Control (SMC)
 ### Runway 14R/32L

--- a/docs/worldflight/Aerodromes/sydneydep.md
+++ b/docs/worldflight/Aerodromes/sydneydep.md
@@ -52,7 +52,7 @@ This must be changed to be ordered by **Time**, as shown below.
     <figcaption>Change to Time</figcaption>
 </figure>
 
-By default, the OzStrips Preactive bay will already be ordered by when the aircraft connected to VATSIM, from top to bottom.
+By default, the OzStrips Preactive bay will already be ordered by when the aircraft connected to VATSIM, from bottom to top.
 
 ### Dual ACD Controller Operations
 YSSY will have a non-standard second ACD Controller.
@@ -66,7 +66,7 @@ YSSY will have a non-standard second ACD Controller.
 
 SY-C_DEL has *no frequency*, and will not talk to aircraft by voice.
 
-Work through the OzStrips Preactive bay from *top to bottom* when sending PDCs.
+Work through the OzStrips Preactive bay from *bottom to top* when sending PDCs.
 
 #### SY_DEL
 **SY_DEL** will be responsible for:


### PR DESCRIPTION
## Summary
Strips are inserted at the top, so PDCs should be sent bottom-to-top. Changed wording after I led Alex up the garden path.

## Changes
**Fixes**:
- Changed "top to bottom" to "bottom to top" to reflect how strips are actually inserted.
