### PR TITLE
YBBN Helicopter Procedures

### DIFF
--- a/docs/aerodromes/classc/Brisbane.md
+++ b/docs/aerodromes/classc/Brisbane.md
@@ -30,7 +30,7 @@ There are three SMC positions at Brisbane which are responsible for various part
 </figure>
 
 ## Helicopter Operations
-Brisbane has one helipad located within the general aviation apron, most rescue helicopters are based within the airline maintenance hangars and will depart from the **H2 taxiway** to save time when operating.
+Brisbane has one helipad located within the general aviation apron, most rescue helicopters are based within the general aviation maintenance area and will depart from the **H2 taxiway** to save time when operating.
 
 #### Waypoints
 VFR and IFR helicopters are normally processed via two visual waypoints north and south of the field, when in VMC conditions. IFR helicopters in IMC conditions may conform to fixed wing ops and be processed via the BN (RADAR) SID from an appropriate runway, unless a visual departure is acceptable. These waypoints are used for **departures** and **arrivals**, depending on weather and traffic conditions.

--- a/docs/aerodromes/classc/Brisbane.md
+++ b/docs/aerodromes/classc/Brisbane.md
@@ -64,7 +64,7 @@ Taxiway H2 is inside the maneuvering area and therefore owned by **BN SMC-N**, t
 
 #### Arrivals
 
-IFR helicopters operating within in IMC conditions may conform to fixed wing ops and be processed via an instrument approach for a appropriate duty runway. Standard fixed wing phraseology shall be used during these conditions.
+IFR helicopters operating within IMC conditions may conform to fixed wing ops and be processed via an instrument approach for a appropriate duty runway. Standard fixed wing phraseology shall be used during these conditions.
 
 !!! example
     **RSCU533:** "Brisbane Tower, helicopter RSCU533"  

