### PR TITLE
Run Discord notification job on base branch

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,7 +1,7 @@
 name: Send Discord Notification
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types:


### PR DESCRIPTION
## Summary
Updates the GitHub Action publishing Discord notifications to run against code on the PR's base branch. This prevents issues around secret inaccessibility with changes from external authors or those with lower permission levels.

## Changes
**Fixes**:
- Set action trigger to `pull_request_target` (instead of `pull_request`)
