### PR TITLE
update: remove reference to TAC abbreviation

### DIFF
--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -290,7 +290,6 @@
 *[TRA]: Temporary Reserved Airspace
 *[VSA]: Visual Straight-In Approach
 *[IP]: Initial Point
-*[TAC]: Tactical Air Navigation System (TACAN)
 *[TACAN]: Tactical Air Navigation System
 *[LSALT]: Lowest Safe Altitude
 *[FPR]: Flight Planned Route


### PR DESCRIPTION
## Summary
The TAC abbreviation is causing other uses of TAC (in relation to charts) to be incorrectly defined. Removing reference as TAC is not used to mean TACAN in the SOPs and causing confusion.

## Changes

**Removals**:
- TAC abbreviation removed from abbreviations file
