### PR TITLE
Add OzStrips Ordering & Mandate Notes

### DIFF
--- a/docs/worldflight/Aerodromes/adelaide.md
+++ b/docs/worldflight/Aerodromes/adelaide.md
@@ -22,6 +22,9 @@ An additional Non-Standard position for AD SMC will be used
 
 *Single Runway* Operations shall be **avoided** at all costs.
 
+## Workload Management
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../client/towerstrips.md#recommended-workflow).
+
 ## Airways Clearance Delivery (ACD)
 ### Flight Plan Compliance
 Ensure **all flight plans** are checked for compliance with the approved WF Route:
@@ -61,7 +64,10 @@ Departures from Runway 05, 23, and 30 shall be given the AAW frequency (124.2).
 Departures from Runway 12 shall be given the AAE frequency (118.2).
 
 ### PDCs
-PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
+PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect, prioritising those who connected first. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
+
+!!! tip
+    OzStrips displays strips in the Preactive bay ordered by connection time. Aircraft who connected first are shown down the bottom of the bay.
 
 ## Surface Movement Control (SMC)
 ### Areas of Responsibility

--- a/docs/worldflight/Aerodromes/brisbane.md
+++ b/docs/worldflight/Aerodromes/brisbane.md
@@ -13,6 +13,9 @@
 
 *Single Runway* Operations and *SODPROPS* shall not be used.
 
+## Workload Management
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../client/towerstrips.md#recommended-workflow).
+
 ## Airways Clearance Delivery (ACD)
 ### Flight Plan Compliance
 Ensure **all flight plans** are checked for compliance with the approved WF Route:
@@ -60,7 +63,10 @@ Departures from Runway 01L and 19L shall be given the BDN frequency (133.45).
 Departures from Runway 01R and 19R shall be given the BDS frequency (118.45).
 
 ### PDCs
-PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
+PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect, prioritising those who connected first. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
+
+!!! tip
+    OzStrips displays strips in the Preactive bay ordered by connection time. Aircraft who connected first are shown down the bottom of the bay.
 
 ## Surface Movement Control (SMC)
 ### Pushback Delays

--- a/docs/worldflight/Aerodromes/darwin.md
+++ b/docs/worldflight/Aerodromes/darwin.md
@@ -7,6 +7,9 @@
 ## Runway Modes
 Single runway operations on either **runway 11 or 29** will be in use for all aircraft. Runway 18/36 will not be available for arrivals and departures, due to it's use as a taxiway for some aircraft.
 
+## Workload Management
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../client/towerstrips.md#recommended-workflow).
+
 ## Airways Clearance Delivery (ACD)
 ### Flight Plan Compliance
 Ensure **all flight plans** are checked for compliance with the approved WF Route:
@@ -38,7 +41,10 @@ Runway 29 Departures shall be issued the **DN7** RADAR SID.
 Regardless of Runway in use, Departure frequency shall be DAE (**125.2**).
 
 ### PDCs
-PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
+PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect, prioritising those who connected first. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
+
+!!! tip
+    OzStrips displays strips in the Preactive bay ordered by connection time. Aircraft who connected first are shown down the bottom of the bay.
 
 ## Surface Movement Control (SMC)
 ### Pushback Delays

--- a/docs/worldflight/Aerodromes/perth.md
+++ b/docs/worldflight/Aerodromes/perth.md
@@ -13,6 +13,9 @@
 
 *Single Runway* Operations shall be **avoided** at all costs.
 
+## Workload Management
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../client/towerstrips.md#recommended-workflow).
+
 ### 24A21D
 Simultaneous Independent Crossing Runway Operations will be in use, allowing aircraft to depart from Runway 21 without conflicting with Runway 24 arrivals.
 
@@ -71,7 +74,10 @@ Departures from Runway 06 will be assigned the **PH7** SID.
 Departures from Runway 03 and 21 will be assigned the standard **AVNEX5** SID.
 
 ### PDCs
-PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
+PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect, prioritising those who connected first. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
+
+!!! tip
+    OzStrips displays strips in the Preactive bay ordered by connection time. Aircraft who connected first are shown down the bottom of the bay.
 
 ## Surface Movement Control (SMC)
 ### Pushback Delays

