### PR TITLE
Remove REP reference to DEENA SID

### DIFF
--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -474,7 +474,7 @@ Within 15 DME of SY, Departure controllers (**SDN** and **SDS**) can allow aircr
     SIDs from YSSY do not guarantee that aircraft will reach A100 by 15DME, so Departure controllers should be mindful of this and take action where necessary to expedite climb or coordinate with Approach.  
 
     Departure controllers should take extra caution when processing the following procedures to ensure they reach `A100` prior to entering REP airspace:  
-    <ul><li>RWY 34L: WOL SID & RIC SID with RADAR transition</li><li>RWY 16R: DEENA SID with RIC/KADOM transitions</li><li>YSBK departures via OLSEM/WOL</li></ul>
+    <ul><li>RWY 34L: WOL SID, & RIC SID with RADAR transition</li><li>YSBK departures via OLSEM/WOL</li></ul>
 
 It is vital that Approach controllers ensure all arriving aircraft are established below `A090` no later than 20DME to avoid conflicting with departures utilising the airspace.  All STARs have height requirements which ensure this is achieved.  Aircraft inbound to YSBK or YSSY who are not cleared via a STAR should be instructed to reach `A090` by 20DME.
 


### PR DESCRIPTION
## Summary
DEENA SID no longer relevant to REP airspace considerations. GROOK SID height requirements assure aircraft are abv A100 before entering REP airspace over approach corridor.

## Changes
**Removals**:
- Removed reference to DEENA SID in APP/DEP coordination section.