### PR TITLE
Update Sydney.md - Remove WOL from ABBEY SID

### DIFF
--- a/docs/aerodromes/classc/Sydney.md
+++ b/docs/aerodromes/classc/Sydney.md
@@ -235,7 +235,7 @@ Unless operationally required, aircraft shall be assigned the following runways 
 | Type  | Via  | SID     |
 | ------| ---- | --------|
 | Jet  | OLSEM<br>NOBAR<br>DIPSO<br>EVONN<br>CAWLY<br>OPTIC | **KEVIN** SID, Relevant Transition |
-| Jet  | WOL | **ABBEY** SID, WOL Transition |
+| Jet  | WOL | **ABBEY** SID |
 | Jet  | All others | **KEVIN** SID, RADAR Transition |
 | Non-Jet | All | **RADAR** SID |
 


### PR DESCRIPTION
## Summary
Minor amendment to remove mention of WOL transition for 16L ABBEY SID (it only goes to WOL).

## Changes
**Fixes**:
- Minor amendment to 16L SID selection on YSSY page.