--- a/docs/worldflight/Aerodromes/portmoresby.md
+++ b/docs/worldflight/Aerodromes/portmoresby.md
@@ -11,6 +11,9 @@ An additional Non-Standard position for AYPY ACD will be used
 | ------------------ | --------------| -------------- | ---------------- | --------------------------------------|
 | Port Moresby Delivery       | AYPY ACD | Jacksons Delivery             | 124.400 | AYPY_DEL                              |
 
+## Workload Management
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../client/towerstrips.md#recommended-workflow).
+
 ## Airways Clearance Delivery (ACD)
 ### Flight Plan Compliance
 Ensure **all flight plans** are checked for compliance with the approved WF Route:
@@ -38,7 +41,10 @@ This must be changed to be ordered by **Time**, as shown below.
 All aircraft shall be issued the **LOTGU1** SID.  
 
 ### PDCs
-PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
+PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect, prioritising those who connected first. Upon successful readback of the PDC, ACD shall direct the pilot to contact SMC when ready for pushback or taxi.
+
+!!! tip
+    OzStrips displays strips in the Preactive bay ordered by connection time. Aircraft who connected first are shown down the bottom of the bay.
 
 ## Surface Movement Control (SMC)
 ### Runway 14R/32L

--- a/docs/worldflight/Aerodromes/sydneydep.md
+++ b/docs/worldflight/Aerodromes/sydneydep.md
@@ -14,6 +14,14 @@ An additional Non-Standard position for Sydney ACD will be used
 ## Runway Modes
 **16 PROPS** and **34 PROPS** are the available Runway Modes, with equal preference. Any other Runway Mode may **only** be used with approval from the Events Coordinator.
 
+## Workload Management
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../client/towerstrips.md#recommended-workflow). 
+
+### Ground Stop
+A ground stop will be in place for all event-aircraft departing Sydney from time 2000z until the listed departure time on the Events site. This helps to organise the flow of traffic and prevent aircraft from bypassing flow control measures which are put in place to allow our controllers to handle the extraordinary number of aircraft passing through each sector.
+
+Aircraft arriving at Sydney or departing to other destinations will be unaffected by the ground stop.
+
 ## Airways Clearance Delivery (ACD)
 ### Flight Plan Compliance
 Ensure **all flight plans** are checked for compliance with the approved WF Route:
@@ -72,7 +80,10 @@ Departures from Runway 16R and 34L shall be given the SDN frequency (123.0).
 Departures from Runway 16L and 34R shall be given the SDS frequency (129.7).
 
 ### PDCs
-PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect. Upon successful readback of the PDC, ACD shall direct the pilot to contact Coordinator when ready for pushback or taxi.
+PDCs will be in use by default, to avoid frequency congestion. ACD shall send a PDC to each aircraft as they connect, prioritising those who connected first. Upon successful readback of the PDC, ACD shall direct the pilot to contact Coordinator when ready for pushback or taxi.
+
+!!! tip
+    OzStrips displays strips in the Preactive bay ordered by connection time. Aircraft who connected first are shown down the bottom of the bay.
 
 ## Coordinator
 Coordinator operations shall be conducted in accordance with the Sydney Aerodrome [Coordinator](../../aerodromes/classc/Sydney.md#sydney-coordinator) procedures, using the OzStrips plugin.

--- a/docs/worldflight/Aerodromes/sydneydep.md
+++ b/docs/worldflight/Aerodromes/sydneydep.md
@@ -17,11 +17,6 @@ An additional Non-Standard position for Sydney ACD will be used
 ## Workload Management
 Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../client/towerstrips.md#recommended-workflow). 
 
-### Ground Stop
-A ground stop will be in place for all event-aircraft departing Sydney from time 2000z until the listed departure time on the Events site. This helps to organise the flow of traffic and prevent aircraft from bypassing flow control measures which are put in place to allow our controllers to handle the extraordinary number of aircraft passing through each sector.
-
-Aircraft arriving at Sydney or departing to other destinations will be unaffected by the ground stop.
-
 ## Airways Clearance Delivery (ACD)
 ### Flight Plan Compliance
 Ensure **all flight plans** are checked for compliance with the approved WF Route:


### PR DESCRIPTION
## Summary
Clarifies particular procedures after recent community feedback. The use of the OzStrips plugin is mandatory for all aerodrome positions. Adds notes about the ordering of strips in an OzStrips bay.

## Changes

**Additions**:
- OzStrips mandate note
- OzStrips ordering note