--- a/docs/aerodromes/classc/Brisbane.md
+++ b/docs/aerodromes/classc/Brisbane.md
@@ -52,7 +52,7 @@ Refer to [Maneuvering Area Responsibility](#maneuvering-area-responsibility) to 
     **BN ACD:** "RSCU533, Brisbane Delivery, cleared to YXHE via BLHS, climb 2500, squawk 1256, departure frequency 124.7"  
     **RSCU533:** "Cleared to YXHE via BLHS, climb 2500, squawk 1256, departures 124.7, RSCU533"
 
-Taxiway H2 is inside the maneuvering area and therefore owned by **BN SMC-N**, treated like a runway requiring a takeoff and landing clearance BN ADC. Helicopters landing on other surfaces outside the maneuvering areas should be instructed to *"report on the ground"* so the controllers knows when they are no longer active in their airspace. 
+Taxiway H2 is inside the maneuvering area and therefore owned by **BN SMC-N**, treated like a runway requiring a takeoff and landing clearance by BN ADC. Helicopters departing on other surfaces outside the maneuvering areas should be instructed to *"report airborne"* so the controllers knows when they are active in their airspace. 
 
 !!! example
     **RSCU533:** "Brisbane Tower, helicopter RSCU533, H2 ready"  
@@ -90,7 +90,7 @@ Traffic information must be issued to both aircraft.
     **BN ADC:** "RSCU533, H2 cleared to land"   
     **RSCU533:** "Cleared to land H2, RSCU533"
 
-Taxiway H2 is inside the maneuvering area and therefore owned by **BN SMC-N**, treated like a runway requiring a takeoff and landing clearance BN ADC. Helicopters landing on other surfaces outside the maneuvering areas should be instructed to *"report on the ground"* so the controllers knows when they are no longer active in their airspace.
+Taxiway H2 is inside the maneuvering area and therefore owned by **BN SMC-N**, treated like a runway requiring a takeoff and landing clearance by BN ADC. Helicopters landing on other surfaces outside the maneuvering areas should be instructed to *"report on the ground"* so the controllers knows when they are no longer active in their airspace.
 
 !!! example
     **RSCU533:** "RSCU533, on the ground H2"  

--- a/docs/aerodromes/classc/Brisbane.md
+++ b/docs/aerodromes/classc/Brisbane.md
@@ -29,6 +29,74 @@ There are three SMC positions at Brisbane which are responsible for various part
   <figcaption>YBBN Maneuvering Area Responsibility</figcaption>
 </figure>
 
+## Helicopter Operations
+Brisbane has one helipad located within the general aviation apron, most rescue helicopters are based within the airline maintenance hangars and will depart from the **H2 taxiway** to save time when operating.
+
+#### Waypoints
+VFR and IFR helicopters are normally processed via two visual waypoints north and south of the field, when in VMC conditions. IFR helicopters in IMC conditions may conform to fixed wing ops and be processed via the BN (RADAR) SID from an appropriate runway, unless a visual departure is acceptable. These waypoints are used for **departures** and **arrivals**, depending on weather and traffic conditions.
+
+
+| Direction               | Waypoint       | Name        |
+| ------------------ | -------------- | ---------------- |
+| North      | BLHS   | Bald Hills          |
+| South      | MBHM   | Manly Boat Harbour          |
+| East      | MBHM   | Manly Boat Harbour          |
+| West      | BLHS   | Bald Hills          |
+
+#### Departures
+
+Refer to [Maneuvering Area Responsibility](#maneuvering-area-responsibility) to determine which SMC or ADC position (when non-standard positions are online) is responsible for managing helicopter arrivals and departures.
+
+!!! example
+    **RSCU533:** "Brisbane Delivery, helicopter RSCU533, medivac for YXHE, request clearance"  
+    **BN ACD:** "RSCU533, Brisbane Delivery, cleared to YXHE via BLHS, climb 2500, squawk 1256, departure frequency 124.7"  
+    **RSCU533:** "Cleared to YXHE via BLHS, climb 2500, squawk 1256, departures 124.7, RSCU533"
+
+Taxiway H2 is inside the maneuvering area and therefore owned by **BN SMC-N**, treated like a runway requiring a takeoff and landing clearance BN ADC. Helicopters landing on other surfaces outside the maneuvering areas should be instructed to *"report on the ground"* so the controllers knows when they are no longer active in their airspace. 
+
+!!! example
+    **RSCU533:** "Brisbane Tower, helicopter RSCU533, H2 ready"  
+    **BN ADC:** "RSCU533, Brisbane Tower, H2 cleared for takeoff"  
+    **RSCU533:** "H2 cleared for takeoff, RSCU533"
+ 
+    **BN ADC:** "RSCU533, contact departures"  
+    **RSCU533:** "Departures, RSCU533"
+
+#### Arrivals
+
+IFR helicopters operating within in IMC conditions may conform to fixed wing ops and be processed via an instrument approach for a appropriate duty runway. Standard fixed wing phraseology shall be used during these conditions.
+
+!!! example
+    **RSCU533:** "Brisbane Tower, helicopter RSCU533"  
+    **BN ADC:** "RSCU533, Brisbane Tower, cleared visual approach H2"  
+    **RSCU533:** "Cleared visual approach H2, RSCU533"
+
+During times of peak fixed wing traffic, instruct helicopters to orbit in present position or overhead the VFR waypoint until advised, and maintain own separation on approach to the helipad.
+
+!!! example
+    **BN ADC:** "RSCU533, orbit overhead Bald Hills until advised, traffic is a Fokker 70 on 4nm final 01L, report in sight"   
+    **RSCU533:** "Orbit overhead Bald Hills, traffic in sight, RSCU533"  
+
+    **BN ADC:** "RSCU533, pass behind that aircraft, maintain own separation, caution wake turbulence, cleared visual approach H2"  
+    **RSCU533:** "Pass behind the Fokker 70, maintain own separation, cleared visual approach H2, RSCU553"
+
+Traffic information must be issued to both aircraft.
+
+!!! example
+    **BN ADC:** "UTY7241 traffic is a rescue helicopter north of the field overhead Bald Hills, they will maintain own separation and pass behind you on approach, runway 01L, cleared to land"   
+    **UTY7241:** "Copied rescue helicopter, runway 01L cleared to land, UTY7241"
+
+!!! example
+    **BN ADC:** "RSCU533, H2 cleared to land"   
+    **RSCU533:** "Cleared to land H2, RSCU533"
+
+Taxiway H2 is inside the maneuvering area and therefore owned by **BN SMC-N**, treated like a runway requiring a takeoff and landing clearance BN ADC. Helicopters landing on other surfaces outside the maneuvering areas should be instructed to *"report on the ground"* so the controllers knows when they are no longer active in their airspace.
+
+!!! example
+    **RSCU533:** "RSCU533, on the ground H2"  
+    **BN ADC:** "RSCU533, contact Ground 124.05"  
+    **RSCU533:** "contact Ground 124.05, RSCU533"  
+
 ## Standard Taxi Routes
 Taxiway A is to be used in the same direction as the duty runway. Taxiway B is to be used in the opposite direction to the duty runway.
 


### PR DESCRIPTION
## Summary
Hey all, I have wrote some SOPs for helicopter operations at Brisbane. Ready for review and any feedback is greatly appreciated, the initial addition includes the standard VFR waypoints used by IFR / VFR helicopters departing and arriving into Brisbane, alongside some basic separation for arrivals modified and taken from the Sydney SOPs. I haven't added any coordination yet, or written anything for the TMA section but hope this is a good starting point for the future. Happy to make any changes when I get more information and knowledge surrounding the procedures. Apologies if the PR has any issues, not used github for a while.

Thanks,
Charlie 1713821

## Changes

**Additions**:
- Initial helicopter procedures

