### PR TITLE
Add CODEOWNERS support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Require PR reviews from designated codeowners
+# Currently, the @vatpac-technology/sop-maintainers team owns all files
+
+*  @vatpac-technology/sop-maintainers


### PR DESCRIPTION
## Summary
This PR adds a `CODEOWNERS` file to automatically request a review from the `@vatpac-technology/sop-maintainers` team on new pull requests. Repository settings will also be updated to require an approving review from at least one designated codeowner following the merge of this PR.