### PR TITLE
ASP/ISA Extension Rule Removal

### DIFF
--- a/docs/enroute/Brisbane Centre/ISA.md
+++ b/docs/enroute/Brisbane Centre/ISA.md
@@ -34,9 +34,8 @@ Voice may be used in lieu when applicable.
 ISA is responsible for **ARA**, **STR**, **WEG**, and **CVN** when they are offline.  
 
 ## Extending
-
 !!! Warning
-    BN-ISA_CTR is only permitted to extend to adjacent **YBBB** sectors.
+    Due to the large geographical area covered by this sector and it's neighbours, controllers are reminded of their obligations under the [ATS Policy](https://vatpac.org/publications/policies) when extending. Ensure that you have sufficiently placed visibility points to cover your primary sector and any secondary, extended sectors in their entirety.
 
 ## Sector Responsibilities
 ISA and its subsectors are purely Classes A, E and G of airspace. [Standard separation procedures](../../../separation-standards) apply.

--- a/docs/enroute/Brisbane Centre/TRT.md
+++ b/docs/enroute/Brisbane Centre/TRT.md
@@ -38,6 +38,10 @@ When **BRM ADC** is offline, BRM CTR (Class D/E `SFC` to `A055`) reverts to Clas
 !!! tip
     If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
 
+## Extending
+!!! Warning
+    Due to the large geographical area covered by this sector and it's neighbours, controllers are reminded of their obligations under the [ATS Policy](https://vatpac.org/publications/policies) when extending. Ensure that you have sufficiently placed visibility points to cover your primary sector and any secondary, extended sectors in their entirety.
+    
 ## Sector Responsibilities
 TRT and TRS are responsible for sequencing, issuing STAR Clearances, and issuing descent for aircraft bound for YPDN.  
 ASH is responsible for issuing descent and ascertaining arrival intentions for aircraft bound for YBRM.

--- a/docs/enroute/Melbourne Centre/ASP.md
+++ b/docs/enroute/Melbourne Centre/ASP.md
@@ -43,7 +43,7 @@ When **AS ADC** is offline, AS CTR (Class D and C `SFC` to `F125`) within 80 DME
 
 ## Extending
 !!! Warning
-    ML-ASP_CTR is only permitted to extend to adjacent **YMMM** sectors.
+    Due to the large geographical area covered by this sector and it's neighbours, controllers are reminded of their obligations under the [ATS Policy](https://vatpac.org/publications/policies) when extending. Ensure that you have sufficiently placed visibility points to cover your primary sector and any secondary, extended sectors in their entirety.
 
 ## Surveillance Coverage
 Limited surveillance coverage exists in the FOR sector greater than **250nm** from ADSB stations. [Procedural Standards](../../../separation-standards/procedural/) must be implemented **prior** to losing surveillance coverage

--- a/docs/enroute/Melbourne Centre/YWE.md
+++ b/docs/enroute/Melbourne Centre/YWE.md
@@ -34,6 +34,10 @@ The CPDLC Station Code is `YYWE`.
   <figcaption>Yarrowee Airspace</figcaption>
 </figure>
 
+## Extending
+!!! Warning
+    Due to the large geographical area covered by this sector and it's neighbours, controllers are reminded of their obligations under the [ATS Policy](https://vatpac.org/publications/policies) when extending. Ensure that you have sufficiently placed visibility points to cover your primary sector and any secondary, extended sectors in their entirety.
+
 ## Sector Responsibilities
 ### Yarrowee (YWE)
 YWE is responsible for the final sequencing actions in to YMML.


### PR DESCRIPTION
## Summary
Recent discussion has highlighted the need to review the existing rule preventing extension from ASP to any YBBB sectors, or ISA to any YMMM sectors. This rule was previously implemented to prevent controllers extending beyond their visibility range. The ATS Policy requires controllers to ensure that any sector extensions are covered in their entirety by their visibility points, and additional sectors have been identified as sources of potential over-extension.

The ASP/ISA extension rule has now been removed, but controllers are reminded of their obligations under the ATS Policy.

## Changes
**Additions**:
- Extension visibility warning to ISA, TRT, ASP & YWE pages

**Removals**:
- Rule preventing extension to adjacent FIR for ASP & ISA pages
