### PR TITLE
Coordination Rules Refresh

### DIFF
--- a/docs/aerodromes/classc/Adelaide.md
+++ b/docs/aerodromes/classc/Adelaide.md
@@ -104,26 +104,20 @@ Shall be assigned the **Radar SID**.
 
 ## Coordination
 ### Auto Release
-'Next' coordination is **not** required to AD TCU for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a **Procedural** SID
+[Next](../../controller-skills/coordination.md#next) coordination is **not** required to AD TCU for aircraft that are:   
 
-All other aircraft require a 'Next' call to AD TCU.
+  - Departing from a runway nominated on the ATIS; and  
+  - Assigned the standard assignable level; and  
+  - Assigned a **Procedural** SID
 
-!!! phraseology
-    <span class="hotline">**AD ADC** -> **AD TCU**</span>: "Next, RXA4362, Runway 23"  
-    <span class="hotline">**AD TCU** -> **AD ADC**</span>: "RXA4362, Track Extended Centreline, Unrestricted"  
-    <span class="hotline">**AD ADC** -> **AD TCU**</span>: "Track Extended Centreline, RXA4362"  
-    
-    **AD ADC**: "RXA4362, Track Extended Centreline 222 degrees, Runway 23, Cleared for Takeoff"  
-    **RXA4362**: "Track Extended Centreline 222 degrees, Runway 23, Cleared for Takeoff, RXA4362"
-
-The AD TCU controller can suspend/resume Auto Release at any time, with the concurrence of **AD ADC**.
+All other aircraft require a Next call to AD TCU.
 
 The Standard Assignable level from AD ADC to AD TCU is:  
-For Jets: `A050`  
-For Non-Jets: The lower of `A040` or the `RFL`
+
+| Aircraft | Level |
+| -------- | ----- |
+| Jets | `A050` |
+| Non-Jets | The lower of `A040` and `RFL` |
 
 ### Departures Controller
 When **AAE** is online, the AD TCU airspace is split down the 05/23 Runway Centreline. As such, departing aircraft shall be instructed to contact the departures controller corresponding to the direction of turn of the aircraft after departure

--- a/docs/aerodromes/classc/Amberley.md
+++ b/docs/aerodromes/classc/Amberley.md
@@ -167,16 +167,14 @@ Circuits are flown at `A010`, in the same circuit direction as the duty runway.
 
 ## Coordination
 ### AMB TCU
-'Next' coordination is required from AMB ADC to AMB TCU for all aircraft.
-
-!!! phraseology
-    <span class="hotline">**AMB ADC** -> **AMB TCU**</span>: "Next, STAL56, runway 33"  
-    <span class="hotline">**AMB TCU** -> **AMB ADC**</span>: "STAL56, unrestricted"  
-    <span class="hotline">**AMB ADC** -> **AMB TCU**</span>: "STAL56"  
+[Next](../../controller-skills/coordination.md#next) coordination is required from AMB ADC to AMB TCU for all aircraft.
 
 The Standard Assignable Level from  **AMB ADC** to **AMB TCU** is:  
-a) The Lower of `F180` or `RFL` for Aircraft assigned via Procedural or RNAV SID.  
-b) `F190` for Aircraft assigned a Coded Departure.
+
+| Assigned Departure | Level |
+| ------------------ | ----- |
+| Procedural SID | The lower of `F180` and `RFL` |
+| Coded Departure | `F190` |
 
 ## Charts
 !!! abstract "Reference"

--- a/docs/aerodromes/classc/Brisbane.md
+++ b/docs/aerodromes/classc/Brisbane.md
@@ -198,30 +198,23 @@ Both taxiway **H2** and **F4** are inside the maneuvering area and treated like 
 
 ## Coordination
 ### Auto Release
-'Next' coordination is **not** required to BN TCU for aircraft that are:
+[Next](../../controller-skills/coordination.md#next) coordination is **not** required to BN TCU for aircraft that are:
 
 - Departing from a runway nominated on the ATIS (except during SODPROPS^); and  
 - Assigned the standard assignable level; and  
 - Assigned a **Procedural** SID; or
 - Assigned the **Radar** SID with a [Standard Assignable Heading](#standard-assignable-departure-headings)
 
-^Auto Release is not available during SODPROPS runway mode. All aircraft must be coordinated from BN ADC to BN TCU.
+^*Auto Release is not available during SODPROPS runway mode. All aircraft must be coordinated from BN ADC to BN TCU.*
 
 All other aircraft require a 'Next' call to BN TCU.
 
-!!! phraseology
-    <span class="hotline">**BN ADC** -> **BN TCU**</span>: "Next, QLK404D, Runway 19L"  
-    <span class="hotline">**BN TCU** -> **BN ADC**</span>: "QLK404D, heading 160, unrestricted"  
-    <span class="hotline">**BN ADC** -> **BN TCU**</span>: "Heading 160, QLK404D"   
-
-    **BN ADC**: "QLK404D, Assigned heading Left 160, Runway 19L, Cleared for Takeoff"  
-    **QLK404D**: "Left heading 160, Runway 19L, Cleared for Takeoff, QLK404D"
-
-The BN TCU controller can suspend/resume Auto Release at any time, with the concurrence of **BN ADC**.
-
 The Standard Assignable level from BN ADC to BN TCU is:  
-For Jets: `A060`  
-For Non-Jets: The lower of `A040` or the `RFL`
+
+| Aircraft | Level |
+| -------- | ----- |
+| Jets | `A060` |
+| Non-Jets | The lower of `A040` and `RFL` |
 
 ### Departures Controller
 Refer to [Brisbane TCU Airspace Division](../../../terminal/brisbane/#airspace-division) for information on airspace divisions when **BDN** and/or **BDS** are online.

--- a/docs/aerodromes/classc/Cairns.md
+++ b/docs/aerodromes/classc/Cairns.md
@@ -154,42 +154,30 @@ The ATIS approach expectation shall be `EXPECT INSTRUMENT APPROACH` when:
 Taxiways A2 and A between A2 and A3 are not available to aircraft above 7,000 kilograms. Taxiway A4 is not available to aircraft above 90,000 kilograms. Taxiway Y is not available to aircraft above 10,000 kilograms.
 
 ## Coordination
-
 ### CS TCU
 #### Auto Release
-'Next' coordination is **not** required for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a **Procedural** SID
+[Next](../../controller-skills/coordination.md#next) coordination is **not** required for aircraft that are:   
+
+  - Departing from a runway nominated on the ATIS; and  
+  - Assigned the standard assignable level; and  
+  - Assigned a **Procedural** SID
 
 All other aircraft require a 'Next' call to CS TCU.
 
-!!! phraseology
-    <span class="hotline">**CS ADC** -> **CS TCU**</span>: "Next, HND151"  
-    <span class="hotline">**CS TCU** -> **CS ADC**</span>: "HND151, Heading 030, unrestricted"  
-    <span class="hotline">**CS ADC** -> **CS TCU**</span>: "Heading 030, HND151"   
+The Standard Assignable level from CS ADC to CS TCU is:
 
-    **CS ADC**: "HND151, Assigned heading Left 030, Runway 15, Cleared for Takeoff"  
-    **HND151**: "Left heading 030, Runway 15, Cleared for Takeoff, HNT151"
-
-The Standard Assignable level from CS ADC to CS TCU is the lower of `A060` or the `RFL`.
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `A060` and `RFL` |
 
 #### Arrivals
 Aircraft tracking via a visual right base to runway 33 will be coordinated by CS TCU (see [Runway 33](#runway-33)). All other arriving aircraft do not require coordination.
 
 #### ACD to CS TCU
-The controller assuming responsibility of **CS ACD** shall give heads-up coordination to the relevant CS TCU controller prior to the issue of the following clearances:  
-a) VFR Departures  
-b) Aircraft using a runway not on the ATIS
+The controller assuming responsibility of **CS ACD** shall give [heads-up](../../controller-skills/coordination.md#airways-clearance) coordination to the relevant CS TCU controller prior to the issue of the following clearances:  
 
-!!! phraseology
-    <span class="coldline">**CS ACD** -> **CS TCU**</span>: "ABC, Requesting clearance for a Northbound VFR Coastal departure at A035"  
-    <span class="coldline">**CS TCU** -> **CS ACD**</span>: "ABC, Cleared for a Northbound VFR Coastal departure, A035"  
-    <span class="coldline">**CS ACD** -> **CS TCU**</span>: "Cleared for a Northbound VFR Coastal departure, A035, ABC"   
-    
-    **CS ACD**: "ABC, Cleared for a Northbound VFR Coastal departure, A035, Squawk 3601"  
-    **ABC**: "Cleared for a Northbound VFR Coastal departure, A035, 3601, ABC"  
+- VFR departures into CS TCU CTA  
+- Aircraft using a runway not on the ATIS 
 
 ### CS FLW
-FLW must advise ADC of any sequence changes within 36 Miles CS.  
-All requests for non-duty runway arrivals must be approved by ADC.
+FLW must advise ADC of any sequence changes within 36 Miles CS. All requests for non-duty runway arrivals must be approved by ADC.

--- a/docs/aerodromes/classc/Canberra.md
+++ b/docs/aerodromes/classc/Canberra.md
@@ -99,26 +99,20 @@ Helicopters arriving to the pads will generally be coordinated by the TMA contro
 
 ## Coordination
 ### Auto Release
-'Next' coordination is not required to CB TCU for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a **Procedural** SID
+[Next](../../controller-skills/coordination.md#next) coordination is not required to CB TCU for aircraft that are:   
+  
+  - Departing from a runway nominated on the ATIS; and  
+  - Assigned the standard assignable level; and  
+  - Assigned a **Procedural** SID
 
 All other aircraft require a 'Next' call to CB TCU.
 
-!!! phraseology
-    <span class="hotline">**CB ADC** -> **CB TCU**</span>: "Next, XEB, runway 35"  
-    <span class="hotline">**CB TCU** -> **CB ADC**</span>: "XEB, heading 010, Unrestricted"  
-    <span class="hotline">**CB ADC** -> **CB TCU**</span>: "Heading 010, XEB"
-
-    **CB ADC**: "XEB, Assigned heading Right 010, Runway 35, Cleared for Takeoff"  
-    **XEB**: "Right heading 010, Runway 35, Cleared for Takeoff, XEB"
-
-The CB TCU controller can suspend/resume Auto Release at any time, with the concurrence of **CB ADC**.
-
 The Standard Assignable level from CB ADC to CB TCU is:  
-For IFR aircraft: `A100`  
-For VFR aircraft: The lower of `A040` or the `RFL`
+
+| Flight Rules | Level |
+| ------------ | ----- |
+| IFR | `A100` |
+| VFR | The lower of `A040` and `RFL` |
 
 ### Runway Change
 Any Runway change must be prior coordinated to **CB TCU**.

--- a/docs/aerodromes/classc/Curtin.md
+++ b/docs/aerodromes/classc/Curtin.md
@@ -25,17 +25,16 @@ CIN ADC owns the Class C airspace within the CIN MIL CTR from `SFC` to `A015`.
 
 ## Coordination
 ### CIN TCU
-'Next' coordination is required from CIN ADC to CIN TCU for all aircraft.
+[Next](../../controller-skills/coordination.md#next) coordination is required from CIN ADC to CIN TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**CIN ADC** -> **CIN TCU**</span>: "Next, ASY404, runway 29"  
-    <span class="hotline">**CIN TCU** -> **CIN ADC**</span>: "ASY404, unrestricted"  
-    <span class="hotline">**CIN ADC** -> **CIN TCU**</span>: "ASY404"  
+The Standard Assignable Level from  **CIN ADC** to **CIN TCU** is:
 
-The Standard Assignable Level from  **CIN ADC** to **CIN TCU** is the Lower of `F190` or the `RFL`.
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `F190` and `RFL` |
 
 ### TRT(ASH)
-When CIN TCU is offline, coordination is not required between CIN ADC and TRT(ASH). Aircraft entering TRT(ASH) airspace shall be handed off, and instructed to contact TRT(ASH) for onwards clearance.
+When CIN TCU is offline, coordination is not required between CIN ADC and TRT(ASH). Aircraft entering TRT(ASH) airspace shall be handed off and instructed to contact TRT(ASH) for onwards clearance.
 
 ## Charts
 !!! abstract "Reference"

--- a/docs/aerodromes/classc/Darwin.md
+++ b/docs/aerodromes/classc/Darwin.md
@@ -86,15 +86,12 @@ Assign VFR routes in accordance with the following radial chart:
 
 ## Coordination
 ### DN TCU
-Auto-Release is **not available** at YPDN. All Departures will be coordinated when ready for departure.
+[Next](../../controller-skills/coordination.md#next) coordination is required from DN ADC to DN TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**DN ADC** -> **DN TCU**</span>: "Next, EOC, runway 18"  
-    <span class="hotline">**DN TCU** -> **DN ADC**</span>: "EOC, Track Extended Centreline, unrestricted"  
-    <span class="hotline">**DN ADC** -> **DN TCU**</span>: "Track Extended Centreline, EOC"  
+The Standard Assignable Level from  **DN ADC** to **DN TCU** is:
 
-The Standard Assignable level from **DN ADC** to **DN TCU** is:
-
-- For IFR aircraft assigned a Procedural SID: the lower of `F180` or the `RFL`.  
-- For IFR aircraft **not** assigned a Procedural SID: the lower of `A030` or the `RFL`.  
-- For VFR aircraft: the lower of `A020` or the `RFL`.
+| Aircraft | Level |
+| -------- | ----- |
+| IFR aircraft assigned a **Procedural** SID | The lower of `F180` and `RFL` |
+| IFR aircraft **not** assigned a **Procedural** SID | The lower of `A030` and `RFL` |
+| VFR aircraft | The lower of `A020` and `RFL` |

--- a/docs/aerodromes/classc/Darwin.md
+++ b/docs/aerodromes/classc/Darwin.md
@@ -60,17 +60,16 @@ For non-RNAV approved IFR aircraft with a wake turbulence category of light, iss
 VFR aircraft that will operate only in ADCs airspace shall be assigned SSR code 0100  
 
 Circuit altitude will depend on the type of aircraft. Assign circuit altitudes for the following aircraft types:  
-a) MIL Jet: `A020`  
-b) Jet: `A015`  
-c) Non-jet: `A010`  
-d) Helo: `A010`  
+
+| Aircraft | Altitude |
+| ----- | ---- |
+| Military Jet | `A020` |
+| Other Jet | `A015` |
+| Non-Jet | `A010` |
+| Helicopter | `A010` | 
 
 ### VFR Departures
-VFR aircraft are required to track via one of the published VFR Routes.  
-
-VFR routes shall be assigned based on the destination radial from Darwin.  
-
-Assign VFR routes in accordance with the following radial chart:  
+VFR aircraft are required to track via one of the published VFR Routes (as shown on the Darwin VTC). VFR routes shall be assigned based on the destination radial from Darwin, as per below:  
 
 |Outbound Radial |Assigned VFR Route|
 |---|---|
@@ -82,7 +81,7 @@ Assign VFR routes in accordance with the following radial chart:
 |225 – 359| Direct|
 
 !!! tip
-    If a VFR aircraft has not planned via a VFR route as above, use the phraseology: “ABC, cleared amended route VFR route 1, maintain A020, squawk 4512”
+    If a VFR aircraft has not planned via a VFR route as above, use the phraseology: “*ABC, cleared amended route VFR route 1, climb to A020, squawk 4512*”
 
 ## Coordination
 ### DN TCU

--- a/docs/aerodromes/classc/EastSale.md
+++ b/docs/aerodromes/classc/EastSale.md
@@ -118,7 +118,7 @@ Lanes extend from `SFC` or the base of restricted airspace to `F160`. Aircraft d
 
 !!! phraseology
     *BRCT21 is departing East Sale via the Eastern Lane at FL110 to YORB*  
-    **ES SMC** -> **BRCT21**: "BRCT21 cleared to YORB via Eastern Lane, flight plan route, climb to FL110, squawk 5072, departure frequency 123.3"
+    **ES SMC** -> **BRCT21**: "BRCT21 cleared to YORB via Eastern Lane, flight plan route, climb to F110, squawk 5072, departure frequency 123.3"
 
 ## Coordination
 ### Auto Release

--- a/docs/aerodromes/classc/EastSale.md
+++ b/docs/aerodromes/classc/EastSale.md
@@ -17,17 +17,16 @@
 ES ADC owns no airspace. Release may be available from ES APP for circuits.
 
 ## Flight Category
-- **Resuming VFR**:
-  - Recovering military aircraft must automatically revert to VFR at the following points:
-    - At the initial point when recovering via military stream landing pattern (initial and pitch).
-    - At Hi-Key.
-    - Following a touch and go, go-around, or visual overshoot when a local IFR aircraft has indicated an intention to join the circuit.
+Recovering military aircraft must automatically revert to VFR at the following points:
+
+- At the initial point when recovering via military stream landing pattern (initial and pitch)
+- At Hi-Key
+- Following a touch and go, go-around, or visual overshoot when a local IFR aircraft has indicated an intention to join the circuit
 
 ## Runway Modes
 Single runway operations only.
 
 ## Circuit Procedures
-
 The East Sale Circuit Area (ESL CIRA) is active at all times when R360A is active.
 
 Circuit operations occur within a `5NM` radius of ESL ARP, at the following altitudes:
@@ -70,18 +69,14 @@ Circuit operations occur within a `5NM` radius of ESL ARP, at the following alti
 | 04     | Right     |
 | 27     | Right     |
 
-### Circuit Saturation
-ATC should declare the circuit saturated when aircraft exceeds the below table.
-When the circuit is saturated further circuits will be unavailable until numbers are within tolerance of the table.
-This number may be reduced by ATC due to complexity of operations and prevailing weather in order to ensure safety.
+No more than the following aircraft shall be permitted to operate in the circuit area at any one time:
 
-| Time   | ESL Day | ESL Night | WSL Day | WSL Night |
+| | ESL Day | ESL Night | WSL Day | WSL Night |
 | ------ | ------- | --------- | ------- | --------- |
-| Day    | 6       | 5         | 5       | 5         |
+| Aircraft Count    | 6       | 5         | 5       | 5         |
 
 ## Low Approach
-- By day, pilots of local aircraft may request a low approach.
-- Pilots are responsible for ensuring that no collision risk exists and that there is suitable spacing to continue the approach and for the potential/subsequent go-around.
+By day, pilots of local aircraft may request a low approach. Pilots are responsible for ensuring that no collision risk exists and that there is suitable spacing to continue the approach and for the potential/subsequent go-around.
 
 ## Standard Taxi Routes
 | Runway     | Outbound Route                   | Inbound Route                   |
@@ -92,23 +87,22 @@ This number may be reduced by ATC due to complexity of operations and prevailing
 | Runway 04  | J                                | D2                              |
 
 <figure markdown>
-![ESL TAXI INBOUND](img/esl_taxi_inbound.png){ width="700" }
-<figcaption>ESL TAXI INBOUND</figcaption>
+![Inbound Taxi Routes](img/esl_taxi_inbound.png){ width="700" }
+<figcaption>Inbound Taxi Routes</figcaption>
 </figure>
 
 <figure markdown>
-![ESL TAXI OUTBOUND](img/esl_taxi_outbound.png){ width="700" }
-<figcaption>ESL TAXI OUTBOUND</figcaption>
+![Outbound Taxi Routes](img/esl_taxi_outbound.png){ width="700" }
+<figcaption>Outbound Taxi Routes</figcaption>
 </figure>
 
 ## Helicopter Operations
-- **Helicopter Circuits**:  
-  - When RWY09/27 is being used for fixed-wing circuit training, it is preferred that helicopters utilise threshold runway 04 (runway 09/27 direction) for landing and take-off to increase segregation between final approach and upwind segments.
-  - When helicopters require use of TWY A (Pad Alpha) for circuit training, base turns should be sequenced to avoid conflict during the final approach segment.
+### Circuits  
+When RWY09/27 is being used for fixed-wing circuit training, it is preferred that helicopters utilise the threshold of runway 04 (runway 09/27 direction) for landing and take-off to increase segregation between final approach and upwind segments. When helicopters require use of TWY A (Pad Alpha) for circuit training, base turns should be sequenced to avoid conflict during the final approach segment.
 
 ## Lanes
-The 16 individual training areas within the ESL military airspace are separated by 4 outbound lanes.
-These lanes are used by aircraft transiting to/from exterior training areas or for entry and exit of ESL military airspace.
+The 16 individual training areas within the ESL military airspace are separated by 4 outbound lanes. These lanes are used by aircraft transiting to/from exterior training areas or for entry and exit of ESL military airspace.
+
 Lanes are defined by GNSS waypoints situated at 12, 35, and 50 NM from YMES AD.
 
 ### Outbound Lanes
@@ -120,32 +114,22 @@ Lanes are defined by GNSS waypoints situated at 12, 35, and 50 NM from YMES AD.
 | Southern       | SABAX              | LUTUK              | NOLOX              | 180     |
 | Western        | DUGAD              | LERKO              | DUNNE              | 270     |
 
-- **Vertical Dimensions**:  
-  Lanes extend from `SFC` or the base of restricted airspace to `F160`.
-
-#### Example Departure Clearance via Lane
-
-Aircraft departing ESL military airspace may be instructed to track via a lane at or below `F160`.
+Lanes extend from `SFC` or the base of restricted airspace to `F160`. Aircraft departing ESL military airspace may be instructed to track via a lane at or below `F160`.
 
 !!! phraseology
-    **BRCT21** is departing East Sale via the Eastern Lane at FL110 to Orbost (YORB). The departure clearance would be issued as follows:
-    **ES SMC** -> **BRCT21**: "BRCT21 CLEARED TO YORB, VIA EASTERN LANE, FPR, FL110, SQUAWK 1234, DEPARTURES 123.3"
-
-**If BRCT21 was departing at or above FL160**, then departure clearance is as normal.
-
-## Level Assignment
-- `F160` or `RFL` whichever is lower for fixed-wing aircraft.
-- `A040` or `RFL` whichever is lower for rotary-wing aircraft.
+    *BRCT21 is departing East Sale via the Eastern Lane at FL110 to YORB*
+    **ES SMC** -> **BRCT21**: "BRCT21 cleared to YORB via Eastern Lane, flight plan route, climb to FL110, squawk 5072, departure frequency 123.3"
 
 ## Coordination
-
 ### Auto Release
-Auto release is not utilised at East Sale. 'Next' coordination is required from ES ADC to ES TCU for all aircraft.
+[Next](../../controller-skills/coordination.md#next) coordination is required from ES ADC to ES TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**ES ADC** -> **ES TCU**</span>: "Next, ASY01, runway 09"  
-    <span class="hotline">**ES TCU** -> **ES ADC**</span>: "ASY01, Assigned Heading Left 030, unrestricted"  
-    <span class="hotline">**ES ADC** -> **ES TCU**</span>: "Left Heading 030, ASY01" 
+The Standard Assignable Level from  **ES ADC** to **ES TCU** is:
+
+| Aircraft | Level |
+| -------- | ----- |
+| Fixed-wing | The lower of `F160` and `RFL` |
+| Rotary-wing | The lower of `A040` and `RFL` |
 
 Helicopters departing from helicopter spots will be treated as if departing from the duty runway.
 

--- a/docs/aerodromes/classc/EastSale.md
+++ b/docs/aerodromes/classc/EastSale.md
@@ -117,7 +117,7 @@ Lanes are defined by GNSS waypoints situated at 12, 35, and 50 NM from YMES AD.
 Lanes extend from `SFC` or the base of restricted airspace to `F160`. Aircraft departing ESL military airspace may be instructed to track via a lane at or below `F160`.
 
 !!! phraseology
-    *BRCT21 is departing East Sale via the Eastern Lane at FL110 to YORB*
+    *BRCT21 is departing East Sale via the Eastern Lane at FL110 to YORB*  
     **ES SMC** -> **BRCT21**: "BRCT21 cleared to YORB via Eastern Lane, flight plan route, climb to FL110, squawk 5072, departure frequency 123.3"
 
 ## Coordination

--- a/docs/aerodromes/classc/EastSale.md
+++ b/docs/aerodromes/classc/EastSale.md
@@ -8,9 +8,9 @@
 
 | Name               | Callsign           | Frequency        | Login ID             |
 | ------------------ | --------------     | ---------------- | -----------------------------|
-| **East Sale ADC**      | **East Sale Tower**    | **118.300**          | **ES_TWR**                       |
-| **East Sale SMC**      | **East Sale Ground**   | **127.250**          | **ES_GND**                       |
-| **East Sale ACD**      | **East Sale Delivery** | **134.100**          | **ES_DEL**                       |
+| **East Sale ADC**      | **Sale Tower**    | **118.300**          | **ES_TWR**                       |
+| **East Sale SMC**      | **Sale Ground**   | **127.250**          | **ES_GND**                       |
+| **East Sale ACD**      | **Sale Delivery** | **134.100**          | **ES_DEL**                       |
 | **East Sale ATIS**     |                    | **125.40**           | **YMES_ATIS**                    |
 
 ## Airspace

--- a/docs/aerodromes/classc/Edinburgh.md
+++ b/docs/aerodromes/classc/Edinburgh.md
@@ -13,11 +13,11 @@
 | **Edinburgh ATIS**      |                        | **126.250**        | **YPED_ATIS**            |
 
 ## Airspace
+ED ADC is responsible for the airspace within the Edinburgh CTR, `SFC` to `A020`.
+
 <figure markdown>
 ![ED ADC Airspace](img/edncircuits.png){ width="700" }
 </figure>
-
-- **ED ADC Airspace**: `SFC` to `A020` within the Edinburgh Control Zone (ED CTR). This airspace is primarily used for military circuits and initial and pitch approaches.
 
 ## Runway Modes
 Single runway operations only.
@@ -46,21 +46,21 @@ Aircraft can be instructed to extend outside of this airspace by ATC for traffic
 Aircraft will be pitching to the west in order not to impede on Class G boundary, the intail point is 2NM for RWY36 and 4NM for RWY18 along the extended centreline of taxiway E.
 
 ## Helicopter Operations
-- **HLS Locations**: The HLS is located on TWY D immediately east of OLA 11. There are no SIDs associated with the HLS; aircraft requiring an instrument departure can expect to depart from the runway.
+The HLS is located on TWY D immediately east of OLA 11. There are no SIDs associated with the HLS; aircraft requiring an instrument departure can expect to depart from the runway.
+
 <figure markdown>
 ![ED HLS](img/ednhelicopterhls.png){ width="700" }
 </figure>
 
 ## Coordination
 ### Departures
-'Next' coordination is required from ED ADC to AD TCU for all aircraft.
+[Next](../../controller-skills/coordination.md#next) coordination is required from ED ADC to AD TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**ED ADC** -> **AD TCU**</span>: "Next, SGE"  
-    <span class="hotline">**AD TCU** -> **ED ADC**</span>: "SGE, unrestricted"  
-    <span class="hotline">**ED ADC** -> **AD TCU**</span>: "SGE"
+The Standard Assignable level from **ED ADC** to **AD TCU** is:
 
-The Standard Assignable level from ED ADC to AD TCU is the lower of `A040` or the `RFL`.
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `A040` and `RFL` |
 
 ### Arrivals/Overfliers
 AD TCU will Heads-up coordinate all arrivals/overfliers to ED ADC.
@@ -69,8 +69,7 @@ AD TCU will Heads-up coordinate all arrivals/overfliers to ED ADC.
     <span class="hotline">**AD TCU** -> **ED ADC**</span>: "To the west, PLE, for the ILS-Z"  
     <span class="hotline">**ED ADC** -> **AD TCU**</span>: "PLE, ILS-Z"
 
-- **IFR arrivals** will be cleared for the coordinated approach (Instrument or Visual) prior to handoff to ED ADC, unless ED ADC nominates a restriction.  
-- **VFR arrivals** will be cleared for the coordinated visual approach prior to handoff to ED ADC, unless ED ADC nominates a restriction.
+Inbound aircraft will be cleared for an instrument or visual approach prior to handoff to ED ADC, unless ADC nominates a restriction.
 
 ## Charts
 !!! abstract "Reference"

--- a/docs/aerodromes/classc/Essendon.md
+++ b/docs/aerodromes/classc/Essendon.md
@@ -119,15 +119,14 @@ The Standard Assignable level from ED ADC to AD TCU is:
 
 #### Arrivals/Overfliers
 ML TCU will heads-up coordinate arrivals/overfliers from Class C to EN ADC.  
-IFR aircraft will be cleared for the coordinated approach (Instrument or Visual) prior to handoff to EN ADC, unless EN ADC nominates a restriction.  
-VFR aircraft require a level readback.
+IFR aircraft will be cleared for the coordinated approach (Instrument or Visual) prior to handoff to EN ADC, unless EN ADC nominates a restriction.
 
 !!! phraseology 
     <span class="hotline">**ML TCU** -> **EN ADC**</span>: "via KAO, KHU"  
     <span class="hotline">**EN ADC** -> **ML TCU**</span>: "KHU, A015"
 
 !!! Note
-    For aircraft not tracking via an Arrival Gate (ML TCU shall clear aircraft for approach via the appropriate arrival gate:), ML TCU is required to coordinate descent of aircraft into EN ADC airspace.
+    For aircraft not tracking via an Arrival Gate, ML TCU is required to coordinate descent of aircraft into EN ADC airspace.
 
 When “The Coffin” is released, ML TCU is required to coordinate any use of Runway 27 prior to use.
 

--- a/docs/aerodromes/classc/Essendon.md
+++ b/docs/aerodromes/classc/Essendon.md
@@ -109,16 +109,13 @@ YMEN ATIS identifiers only uses letters `A` through to `M`, due to nearby YMML u
 When an aircraft requests start clearance, the EN SMC controller shall coordinate with ML TCU to obtain the start clearance.
 
 #### Departures
-Essendon departures that will not enter ML TCU Class C airspace are not required to be coordinated.
+[Next](../../controller-skills/coordination.md#next) coordination is required from ED ADC to AD TCU for all aircraft **entering ML TCU CTA**.
 
-All aircraft departing into Class C must be coordinated to ML TCU with a "Next" Call
+The Standard Assignable level from ED ADC to AD TCU is:
 
-!!! phraseology
-    <span class="hotline">**EN ADC** -> **ML TCU**</span>: "Next, FD318"  
-    <span class="hotline">**ML TCU** -> **EN ADC**</span>: "FD318, heading 330, unrestricted"  
-    <span class="hotline">**EN ADC** -> **ML TCU**</span>: "Heading 330, FD318"
-
-The Standard Assignable level from EN ADC to ML TCU is the lower of `A030` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `A030` and `RFL` |
 
 #### Arrivals/Overfliers
 ML TCU will heads-up coordinate arrivals/overfliers from Class C to EN ADC.  
@@ -141,6 +138,6 @@ Any Runway change must be prior coordinated to **ML TCU**
 EN ADC is responsible for separation with all YMML traffic, and must coordinate any aircraft operating in EN ADC airspace that cannot be visually or laterally separated with the 09/27 or 16/34 Extended Centrelines at YMML.
 
 !!! phraseology 
-    <span class="hotline">**EN ADC** -> **ML ADC**</span>: "Boundary Ident, OXG, Published Missed Approach from the ILS 26"  
-    <span class="hotline">**ML ADC** -> **EN ADC**</span>: "OXG, My restriction is QFA451 on a 10nm final RWY 34. Your separation"  
+    <span class="hotline">**EN ADC** -> **ML ADC**</span>: "For Ident, OXG, published missed approach from the ILS 26"  
+    <span class="hotline">**ML ADC** -> **EN ADC**</span>: "OXG, my restriction is QFA451 on a 10nm final RWY 34, your separation"  
     <span class="hotline">**EN ADC** -> **ML ADC**</span>: "My separation with QFA451, OXG"

--- a/docs/aerodromes/classc/Gingin.md
+++ b/docs/aerodromes/classc/Gingin.md
@@ -31,14 +31,13 @@ The intial points for Gingin are RWY 08 is the corner of the pine plantation and
 
 ## Coordination
 ### PE TCU
-'Next' coordination is required from GIG ADC to PE TCU for all aircraft.
+[Next](../../controller-skills/coordination.md#next) coordination is required from GIG ADC to PE TCU for all aircraft.
 
-!!! example
-    <span class="hotline">**GIG ADC** -> **PE TCU**</span>: "Next, VIPR01, Runway 08"  
-    <span class="hotline">**PE TCU** -> **GIG ADC**</span>: "VIPR01, Assigned Heading Right 030, unrestricted"  
-    <span class="hotline">**PE ADC** -> **PE TCU**</span>: "Right Heading 030, VIPR01"
+The Standard Assignable Level from **GIG ADC** to **PE TCU** is:
 
-The Standard Assignable Level from **GIG ADC** to **PE TCU** is the lower of `A050` or the `RFL`.
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `A050` and `RFL` |
 
 ## Charts
 !!! abstract "Reference"

--- a/docs/aerodromes/classc/Goldy.md
+++ b/docs/aerodromes/classc/Goldy.md
@@ -198,26 +198,20 @@ Both hospital helipads are outside the maneuvering area and do not require a tak
 
 ## Coordination
 ### Auto Release
-'Next' coordination is **not** required to BN TCU for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a **Procedural** SID
+[Next](../../controller-skills/coordination.md#next) coordination is **not** required to BN TCU for aircraft that are:   
+  
+  - Departing from a runway nominated on the ATIS; and  
+  - Assigned the standard assignable level; and  
+  - Assigned a **Procedural** SID
 
 All other aircraft require a 'Next' call to CG TCU.
 
-!!! phraseology
-    <span class="hotline">**CG ADC** -> **BAC**</span>: "Next, CBN, runway 14"  
-    <span class="hotline">**BAC** -> **CG ADC**</span>: "CBN, heading 030, unrestricted"  
-    <span class="hotline">**CG ADC** -> **BAC**</span>: "Heading 030, CBN"  
-
-    **CG ADC**: "CBN, Assigned heading left 030, Runway 14, Cleared for Takeoff"  
-    **CBN**: "Left heading 030, Runway 14, Cleared for Takeoff, CBN"
-
-The BN TCU controller can suspend/resume Auto Release at any time, with the concurrence of **CG ADC**.
-
 The Standard Assignable level from CG ADC to BN TCU is:  
-For Jets: `A060`  
-For Non-Jets: The lower of `A060` or the `RFL`
+
+| Aircraft | Level |
+| -------- | ----- |
+| Jets | `A060` |
+| Non-Jets | The lower of `A060` and `RFL` |
 
 ### Start Clearance
 A start clearance is required for aircraft planned to YBBN. Start clearance must be coordinated with BN TCU.

--- a/docs/aerodromes/classc/Learmonth.md
+++ b/docs/aerodromes/classc/Learmonth.md
@@ -24,14 +24,13 @@ LM ADC owns the Class C airspace within the LM CTR from `SFC` to `A015`.
 
 ## Coordination
 ### LM TCU
-'Next' coordination is required from LM ADC to LM TCU for all aircraft.
+[Next](../../controller-skills/coordination.md#next) coordination is required from LM ADC to LM TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**LM ADC** -> **LM TCU**</span>: "Next, QFA1601, runway 36"  
-    <span class="hotline">**LM TCU** -> **LM ADC**</span>: "QFA1601, Right heading 060 Visual, unrestricted"  
-    <span class="hotline">**LM ADC** -> **LM TCU**</span>: "Right heading 060 Visual, QFA1601"  
+The Standard Assignable Level from  **LM ADC** to **LM TCU** is:
 
-The Standard Assignable Level from  **LM ADC** to **LM TCU** is the Lower of `F270` or the `RFL`.
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `F270` and `RFL` |
 
 ### OLW
 When LM TCU is offline, coordination is not required between LM ADC and OLW. Aircraft entering OLW airspace shall be handed off, and instructed to contact OLW for onwards clearance.

--- a/docs/aerodromes/classc/Melbourne.md
+++ b/docs/aerodromes/classc/Melbourne.md
@@ -234,7 +234,7 @@ During busy events, VATPAC may utilise prebooked slots to manage traffic congest
 
 All other aircraft require a 'Next' call to ML TCU.
 
-The Standard Assignable level from ML ADC to ML TCU is:
+The Standard Assignable level from **ML ADC** to **ML TCU** is:
 
 | Aircraft | Level |
 | -------- | ----- |

--- a/docs/aerodromes/classc/Melbourne.md
+++ b/docs/aerodromes/classc/Melbourne.md
@@ -132,7 +132,7 @@ Remember to pass traffic information to both aircraft.
     **JST515:** "Runway 16, cleared to land, JST515"
 
 ## Pushback Disconnect Points
-In the real world, YMML utilises designated disconnect points to allow predictable pushback paths from various bays. On VATSIM, this is difficult to simulate, given the limited access to pushback maps and the additional plugins required to facilitate a pushback in this way.
+In the real world, YMML utilises Towbar Disconnect Points (TDPs) to allow predictable pushback paths from various bays. On VATSIM, this is difficult to simulate, given the limited access to pushback maps and the additional plugins required to facilitate a pushback in this way.
 
 !!! warning "Important"
     Disconnect points should only be issued with a pushback instruction on **pilot request** or after confirming that **both the pilot & controller** are competent in their use.

--- a/docs/aerodromes/classc/Melbourne.md
+++ b/docs/aerodromes/classc/Melbourne.md
@@ -135,7 +135,7 @@ Remember to pass traffic information to both aircraft.
 In the real world, YMML utilises Towbar Disconnect Points (TDPs) to allow predictable pushback paths from various bays. On VATSIM, this is difficult to simulate, given the limited access to pushback maps and the additional plugins required to facilitate a pushback in this way.
 
 !!! warning "Important"
-    Disconnect points should only be issued with a pushback instruction on **pilot request** or after confirming that **both the pilot & controller** are competent in their use.
+   In the real world, disconnect points are rarely assigned by the SMC controller, as each bay has a standard disconnect point. As such, disconnect points should only be assigned where there is benefit to traffic flow on the apron, after confirming that **both the pilot & controller** are competent in their use, or on **pilot request**.
 
 ## Workload Management
 During busy events, such as [Milk Run Monday](../../../events/milkrun/), the **SMC** controller may end up with a much higher workload than the **ACD** controller. Additionally, delays may need to be implemented for aircraft requesting pushback, so as to not overload the taxiways and holding points.

--- a/docs/aerodromes/classc/Melbourne.md
+++ b/docs/aerodromes/classc/Melbourne.md
@@ -213,7 +213,7 @@ During busy events, VATPAC may utilise prebooked slots to manage traffic congest
 !!! warning "Important"
     Melbourne utilises auto release for all **Procedural** SIDs and the **ML (RADAR)** SID provided aircraft are assigned the Standard Assignable Level and a [Standard Assignable Heading](#standard-assignable-departure-headings).
 
-'Next' coordination is **not** required for aircraft that are:  
+[Next](../../controller-skills/coordination.md#next) coordination is **not** required for aircraft that are:  
 
 - Assigned a **Procedural** SID  
     - Departing from a runway nominated on the ATIS; and  
@@ -229,17 +229,11 @@ During busy events, VATPAC may utilise prebooked slots to manage traffic congest
 
 All other aircraft require a 'Next' call to ML TCU.
 
-!!! phraseology
-    <span class="hotline">**ML ADC** -> **ML TCU**</span>: "Next, JIA, runway 34"  
-    <span class="hotline">**ML TCU** -> **ML ADC**</span>: "JIA, Track Extended Centreline, Unrestricted"  
-    <span class="hotline">**ML ADC** -> **ML TCU**</span>: "Track Extended Centreline, JIA"  
+The Standard Assignable level from ML ADC to ML TCU is:
 
-    **ML ADC**: "JIA, Track Extended Centreline 340 degrees, Runway 34, Cleared for Takeoff"  
-    **JIA**: "Track Extended Centreline 340 degrees, Runway 34, Cleared for Takeoff, JIA"
-
-The ML TCU controller can suspend/resume Auto Release at any time, with the concurrence of **ML ADC**.
-
-The Standard Assignable level from ML ADC to ML TCU is the lower of `A050` or the `RFL`.
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `A050` and `RFL` |
 
 ### Standard Assignable Departure Headings
 Aircraft that have been cleared the **ML (RADAR) SID** must receive an assigned heading with their line up or takeoff clearance.
@@ -267,6 +261,6 @@ Refer to [Melbourne TCU Airspace Division](../../../terminal/melbourne/#airspace
 EN ADC is responsible for separation with all YMML traffic, and will coordinate any aircraft operating in EN ADC airspace that cannot be visually or laterally separated with YMML traffic.
 
 !!! phraseology 
-    <span class="hotline">**EN ADC** -> **ML ADC**</span>: "Boundary Ident, OXG, Published Missed Approach from the ILS 26"  
-    <span class="hotline">**ML ADC** -> **EN ADC**</span>: "OXG, My restriction is QFA451 on a 10nm final RWY 34. Your separation"  
+    <span class="hotline">**EN ADC** -> **ML ADC**</span>: "For Ident, OXG, published missed approach from the ILS 26"  
+    <span class="hotline">**ML ADC** -> **EN ADC**</span>: "OXG, my restriction is QFA451 on a 10nm final RWY 34, your separation"  
     <span class="hotline">**EN ADC** -> **ML ADC**</span>: "My separation with QFA451, OXG"

--- a/docs/aerodromes/classc/Melbourne.md
+++ b/docs/aerodromes/classc/Melbourne.md
@@ -96,8 +96,7 @@ This allows for both Runway 09 and Runway 16 to operate independently of each ot
 When implementing the [Pushback Requests on ACD](#pushback-requests-on-acd) procedure, the OPR INFO shall include:  
 `ALL DEPARTURES MUST REQUEST PUSH BACK ON 127.2`  
 
-## Miscellaneous
-### Sunbury Corridor
+## Sunbury Corridor
 Day VFR Helicopters may request clearance via the **Sunbury Corridor**. It is defined as the corridor 1nm either side of a track from SWT - PWLC - 16/27 Intersection at YMML.
 
 <figure markdown>
@@ -131,6 +130,12 @@ Remember to pass traffic information to both aircraft.
 !!! phraseology
     **ML ADC:** "JST515, traffic is a helicopter, 2nm northwest of the field, tracking for Essendon and maintaining own separation with you, runway 16, cleared to land"  
     **JST515:** "Runway 16, cleared to land, JST515"
+
+## Pushback Disconnect Points
+In the real world, YMML utilises designated disconnect points to allow predictable pushback paths from various bays. On VATSIM, this is difficult to simulate, given the limited access to pushback maps and the additional plugins required to facilitate a pushback in this way.
+
+!!! warning "Important"
+    Disconnect points should only be issued with a pushback instruction on **pilot request** or after confirming that **both the pilot & controller** are competent in their use.
 
 ## Workload Management
 During busy events, such as [Milk Run Monday](../../../events/milkrun/), the **SMC** controller may end up with a much higher workload than the **ACD** controller. Additionally, delays may need to be implemented for aircraft requesting pushback, so as to not overload the taxiways and holding points.

--- a/docs/aerodromes/classc/Nowra.md
+++ b/docs/aerodromes/classc/Nowra.md
@@ -79,12 +79,13 @@ Aerodrome and instrument approach charts are available in the AIP, or otherwise 
 
 ## Coordination
 ### Auto Release
-Auto release is not utilised at Nowra. 'Next' coordination is required from NW ADC to NW TCU for all aircraft.
+[Next](../../controller-skills/coordination.md#next) coordination is required from NW ADC to NW TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**NW ADC** -> **NW TCU**</span>: "Next, ASY01, runway 08"  
-    <span class="hotline">**NW TCU** -> **NW ADC**</span>: "ASY01, Assigned Heading Left 030, unrestricted"  
-    <span class="hotline">**NW ADC** -> **NW TCU**</span>: "Assigned Heading Heading Left 030, ASY01" 
+The Standard Assignable level from **NW ADC** to **NW TCU** is:
+
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `F120` and `RFL` | 
 
 Helicopters departing from helicopter spots will be treated as if departing from the duty runway.
 
@@ -92,8 +93,4 @@ Helicopters departing from helicopter spots will be treated as if departing from
     *PSDN14 is a VFR helicopter departing from spot 2 (in the direction of runway 08)*  
     <span class="hotline">**NW ADC** -> **NW TCU**</span>: "Next, PSDN14, runway 08"  
     <span class="hotline">**NW TCU** -> **NW ADC**</span>: "PSDN14, right turn, unrestricted"  
-    <span class="hotline">**NW ADC** -> **NW TCU**</span>: "Right turn, PSDN14" 
-
-
-### Level Assignment
-The Standard Assignable Level from **NW ADC** to **NW TCU** is `F120` or `RFL`, whichever is lower.
+    <span class="hotline">**NW ADC** -> **NW TCU**</span>: "Right turn, PSDN14"

--- a/docs/aerodromes/classc/Oakey.md
+++ b/docs/aerodromes/classc/Oakey.md
@@ -38,11 +38,10 @@ The standard circuit direction is to the north of the field.
 
 ## Coordination
 ### OK TCU
-'Next' coordination is required from OK ADC to OK TCU for all aircraft not remaining in the circuit. 
+[Next](../../controller-skills/coordination.md#next) coordination is required from OK ADC to OK TCU for all aircraft not remaining in the circuit.
 
-!!! phraseology
-    <span class="hotline">**OK ADC** -> **OK TCU**</span>: "Next, MRCH01, runway 32"  
-    <span class="hotline">**OK TCU** -> **OK ADC**</span>: "MRCH01, Make Right Turn, unrestricted"  
-    <span class="hotline">**OK ADC** -> **OK TCU**</span>: "Make Right Turn, MRCH01"  
+The Standard Assignable level from **OK ADC** to **OK TCU** is:
 
-The Standard Assignable level from **OK ADC** to **OK TCU** is the lower of `F120` or the `RFL`.
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `F120` and `RFL` |

--- a/docs/aerodromes/classc/Oakey.md
+++ b/docs/aerodromes/classc/Oakey.md
@@ -38,7 +38,7 @@ The standard circuit direction is to the north of the field.
 
 ## Coordination
 ### OK TCU
-[Next](../../controller-skills/coordination.md#next) coordination is required from OK ADC to OK TCU for all aircraft not remaining in the circuit.
+[Next](../../controller-skills/coordination.md#next) coordination is required from OK ADC to OK TCU for all aircraft.
 
 The Standard Assignable level from **OK ADC** to **OK TCU** is:
 

--- a/docs/aerodromes/classc/Pearce.md
+++ b/docs/aerodromes/classc/Pearce.md
@@ -54,18 +54,15 @@ HAWKs have circuit altitude of `A016`, while both 2FTS and RSAF PC21s are assign
 
 ## Coordination
 ### PE TCU
-'Next' coordination is required from PE ADC to PE TCU for all aircraft.
-
-!!! phraseology
-    <span class="hotline">**PE ADC** -> **PE TCU**</span>: "Next, ASY01, runway 36L"  
-    <span class="hotline">**PE TCU** -> **PE ADC**</span>: "ASY01, Heading 030, unrestricted"  
-    <span class="hotline">**PE ADC** -> **PE TCU**</span>: "Heading 030, ASY01"
+[Next](../../controller-skills/coordination.md#next) coordination is required from PE ADC to PE TCU for all aircraft.
 
 The Standard Assignable Level from **PE ADC** to **PE TCU** is:
 
-- `F130` for aircraft assigned a Procedural SID; except
-- `A030` for aircraft assigned the **GUNOK** SID; or
-- The lower of `F130` or `RFL` for all other aircraft
+| Departure Procedure | Level |
+| ------------------- | ----- |
+| **GUNOK** SID | `A030` |
+| A **Procedural** SID | `F130` |
+| All others | The lower of `F130` and `RFL` |
 
 ## Charts
 !!! abstract "Reference"

--- a/docs/aerodromes/classc/Perth.md
+++ b/docs/aerodromes/classc/Perth.md
@@ -66,40 +66,24 @@ When traffic permits, VFR scenic flights over Perth are cleared via VICTOR 65 ro
 
 ## Coordination
 ### Auto Release
-'Next' coordination is **not** required for aircraft that are:   
-    a) Departing from a runway nominated on the ATIS; and  
-    b) Assigned the standard assignable level; and  
-    c) Assigned a **Procedural SID**
+[Next](../../controller-skills/coordination.md#next) coordination is **not** required for aircraft that are:   
+
+- Departing from a runway nominated on the ATIS; and  
+- Assigned the standard assignable level; and  
+- Assigned a **Procedural SID**
 
 All other aircraft require a 'Next' call to PH TCU.
 
-!!! phraseology
-    <span class="hotline">**PH ADC** -> **PH TCU**</span>: "Next, ABC, runway 03"  
-    <span class="hotline">**PH TCU** -> **PH ADC**</span>: "ABC, Heading 010, unrestricted"  
-    <span class="hotline">**PH ADC** -> **PH TCU**</span>: "Heading 010, ABC"  
+The Standard Assignable level from PH ADC to PH TCU is:
 
-    **PH ADC**: "ABC, Assigned heading left 010, Runway 03, Cleared for Takeoff"  
-    **ABC**: "Left heading 010, Runway 010, Cleared for Takeoff, ABC"
-
-The PH TCU controller can suspend/resume Auto Release at any time, with the concurrence of **PH ADC**.
-
-The Standard Assignable level from PH ADC to PH TCU is the lower of `A050` or the `RFL`.
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `A050` and `RFL` |
 
 ### Departures Controller
 Refer to [Perth TCU Airspace Division](../../../terminal/perth/#airspace-division) for information on airspace divisions when **PHD** is online.
 
 ### ACD to PH TCU
-The controller assuming responsibility of ACD shall give heads-up coordination to the relevant PH TCU controller prior to the issue of the following clearances:  
-a) VFR Departures  
-b) Aircraft using a runway not on the ATIS
-
-!!! phraseology
-    **ABC**: "Perth Delivery, ABC, request Victor 65"  
-    **PH ACD**: "ABC, Perth Delivery, standby"  
-
-    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "ABC, requesting Victor 65"  
-    <span class="coldline">**PH TCU** -> **PH ACD**</span>: "ABC, cleared Victor 65, 1,500ft"  
-    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "Cleared Victor 65, 1,500ft, ABC"   
-     
-    **PH ACD**: "ABC, cleared Victor 65, climb to 1,500ft, squawk 0442"  
-    **ABC**: "Cleared Victor 65, climb to 1,500ft, squawk 0442, ABC"  
+The controller assuming responsibility of ACD shall give [heads-up](../../controller-skills/coordination.md#airways-clearance) coordination to the relevant PH TCU controller prior to the issue of the following clearances:  
+- VFR departures into PH TCU CTA
+- Aircraft using a runway not on the ATIS 

--- a/docs/aerodromes/classc/Perth.md
+++ b/docs/aerodromes/classc/Perth.md
@@ -85,5 +85,6 @@ Refer to [Perth TCU Airspace Division](../../../terminal/perth/#airspace-divisio
 
 ### ACD to PH TCU
 The controller assuming responsibility of ACD shall give [heads-up](../../controller-skills/coordination.md#airways-clearance) coordination to the relevant PH TCU controller prior to the issue of the following clearances:  
+
 - VFR departures into PH TCU CTA
 - Aircraft using a runway not on the ATIS 

--- a/docs/aerodromes/classc/Richmond.md
+++ b/docs/aerodromes/classc/Richmond.md
@@ -17,15 +17,14 @@ RI ADC being online will activate the **R470** Restricted Area, which is reclass
 
 Control authority of the **R470** Restricted Area when active is as follows:
 
-- RI ADC `SFC`-`A015`
-- SY TCU (SDN) `A015`-`A045`
+- RI ADC: `SFC`-`A015`
+- SY TCU (SDN): `A015`-`A045`
 
 ## Charts
 !!! abstract "Reference"
     Additional charts to the AIP may be found in the RAAF TERMA document, available towards the bottom of [RAAF AIP page](https://ais-af.airforce.gov.au/australian-aip){target=new}
 
-## Aerodrome
-### SID Selection
+## SID Selection
 vatSys does not have SIDs built-in for YSRI. Aircraft planned via **ANKUB**, **KADOM** or **MUDGI** may be assigned the SID that terminates at the appropriate waypoint, as long as ATC is familiar with the chart, and the pilot is able.
 
 Aircraft who are not planned via these points, or who are negative RNAV, may be assigned a visual departure.
@@ -50,8 +49,7 @@ There are three training areas located within **R470**, used for civil and milit
 
 Refer to [YSRI FIHA AD2 SUPP](https://ais-af.airforce.gov.au/australian-aip){target=new} for charts and more info.
 
-## Miscellaneous
-### Circuit Operations
+## Circuit Operations
 YSRI circuit area is defined as within 6nm of the YSRI ARP. An aircraft operating in the circuit will be issued a clearance to the operate within the circuit area not above `A015`.
 
 ### Circuit Direction
@@ -60,19 +58,17 @@ YSRI circuit area is defined as within 6nm of the YSRI ARP. An aircraft operatin
 | 10     | Left  |
 | 28     | Left |
 
-### Start Approval
+## Start Approval
 A start approval is required whenever parachute drops are conducted onto the Richmond Drop Zone. Additionally, ‘propellers/engines stopped’ reports are required. ATC shall notify these requirements by ATIS broadcast.
 
-### Inital and Pitch
+## Inital and Pitch
 The standard inital points are 5nm downwind of the active runway, dead side, left pitch/circuit.
 
 ## Coordination
 ### SY TCU
-'Next' coordination is required from RI ADC to SY TCU for all aircraft.
+[Next](../../controller-skills/coordination.md#next) coordination is required from RI ADC to SY TCU for all aircraft **entering SY TCU CTA**.
 
-!!! example
-    <span class="hotline">**RI ADC** -> **SDN**</span>: "Next, TROJ57, runway 28"  
-    <span class="hotline">**SDN** -> **RI ADC**</span>: "TROJ57, unrestricted"  
-    <span class="hotline">**RI ADC** -> **SDN**</span>: "TROJ57"  
-
-The Standard Assignable Level from **RI ADC** to **SY TCU** is the lower of `A050` or the `RFL`.  
+The Standard Assignable Level from **RI ADC** to **SY TCU** is:
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `A050` and `RFL` | 

--- a/docs/aerodromes/classc/Scherger.md
+++ b/docs/aerodromes/classc/Scherger.md
@@ -23,14 +23,13 @@ SG ADC owns the Class C airspace within the SG CTR from `SFC` to `A015`.
 
 ## Coordination
 ### SG TCU
-'Next' coordination is required from SG ADC to SG TCU for all aircraft.
+[Next](../../controller-skills/coordination.md#next) coordination is required from SG ADC to SG TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**SG ADC** -> **SG TCU**</span>: "Next, ASY219, runway 30"  
-    <span class="hotline">**SG TCU** -> **SG ADC**</span>: "ASY219, unrestricted"  
-    <span class="hotline">**SG ADC** -> **SG TCU**</span>: "ASY219"  
+The Standard Assignable Level from  **SG ADC** to **SG TCU** is:
 
-The Standard Assignable Level from  **SG ADC** to **SG TCU** is the lower of `F240` or the `RFL`.
+| Aircraft | Level |
+| ------- | ------- |
+| All | The lower of `F240` and `RFL` |
 
 ### ISA(ARA)
 When SG TCU is offline, coordination is not required between SG ADC and ISA(ARA). Aircraft entering ISA(ARA) airspace shall be handed off, and instructed to contact ISA(ARA) for onwards clearance.

--- a/docs/aerodromes/classc/Scherger.md
+++ b/docs/aerodromes/classc/Scherger.md
@@ -25,7 +25,7 @@ SG ADC owns the Class C airspace within the SG CTR from `SFC` to `A015`.
 ### SG TCU
 [Next](../../controller-skills/coordination.md#next) coordination is required from SG ADC to SG TCU for all aircraft.
 
-The Standard Assignable Level from  **SG ADC** to **SG TCU** is:
+The Standard Assignable Level from **SG ADC** to **SG TCU** is:
 
 | Aircraft | Level |
 | ------- | ------- |

--- a/docs/aerodromes/classc/Sydney.md
+++ b/docs/aerodromes/classc/Sydney.md
@@ -395,34 +395,29 @@ During busy events, VATPAC may utilise prebooked slots to manage traffic congest
 !!! warning "Important"
     YSSY utilises auto release for all **Procedural** SIDs (except **ABBEY** SID during SODPROPS), and the **SY (RADAR)** SID provided aircraft are assigned the standard assignable level and a [Standard Assignable Heading](#standard-assignable-departure-headings).
 
-'Next' coordination is **not** required for aircraft that are:   
-    a) Departing from a runway nominated on the ATIS; and   
-    b) Assigned the Standard assignable level; and  
-    c) Assigned a **Procedural SID** (except **ABBEY** SID); or  
-    d) Assigned the **Radar** SID with a [Standard Assignable Heading](#standard-assignable-departure-headings)
+[Next](../../controller-skills/coordination.md#next) coordination is **not** required for aircraft that are:   
+
+- Departing from a runway nominated on the ATIS; and   
+- Assigned the Standard assignable level; and  
+- Assigned a **Procedural SID** (except **ABBEY** SID); or  
+- Assigned the **Radar** SID with a [Standard Assignable Heading](#standard-assignable-departure-headings)
 
 All other aircraft require a 'Next' call to SY TCU.
 
 'Next' coordination is additionally required for:  
-    a) Visual departures  
-    b) Departures to YSBK  
-    c) After a go around, the next departure from that runway  
-    d) Jets departing 16L via WOL  
-    e) All aircraft during the Curfew Runway Mode
 
-!!! phraseology
-    <span class="hotline">**SY ADC** -> **SY TCU**</span>: "Next, MHQ, Runway 34R"  
-    <span class="hotline">**SY TCU** -> **SY ADC**</span>: "MHQ, heading 030, unrestricted"  
-    <span class="hotline">**SY ADC** -> **SY TCU**</span>: "Heading 030, MHQ"  
+- Visual departures  
+- Departures to YSBK  
+- After a go around, the next departure from that runway  
+- Jets departing 16L via WOL  
+- All aircraft during the Curfew Runway Mode
 
-    **SY ADC**: "MHQ, Assigned heading right 030, Runway 34R, Cleared for Takeoff"  
-    **MHQ**: "Right heading 030, Runway 34R, Cleared for Takeoff, MHQ"
+The Standard Assignable level from SY ADC to SY TCU is: 
 
-The SY TCU controller can suspend/resume Auto Release at any time, with the concurrence of **SY ADC**.
-
-The Standard Assignable level from SY ADC to SY TCU is:  
-For Jets: `A050`  
-For Non-Jets: The lower of `A030` or the `RFL`
+| Aircraft | Level |
+| -------- | ----- |
+| Jets | `A050` |
+| Non-Jets | The lower of `A030` and `RFL` |
 
 ### Departures Controller
 Refer to [Sydney TCU Airspace Division](../../../terminal/sydney/#airspace-division) for information on airspace divisions when **SDN** and/or **SDS** are online.
@@ -447,17 +442,7 @@ Aircraft that have been cleared the **SY (RADAR) SID** must receive an assigned 
 **SY ADC** has responsibility of all runways, requiring **SY SMC** to coordinate with **SY ADC** to allow aircraft to cross runways whilst taxiing. **SY SMC** may request, or **SY ADC** may elect, to release certain runways to the **SY SMC** controller, so they may let aircraft cross the runway without coordination (for example, releasing runway 07/25 to **SY SMC** whilst PROPS are in progress.) This release may also be cancelled at the controller's discretion.
 
 ### ACD to SY TCU
-The controller assuming responsibility of **SY ACD** shall give heads-up coordination to the relevant SY TCU controller prior to the issue of the following clearances:  
-a) VFR Departures  
-b) Aircraft using a runway not on the ATIS 
+The controller assuming responsibility of **SY ACD** shall give [heads-up](../../controller-skills/coordination.md#airways-clearance) coordination to the relevant SY TCU controller prior to the issue of the following clearances: 
 
-!!! phraseology
-    **TEK:** "Sydney Delivery, TEK, for YSHL via CUL, A025, request clearance"  
-    **SY ACD:** "TEK, Sydney Delivery, standby"    
-
-    <span class="coldline">**SY ACD** -> **SY TCU**</span>: "TEK, requesting clearance for YSHL via CUL, A025"  
-    <span class="coldline">**SY TCU** -> **SY ACD**</span>: "TEK, cleared to YSHL via CUL, A025"  
-    <span class="coldline">**SY ACD** -> **SY TCU**</span>: "Cleared to YSHL via CUL, A025, TEK"   
-
-    **SY ACD:** "TEK, cleared to YSHL via CUL, climb A025, squawk 0552, departure frequency 123.0"  
-    **TEK:** "Cleared to YSHL via CUL, climb A025, squawk 0552, departure frequency 123.0, TEK"  
+- VFR departures, other than helicopters assigned a helicopter route coded clearance  
+- Aircraft using a runway not on the ATIS

--- a/docs/aerodromes/classc/Tindal.md
+++ b/docs/aerodromes/classc/Tindal.md
@@ -80,14 +80,13 @@ The intial point is at A020 on the extended centerline of Taxiway Alpha at 6.5NM
 
 ## Coordination
 ### TN TCU
-'Next' coordination is required from TN ADC to TN TCU for all aircraft.
+[Next](../../controller-skills/coordination.md#next) coordination is required from TN ADC to TN TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**TN ADC** -> **TN TCU**</span>: "Next, ASY01, runway 32"  
-    <span class="hotline">**TN TCU** -> **TN ADC**</span>: "ASY01, Heading 030, unrestricted"  
-    <span class="hotline">**TN ADC** -> **TN TCU**</span>: "Heading 030, ASY01"  
+The Standard Assignable level from TN ADC to TN TCU is:
 
-The Standard Assignable level from TN ADC to TN TCU is the lower of `F180` or the `RFL`.
+| Aircraft | Level |
+| ----- | ---- |
+| All | The lower of `F180` and `RFL` |
 
 ### TRT(TRS)
 When TN TCU is offline, coordination is not required between TN ADC and TRT(TRS). Aircraft entering TRT(TRS) airspace shall be handed off, and instructed to contact TRT(TRS) for onwards clearance.

--- a/docs/aerodromes/classc/Townsville.md
+++ b/docs/aerodromes/classc/Townsville.md
@@ -50,14 +50,14 @@ Procedures relating to Helicopters can be found in the Airforce AIP AD2 SUPPS Se
 
 ## Coordination
 ### Auto Release  
-'Next' coordination is **not** required from TL ADC to TL TCU for aircraft that are:  
-a) Departing from a runway nominated in the ATIS; and  
-b) Assigned the standard assignable level;  
-c) Assigned a **Procedural** SID  
+[Next](../../controller-skills/coordination.md#next) coordination is **not** required from TL ADC to TL TCU for aircraft that are:  
 
-!!! phraseology
-    <span class="hotline">**TL ADC** -> **TL TCU**</span>: "Next, DNGO05, runway 19"  
-    <span class="hotline">**TL TCU** -> **TL ADC**</span>: "DNGO05, Assigned Heading Left 150, unrestricted"  
-    <span class="hotline">**TL ADC** -> **TL TCU**</span>: "Assigned Heading Left 150, DNGO05"  
+- Departing from a runway nominated in the ATIS; and  
+- Assigned the standard assignable level; and 
+- Assigned a **Procedural** SID 
 
-The Standard Assignable level from TL ADC to TL TCU is the lower of `F180` or the RFL.
+The Standard Assignable level from TL ADC to TL TCU is:
+
+| Aircraft | Level |
+| ------ | ------- |
+| All | The lower of `F180` and `RFL` |

--- a/docs/aerodromes/classc/Williamtown.md
+++ b/docs/aerodromes/classc/Williamtown.md
@@ -27,17 +27,17 @@ WLM ADC owns the airspace within the WLM MIL CTR A (`SFC`-`A050`). This may be a
 
 ## Coordination
 ### Departures
-'Next' coordination is **not** required from WLM ADC to WLM TCU for aircraft that are:  
-a) Departing from a runway nominated in the ATIS; and  
-b) Assigned the standard assignable level;  
-c) Assigned a **Procedural** SID  
+[Next](../../controller-skills/coordination.md#next) coordination is **not** required from WLM ADC to WLM TCU for aircraft that are:  
 
-!!! phraseology
-    <span class="hotline">**WLM ADC** -> **WLM TCU**</span>: "Next, MVP"  
-    <span class="hotline">**WLM TCU** -> **WLM ADC**</span>: "MVP, Left Heading 010, Unrestricted"  
-    <span class="hotline">**WLM ADC** -> **WLM TCU**</span>: "Left Heading 010, MVP"  
+- Departing from a runway nominated in the ATIS; and  
+- Assigned the standard assignable level; and 
+- Assigned a **Procedural** SID
 
-The Standard Assignable level from WLM ADC to WLM TCU is the lower of `F120` or the `RFL`.
+The Standard Assignable level from WLM ADC to WLM TCU is:
+
+| Aircraft | Level |
+| ------- | ----- |
+| All | The lower of `F120` and `RFL` |
 
 ### Arrivals/Overfliers
 Voiceless coordination is in place from WLM TCU to WLM ADC for arrivals cleared for an approach on to a runway nominated on the ATIS. All other aircraft and all overfliers must be heads-up coordinated as soon as practical.

--- a/docs/aerodromes/classd/Archerfield.md
+++ b/docs/aerodromes/classd/Archerfield.md
@@ -87,16 +87,14 @@ The APCH field should include `EXP INST APCH` when:
   - visibility is less than 5000m  
 
 ## Coordination
-
 ### Departures
-When aircraft planned via a CTA departure are ready for takeoff and expected to depart imminently, **AF ADC** shall seek release of the aircraft through a 'Next' call.
+[Next](../../controller-skills/coordination.md#next) coordination is required from AF ADC to BN TCU for all aircraft **entering BN TCU CTA**.
 
-!!! phraseology
-    <span class="hotline">**AF ADC** -> **BN TCU**</span>: "Next, XMM, Runway 10L"  
-    <span class="hotline">**BN TCU** -> **AF ADC**</span>: "XMM, Unrestricted"  
-    <span class="hotline">**AF ADC** -> **BN TCU**</span>: "XMM"
+The Standard Assignable level from **AF ADC** to **BN TCU** is:
 
-The Standard Assignable level from AF ADC to BN TCU is the lower of `A040` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ------- | ----- |
+| All | The lower of `A040` and `RFL` |
 
 ### Arrivals/Overfliers
 BN TCU will heads-up coordinate arrivals/overfliers from Class C to AF ADC.  

--- a/docs/aerodromes/classd/Avalon.md
+++ b/docs/aerodromes/classd/Avalon.md
@@ -30,19 +30,19 @@ All other IFR aircraft shall be assigned the **Radar SID**.
 ## Coordination
 ### ML TCU
 #### Departures
-'Next' coordination is **not** required to ML TCU for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a **Procedural** SID
+[Next](../../controller-skills/coordination.md#next) coordination is **not** required to ML TCU for aircraft that are:  
+
+- Departing from a runway nominated on the ATIS; and  
+- Assigned the standard assignable level; and  
+- Assigned a **Procedural** SID
 
 All other aircraft require a 'Next' call to ML TCU.
 
-!!! phraseology
-    <span class="hotline">**AV ADC** -> **MAV**</span>: "Next, UJI, Runway 18"  
-    <span class="hotline">**MAV** -> **AV ADC**</span>: "UJI, heading 030, unrestricted"  
-    <span class="hotline">**AV ADC** -> **MAV**</span>: "Heading 030, UJI"
+The Standard Assignable level from **AV ADC** to **ML TCU** is:
 
-The Standard Assignable level from AV ADC to ML TCU is the lower of `A040` or the `RFL`.
+| Aircraft | Level |
+| ----- | -------| 
+| All | The lower of `A040` and `RFL` |
 
 #### Runway Change
 Any Runway change must be prior coordinated to the relevant [TCU Controller](#tcu-controller).

--- a/docs/aerodromes/classd/Bankstown.md
+++ b/docs/aerodromes/classd/Bankstown.md
@@ -116,16 +116,14 @@ When the crosswind component exceeds 15 knots, the OPR INFO field must include:
 `CROSSWIND ALERT – DO NOT PASS THROUGH FINAL FOR YOUR ASSIGNED RUNWAY`
 
 ## Coordination
-
 ### Departures
-When the aircraft is ready for departure, Tower will coordinate with the relevant Class C sector above them for permission to release the aircraft into their CTA.
+[Next](../../controller-skills/coordination.md#next) coordination is required from BK ADC to SY TCU for all aircraft **entering SY TCU CTA**.
 
-The Standard Assignable level from BK ADC to SY TCU is `A030`, any other level must be prior coordinated.
+The Standard Assignable level from **BK ADC** to **SY TCU** is:
 
-!!! phraseology
-    <span class="hotline">**BK ADC** -> **SY TCU**</span>: "Next, UJN, runway 29C"  
-    <span class="hotline">**SY TCU** -> **BK ADC**</span>: "UJN, unrestricted"  
-    <span class="hotline">**BK ADC** -> **SY TCU**</span>: "UJN"
+| Aircraft | Level |
+| --- | -----|
+| All | `A030` |
 
 Aircraft shall be instructed to contact SY TCU passing `A015`.
 

--- a/docs/aerodromes/classd/Camden.md
+++ b/docs/aerodromes/classd/Camden.md
@@ -107,8 +107,8 @@ CN ADC must advise SY TCU when the aircraft has called 'Ready'. In response to a
     **CN ADC:** "MHQ, contact Sydney Centre on 124.55"  
 
 !!! note
-    Note: Because aircraft enter Class G after departure, an airways clearance need not be issued by CN ADC. This will be done on first contact with Sydney TCU.
-    Therefore, a *next* call & *departure instructions* are not required. You must however, pass the above (ready) coordination & obtain a traffic statement.
+    Note: Because aircraft enter Class G after departure, an airways clearance should not be issued by CN ADC. This will be done on first contact with Sydney TCU.
+    Therefore, *departure instructions* are not required. You must however, pass the above (ready) coordination & obtain a traffic statement.
 
 ### Arrivals/Overfliers
 SY TCU will coordinate inbound IFR aircraft. CN ADC is responsible for issuing a clearance into the CN CTR and for coordination with SY TCU in the event of a missed approach (or on completion of airwork if applicable).

--- a/docs/aerodromes/classd/Hobart.md
+++ b/docs/aerodromes/classd/Hobart.md
@@ -48,6 +48,9 @@ All IFR aircraft departing Cambridge shall be assigned a **Visual Departure** or
     **NDR:** "Hobart Ground, NDR, for Devonport, request clearance"  
     **HB SMC:** "NDR, cleared to Devonport via KANLI flight plan route, KANLI3 departure, climb via SID A045, squawk 4432"
 
+!!! warning "Important"
+    As the assigned SID is applicable to a different departure aerodrome, it will not auto-populate in vatSys. HB SMC must write the name of the SID in the Global Ops Field of the FDR and amend the flight plan route to include all relevant tracking points.
+
 When ready to taxi and prior to leaving the apron aircraft must contact **HB ADC**, advising intended runway for departure and receipt of YMHB ATIS, to obtain traffic information.
 
 !!! phraseology
@@ -125,35 +128,30 @@ Clearances for aircraft entering the CTR must be worded so as to leave no possib
 
 ## Coordination
 ### Departures
-'Next' coordination is **not** required to HBA for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a SID; or  
-  d) Not entering HBA CTA
+[Next](../../controller-skills/coordination.md#next) coordination is **not** required to HBA for aircraft that are:   
+
+- Departing from a runway nominated on the ATIS; and  
+- Assigned the standard assignable level; and  
+- Assigned a SID; or  
+- Not entering HBA CTA
 
 All other aircraft require a 'Next' call to HBA.
-
-!!! phraseology
-    <span class="hotline">**HB ADC** -> **HBA**</span>: "Next, ABC, runway 12"  
-    <span class="hotline">**HBA** -> **HB ADC**</span>: "ABC, Heading 150 Visual, unrestricted"  
-    <span class="hotline">**HB ADC** -> **HBA**</span>: "Heading 150 Visual, ABC"  
-
-    **HB ADC**: "ABC, Assigned heading right 150 Visual, Runway 12, Cleared for Takeoff"  
-    **ABC**: "Right heading 150 Visual, Runway 12, Cleared for Takeoff, ABC"
-
-The HBA controller can suspend/resume Auto Release at any time, with the concurrence of **HB ADC**.
 
 !!! note
     All departures from YCBG who will enter the HBA CTA must be Next coordinated by ADC.
 
-The Standard Assignable level from HB ADC to HBA is:  
-For IFR Aircraft: `A080`  
-For VFR Aircraft: The lower of `A045` or the `RFL`.
+The Standard Assignable level from **HB ADC** to **HBA** is:  
+
+| Flight Rules | Level |
+| ----- | ----- |
+| IFR | `A080` |
+| VFR | The lower of `A045` and `RFL` |
 
 #### Airways Clearance
-**HB SMC** shall give heads-up coordination to HBA controller prior to the issue of the following clearances:  
-a) VFR Departures  
-b) Aircraft using a runway not on the ATIS
+**HB SMC** shall give [heads-up](../../controller-skills/coordination.md#airways-clearance) coordination to HBA controller prior to the issue of the following clearances:
+
+- VFR departures entering HBA CTA
+- Aircraft using a runway not on the ATIS
 
 ### Arrivals/Overfliers
 HBA will heads-up coordinate arrivals/overfliers from Class C to HB ADC.  

--- a/docs/aerodromes/classd/Jandakot.md
+++ b/docs/aerodromes/classd/Jandakot.md
@@ -89,14 +89,13 @@ When PH RWY 03 is in operation, the ATIS should include:
 `DUE PERTH DUTY RUNWAY 03, CAUTION WAKE TURBULANCE`
 ## Coordination
 ### Next Call
-When the aircraft is ready for departure, JT ADC will coordinate with the relevant PH TCU controller above them for permission to release the aircraft into their CTA.
+[Next](../../controller-skills/coordination.md#next) coordination is required from JT ADC to PH TCU for all aircraft **entering PH TCU CTA**. 
 
-!!! phraseology
-    <span class="hotline">**JT ADC** -> **PH TCU**</span>: "Next, FD420, runway 24R"  
-    <span class="hotline">**PH TCU** -> **JT ADC**</span>: "FD420, Unrestricted"  
-    <span class="hotline">**JT ADC** -> **PH TCU**</span>: "FD420"  
+The Standard Assignable level from **JT ADC** to **PH TCU** is:
 
-The Standard Assignable level from JT ADC to PH TCU is the lower of `A030` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ------ | ----- |
+| All | The lower of `A030` and `RFL` |
 
 ### Arrivals/Overfliers
 PH TCU will heads-up coordinate arrivals/overfliers from Class C to JT ADC.  

--- a/docs/aerodromes/classd/Launceston.md
+++ b/docs/aerodromes/classd/Launceston.md
@@ -46,31 +46,26 @@ YMLT ATIS identifiers range from `A` to `M`, as YMHB uses `N` through `Y`.
 
 ## Coordination
 ### Departures
-'Next' coordination is not required to LTA for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a SID; or  
-  d) Not entering LTA CTA
+[Next](../../controller-skills/coordination.md#next) coordination is not required to LTA for aircraft that are:   
 
-All other aircraft require a 'Next' call to LTA.
+- Departing from a runway nominated on the ATIS; and  
+-Assigned the standard assignable level; and  
+-Assigned a SID; or  
+-Not entering LTA CTA
 
-!!! phraseology
-    <span class="hotline">**LT ADC** -> **LTA**</span>: "Next, ABC, runway 14L"  
-    <span class="hotline">**LTA** -> **LT ADC**</span>: "ABC, Heading 150 Visual, unrestricted"  
-    <span class="hotline">**LT ADC** -> **LTA**</span>: "Heading 150 Visual, ABC"   
+All other aircraft require a 'Next' call to LTA. 
 
-    **LT ADC**: "ABC, turn right heading 150 Visual, Runway 14L, Cleared for Takeoff"  
-    **ABC**: "Right heading 150 Visual, Runway 12, Cleared for Takeoff, ABC"
+The Standard Assignable level from **LT ADC** to **LTA** is:  
 
-The LTA controller can suspend/resume Auto Release at any time, with the concurrence of **LT ADC**.
+| Flight Rules | Level |
+| ------- | ------ |
+| IFR | `A080` |
+| VFR | The lower of `A045` and `RFL` |
 
-LT ADC shall give heads-up coordination to LTA controller prior to the issue of the following clearances:  
-a) VFR Departures  
-b) Aircraft using a runway not on the ATIS  
+LT ADC shall give [heads-up](../../controller-skills/coordination.md#airways-clearance) coordination to LTA controller prior to the issue of the following clearances:  
 
-The Standard Assignable level from LT ADC to LTA is:  
-For IFR Aircraft: `A080`  
-For VFR Aircraft: The lower of `A045` or the `RFL`.
+- VFR departures entering LTA CTA
+- Aircraft using a runway not on the ATIS 
 
 ### Arrivals/Overfliers
 LTA will heads-up coordinate arrivals/overfliers from LTA CTA to LT ADC.  

--- a/docs/aerodromes/classd/Mackay.md
+++ b/docs/aerodromes/classd/Mackay.md
@@ -24,6 +24,7 @@ Refer to [Class D Tower Separation Standards](../../../separation-standards/clas
 ### Departures
 #### Auto Release
 [Next](../../controller-skills/coordination.md#next) coordination is **not** required to MKA for aircraft that are:   
+
 - Departing from a runway nominated on the ATIS; and  
 - Assigned the standard assignable level; and  
 - Assigned a **Procedural** SID; or  

--- a/docs/aerodromes/classd/Mackay.md
+++ b/docs/aerodromes/classd/Mackay.md
@@ -23,25 +23,22 @@ Refer to [Class D Tower Separation Standards](../../../separation-standards/clas
 ## Coordination
 ### Departures
 #### Auto Release
-'Next' coordination is **not** required to MKA for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a **Procedural** SID; or  
-  d) Not entering MKA CTA
+[Next](../../controller-skills/coordination.md#next) coordination is **not** required to MKA for aircraft that are:   
+- Departing from a runway nominated on the ATIS; and  
+- Assigned the standard assignable level; and  
+- Assigned a **Procedural** SID; or  
+- Not entering MKA CTA
 
-!!! phraseology
-    <span class="hotline">**MK ADC** -> **MKA**</span>: "Next, ABC, runway 14"  
-    <span class="hotline">**MKA** -> **MK ADC**</span>: "ABC, Heading 150 Visual, unrestricted"  
-    <span class="hotline">**MK ADC** -> **MKA**</span>: "Heading 150 Visual unrestricted, ABC"
+The Standard Assignable level from **MK ADC** to **MKA** is:
 
-The TCU controller can suspend/resume Auto Release at any time, with the concurrence of **MKA**.
-
-The Standard Assignable level from MKADC to MKA is the lower of `A060` or the `RFL`.
+| Aircraft | Level |
+| ------ | ----- |
+| All | The lower of `A060` and `RFL` |
 
 #### SMC
-The controller assuming responsibility of **SMC** shall give heads-up coordination to **MKA** prior to the issue of the following clearances:  
+The controller assuming responsibility of **SMC** shall give [heads-up](../../controller-skills/coordination.md#airways-clearance) coordination to **MKA** prior to the issue of the following clearances:  
 
-- VFR Departures  
+- VFR departures entering MKA CTA
 - Aircraft using a runway not on the ATIS
 
 ### Arrivals/Overfliers

--- a/docs/aerodromes/classd/Moorabbin.md
+++ b/docs/aerodromes/classd/Moorabbin.md
@@ -125,13 +125,13 @@ Night operations must comply with fixed wing operations.
 
 ## Coordination
 ### Departures
-When the aircraft is ready for departure, MB ADC will coordinate with the relevant ML TCU controller above them for permission to release the aircraft into their CTA.
+[Next](../../controller-skills/coordination.md#next) coordination is required from MB ADC to ML TCU for all aircraft **entering ML TCU CTA**.
 
-!!! phraseology
-    <span class="hotline">**MB ADC** -> **MDS**</span>: "Next, SGE"  
-    <span class="hotline">**MDS** -> **MB ADC**</span>: "SGE, unrestricted"
+The Standard Assignable level from **MB ADC** to **ML TCU** is:
 
-The Standard Assignable level from MB ADC to ML TCU is the lower of `A050` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ----- | ---- |
+| All | The lower of `A050` and `RFL` |
 
 Aircraft who will transit Class G airspace on climb into CTA must be **cleared to leave and re-enter controlled airspace** on climb to their assigned level.
 

--- a/docs/aerodromes/classd/Parafield.md
+++ b/docs/aerodromes/classd/Parafield.md
@@ -62,14 +62,14 @@ The APCH field should include `EXP INST APCH` when:
 
 ## Coordination
 ### Departures
-When the aircraft is ready for departure, PF ADC will coordinate with the relevant Class C sector above them for permission to release the aircraft into their CTA.
+[Next](../../controller-skills/coordination.md#next) coordination is required from PF ADC to AD TCU for all aircraft **entering AD TCU CTA**.
 
-!!! phraseology
-    <span class="hotline">**PF ADC** -> **AAW**</span>: "Next, XMM, 03L"  
-    <span class="hotline">**AAW** -> **PF ADC**</span>: "XMM, Heading 020, unrestricted"  
-    <span class="hotline">**PF ADC** -> **AAW**</span>: "Heading 020, XMM"
+The Standard Assignable level from **PF ADC** to **AD TCU** is:
 
-The Standard Assignable level from PF ADC to AD TCU is the lower of `A030` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ----- | ---- |
+| All | The lower of `A030` and `RFL` |
+
 ### Arrivals
 AD TCU will heads-up coordinate arrivals/overfliers from Class C to PF ADC.  
 IFR aircraft will be cleared for the coordinated approach (Instrument or Visual) prior to handoff to PF ADC, unless PF ADC nominates a restriction.  

--- a/docs/aerodromes/classd/Rockhampton.md
+++ b/docs/aerodromes/classd/Rockhampton.md
@@ -40,7 +40,7 @@ The Standard Assignable level from **MK/RK ADC** to **MKA/RKA** is:
 #### MK/RK SMC
 The controller assuming responsibility of **SMC** shall give heads-up coordination to **RKA** controller prior to the issue of the following clearances:  
 
-- VFR Departures  
+- VFR departures entering RKA CTA
 - Aircraft using a runway not on the ATIS
 
 ### Arrivals/Overfliers

--- a/docs/aerodromes/classd/Rockhampton.md
+++ b/docs/aerodromes/classd/Rockhampton.md
@@ -24,20 +24,18 @@ Refer to [Class D Tower Separation Standards](../../../separation-standards/clas
 ## Coordination
 ### Departures
 #### Auto Release
-'Next' coordination is **not** required to **RKA** for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a **Procedural** SID; or  
-  d) Not entering RKA CTA
+[Next](../../controller-skills/coordination.md#next) coordination is **not** required to **RKA** for aircraft that are: 
 
-!!! phraseology
-    <span class="hotline">**RK ADC** -> **RKA**</span>: "Next, VJE"  
-    <span class="hotline">**RKA** -> **RK ADC**</span>: "VJE, Track Extended Centreline, Unrestricted"  
-    <span class="hotline">**RK ADC** -> **RKA**</span>: "Track Extended Centreline, VJE"
+- Departing from a runway nominated on the ATIS; and  
+- Assigned the standard assignable level; and  
+- Assigned a **Procedural** SID; or  
+- Not entering RKA CTA
 
-The TCU controller can suspend/resume Auto Release at any time, with the concurrence of **RKA**.
+The Standard Assignable level from **MK/RK ADC** to **MKA/RKA** is:
 
-The Standard Assignable level from MK/RK ADC to MKA/RKA is the lower of `A060` or the `RFL`.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A060` and `RFL` |
 
 #### MK/RK SMC
 The controller assuming responsibility of **SMC** shall give heads-up coordination to **RKA** controller prior to the issue of the following clearances:  

--- a/docs/aerodromes/procedural/Albury.md
+++ b/docs/aerodromes/procedural/Albury.md
@@ -41,14 +41,13 @@ The **Hume Highway** is a good reference for this standard.
 
 ## Coordination
 ### Departures
-A 'Next' call is made for all aircraft entering ELW(BLA) CTA when they are next to depart. AY ADC must inform ELW(BLA) if the aircraft does not depart within **2 minutes** of the next call.
+[Next](../../controller-skills/coordination.md#next) coordination is required from AY ADC to BLA for all aircraft **entering BLA CTA**.
 
-!!! phraseology
-    <span class="hotline">**AY ADC** -> **BLA**</span>: "Next, AM324"  
-    <span class="hotline">**BLA** -> **AY ADC**</span>: "AM324, Unrestricted"  
-    <span class="hotline">**AY ADC** -> **BLA**</span>: "AM324"
+The Standard Assignable level from **AY ADC** to **BLA** is:
 
-The Standard Assignable level from AY TWR to ELW(BLA) is the lower of `A070` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A070` and `RFL` |
 
 ### Arrivals/Overfliers
 ELW(BLA) will heads-up coordinate all arrivals/overfliers to AY ADC

--- a/docs/aerodromes/procedural/Alice.md
+++ b/docs/aerodromes/procedural/Alice.md
@@ -25,14 +25,13 @@ Surveillance coverage can be expected to be available at all levels in the AS CT
 
 ## Coordination
 ### Departures
-Departures from YBAS in to ASP Class C will be coordinated when ready for departure.
+[Next](../../controller-skills/coordination.md#next) coordination is required from AS ADC to ASP for all aircraft **entering ASP CTA**.
 
-!!! phraseology
-    <span class="hotline">**AS ADC** -> **ASP**</span>: "Next, QFA797"  
-    <span class="hotline">**ASP** -> **AS ADC**</span>: "QFA797, Unrestricted"  
-    <span class="hotline">**AS ADC** -> **ASP**</span>: "QFA797"
+The Standard Assignable level from **AS ADC** to **ASP** is:
 
-The Standard Assignable level from AS ADC to ASP is the lower of `A070` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A070` and `RFL` |
 
 ### Arrivals/Overfliers
 ASP will heads-up coordinate all arrivals/overfliers to AS ADC

--- a/docs/aerodromes/procedural/Broome.md
+++ b/docs/aerodromes/procedural/Broome.md
@@ -41,14 +41,13 @@ The **coastline** is a good reference for this standard.
 
 ## Coordination
 ### Departures
-A 'next' call is made for all aircraft entering TRT(ASH) CTA when they are next to depart. BRM ADC must inform TRT(ASH) if the aircraft does not depart within **2 minutes** of the next call.
+[Next](../../controller-skills/coordination.md#next) coordination is required from BRM ADC to TRT(ASH) for all aircraft **entering TRT(ASH) CTA**.
 
-!!! phraseology
-    <span class="hotline">**BRM ADC** -> **ASH**</span>: "Next, NWK1653"  
-    <span class="hotline">**ASH** -> **BRM ADC**</span>: "NWK1653, Unrestricted"  
-    <span class="hotline">**BRM ADC** -> **ASH**</span>: "NWK1653"
+The Standard Assignable level from **BRM ADC** to **TRT(ASH)** is:
 
-The Standard Assignable level from BRM ADC to TRT(ASH) is the lower of `A050` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A050` and `RFL` |
 
 ### Arrivals/Overfliers
 TRT(ASH) will heads-up coordinate all arrivals/overfliers to BRM ADC

--- a/docs/aerodromes/procedural/Coffs.md
+++ b/docs/aerodromes/procedural/Coffs.md
@@ -43,14 +43,13 @@ The **coastline** is a good reference for this standard. Due to high terrain clo
 
 ## Coordination
 ### Departures
-A 'next' call is made for all aircraft entering INL/ARL(MNN) CTA when they are next to depart. CFS ADC must inform INL/ARL(MNN) if the aircraft does not depart within **2 minutes** of the next call.
+[Next](../../controller-skills/coordination.md#next) coordination is required from CFS ADC to INL/ARL(MNN) for all aircraft **entering INL/ARL(MNN) CTA**.
 
-!!! phraseology
-    <span class="hotline">**CFS ADC** -> **MNN**</span>: "Next, QJE1573"  
-    <span class="hotline">**MNN** -> **CFS ADC**</span>: "QJE1573, Unrestricted"  
-    <span class="hotline">**CFS ADC** -> **MNN**</span>: "QJE1573"
+The Standard Assignable level from **CFS ADC** to **INL/ARL(MNN)** is:
 
-The Standard Assignable level from CFS ADC to INL/ARL(MNN) is the lower of `A070` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A070` and `RFL` |
 
 ### Arrivals/Overfliers
 INL/ARL(MNN) will heads-up coordinate all arrivals/overfliers to CFS ADC.

--- a/docs/aerodromes/procedural/Hammo.md
+++ b/docs/aerodromes/procedural/Hammo.md
@@ -27,14 +27,13 @@ Surveillance coverage can be expected to be not available below `A031` in the HM
 
 ## Coordination
 ### Departures
-A 'next' call is made for all aircraft entering KEN(SWY) CTA when they are next to depart. HM ADC must inform KEN(SWY) if the aircraft does not depart within **2 minutes** of the next call.
+[Next](../../controller-skills/coordination.md#next) coordination is required from HM ADC to KEN(SWY) for all aircraft **entering KEN(SWY) CTA**.
 
-!!! phraseology
-    <span class="hotline">**HM ADC** -> **SWY**</span>: "Next, QFA797"  
-    <span class="hotline">**SWY** -> **HM ADC**</span>: "QFA797, Unrestricted"  
-    <span class="hotline">**HM ADC** -> **SWY**</span>: "QFA797"
+The Standard Assignable level from **HM ADC** to **KEN(SWY)** is:
 
-The Standard Assignable level from HM ADC to KEN(SWY) is the lower of `A050` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A050` and `RFL` |
 
 ### Arrivals/Overfliers
 KEN(SWY) will heads-up coordinate all arrivals/overfliers to HM ADC

--- a/docs/aerodromes/procedural/Hammo.md
+++ b/docs/aerodromes/procedural/Hammo.md
@@ -39,7 +39,7 @@ The Standard Assignable level from **HM ADC** to **KEN(SWY)** is:
 KEN(SWY) will heads-up coordinate all arrivals/overfliers to HM ADC
 
 !!! phraseology
-    <span class="hotline">**SWY** -> **HM ADC**</span>: "Via OPOSI for the RNP-U RWY 32, JST848”  
-    <span class="hotline">**HM ADC** -> **SWY**</span>: "JST848"  
+    <span class="hotline">**SWY** -> **HM ADC**</span>: "Via OPOSI for the RNP-U, JST848”  
+    <span class="hotline">**HM ADC** -> **SWY**</span>: "JST848, A060"  
 
 The Standard Assignable level from KEN(SWY) to HM ADC is `A060`, any other level must be prior coordinated.

--- a/docs/aerodromes/procedural/Karratha.md
+++ b/docs/aerodromes/procedural/Karratha.md
@@ -35,14 +35,13 @@ Surveillance coverage can be expected to be available at all levels in the KA CT
 
 ## Coordination
 ### Departures
-A 'next' call is made for all aircraft entering OLW CTA when they are next to depart. KA ADC must inform OLW if the aircraft does not depart within **2 minutes** of the next call.
+[Next](../../controller-skills/coordination.md#next) coordination is required from KA ADC to OLW for all aircraft **entering OLW CTA**.
 
-!!! phraseology
-    <span class="hotline">**KA ADC** -> **OLW**</span>: "Next, NWK694"  
-    <span class="hotline">**OLW** -> **KA ADC**</span>: "NWK694, Unrestricted"  
-    <span class="hotline">**KA ADC** -> **OLW**</span>: "NWK694"
+The Standard Assignable level from **KA ADC** to **OLW** is:
 
-The Standard Assignable level from KA ADC to OLW is the lower of `A050` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A050` and `RFL` |
 
 ### Arrivals/Overfliers
 OLW will heads-up coordinate all arrivals/overfliers to KA ADC

--- a/docs/aerodromes/procedural/Sunshinecoast.md
+++ b/docs/aerodromes/procedural/Sunshinecoast.md
@@ -51,14 +51,13 @@ All other aircraft may be assigned a visual departure, or a standard IFR departu
 
 ## Coordination
 ### Departures
-A 'next' call is made for all aircraft entering INL(NSA/BUR) CTA when they are next to depart. SU ADC must inform INL(NSA/BUR) if the aircraft does not depart within **2 minutes** of the next call.
+[Next](../../controller-skills/coordination.md#next) coordination is required from SU ADC to INL(NSA/BUR) for all aircraft **entering INL(NSA/BUR) CTA**.
 
-!!! phraseology
-    <span class="hotline">**SU ADC** -> **NSA**</span>: "Next, BNZ133, runway 31"  
-    <span class="hotline">**NSA** -> **SU ADC**</span>: "BNZ133, unrestricted"  
-    <span class="hotline">**SU ADC** -> **NSA**</span>: "BNZ133"
+The Standard Assignable level from **SU ADC** to **INL(NSA/BUR)** is:
 
-The Standard Assignable level from SU ADC to INL(NSA/BUR) is the lower of `A040` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A040` and `RFL` |
 
 Where operationally possible, INL(NSA/BUR) will assign a higher level to high performance aircraft during next coordination. This level assignment should be communicated to the aircraft during the takeoff clearance or when they provide a departure report after takeoff.
 

--- a/docs/aerodromes/procedural/Tamworth.md
+++ b/docs/aerodromes/procedural/Tamworth.md
@@ -85,14 +85,13 @@ When parallel runway operations are in use, the ATIS OPR INFO field shall includ
 
 ## Coordination
 ### Departures
-A 'next' call is made for all aircraft entering ARL/MDE CTA when they are next to depart. TW ADC must inform ARL/MDE if the aircraft does not depart within **2 minutes** of the next call.
+[Next](../../controller-skills/coordination.md#next) coordination is required from TW ADC to ARL/MDE for all aircraft **entering ARL/MDE CTA**.
 
-!!! phraseology
-    <span class="hotline">**TW ADC** -> **ARL**</span>: "Next, QLK5D"  
-    <span class="hotline">**ARL** -> **TW ADC**</span>: "QLK5D, Unrestricted"  
-    <span class="hotline">**TW ADC** -> **ARL**</span>: "QLK5D"
+The Standard Assignable level from **TW ADC** to **ARL/MDE** is:
 
-The Standard Assignable level from TW ADC to ARL/MDE is the lower of `A070` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A070` and `RFL` |
 
 ### Arrivals/Overfliers
 ARL/MDE will heads-up coordinate all arrivals/overfliers to TW ADC

--- a/docs/controller-skills/coordination.md
+++ b/docs/controller-skills/coordination.md
@@ -4,7 +4,7 @@ title: Coordination
 
 --8<-- "includes/abbreviations.md"
 
-Coordination is an underutilised tool in VATPAC airspace, primarily due to how difficult it was to do it back in the Euroscope and VRC days. Now, (almost) all controllers are using vatSys, and voice coordination can be done in seconds with the touch of a button, using the Hotlines and Coldlines. Coordination helps controllers stay aware of aircraft that are about to enter their jurisdiction, and ensure they will operate in a predictable manner, which allows for easier planning of sequencing and separation.
+Coordination is an underutilised tool in VATPAC airspace, primarily due to how difficult it was to do it back in the Euroscope and VRC days. Now, all controllers are using vatSys and voice coordination can be done in seconds with the touch of a button. Coordination helps controllers stay aware of aircraft that are about to enter their jurisdiction and ensure they will operate in a predictable manner, which allows for easier planning of sequencing and separation.
 
 Coordination requirements are often very location-specific, however this page outlines the general guidelines to coordination, which are supplemented by Local Instructions.
 
@@ -23,7 +23,8 @@ Coordination notes are included for most positions, using the following format:
     `Hotline`:  <span class="hotline">**ORIGINATING SECTOR** -> **RECEIVING SECTOR**</span>: "Message"  
     `Coldline`:  <span class="coldline">**ORIGINATING SECTOR** -> **RECEIVING SECTOR**</span>: "Message"  
 
-As a receiving controller, answer a coordination call by stating the name of **your** position.  If you are busy at the time, finish your current radio call and then state your position to indicate that you are ready to receive the message.
+## General Phraseology
+As a receiving controller, answer a coordination call by stating the name of **your** position.
 
 !!! phraseology
     *BIK calls SAN with a hotline to discuss an arrival*  
@@ -32,15 +33,36 @@ As a receiving controller, answer a coordination call by stating the name of **y
     <span class="hotline">**BIK** -> **SAN**</span>: "Via RIVET, QFA541, request heading 030 due weather"  
     <span class="hotline">**SAN** -> **BIK**</span>: "QFA541, Concur heading 030"
 
-!!! tip
-    Remember that coordination items must be read back in the same way a pilot must read back an instruction from ATC.
+If you are busy at the time, tell the other controller to *standby*. If you anticipate a long delay, tell the controller that you'll call them back.
+
+!!! phraseology
+    *ELW calls MAE with a hotline but MAE is awaiting a readback from an aircraft*  
+    <span class="hotline">**ELW** -> **MAE**</span>: \***DING**\*  
+    <span class="hotline">**MAE** -> **ELW**</span>: "Standby"  
+    *When MAE is ready*  
+    <span class="hotline">**MAE** -> **ELW**</span>: "Go ahead, Centre"  
+
+Each controller must verbalise the instruction, clearance, or change once. Generally, with one controller requesting a change, the approving controller will confirm it, completing the conversation.
+
+!!! phraseology
+    <span class="hotline">**ELW** -> **MAE**</span>: "Via LIZZI, JST414, assigned FL120 for my separation with VOZ92"  
+    <span class="hotline">**MAE** -> **ELW**</span>: "FL120, JST414"
+
+In situations where additional changes have been discussed (and as such, both controllers have not yet verbalised them), a readback is required.
+
+!!! phraseology
+    <span class="hotline">**CS ADC** -> **CS TCU**</span>: "Next, LKU, runway 15"  
+    <span class="hotline">**CS TCU** -> **CS ADC**</span>: "LKU, runway 15, left turn, unrestricted"  
+    <span class="hotline">**CS ADC** -> **CS TCU**</span>: "Left turn, LKU"
 
 ## Types of Coordination
 ### Heads-up
 Heads-up Coordination is the act of giving the next sector a "heads-up" about an aircraft about to enter their airspace. The format is as follows:
 
-Controlling Sector -> Receiving Sector: "(Position), (Callsign)"  
-Receiving Sector -> Controlling Sector: "(Callsign), (Level)"
+!!! note "" 
+    <span class="hotline">**Controlling Sector** -> **Receiving Sector**</span>: "(Position), (Callsign)"  
+    <span class="hotline">**Receiving Sector** -> **Controlling Sector**</span>: "(Callsign), (Level)"
+
 
 !!! phraseology
     <span class="hotline">**ELW** -> **BIK**</span>: "via CB, VOZ1234"  
@@ -69,8 +91,9 @@ Ie: Within:
 
 Boundary coordination must be completed so they are aware of the aircraft, and can nominate any restrictions. The format is as follows:
 
-Controlling Sector -> Boundary Sector: "For Ident, (Position), (Callsign), (Details as required)"  
-Boundary Sector -> Controlling Sector: "(Callsign), (Restriction)"
+!!! note "" 
+    <span class="hotline">**Controlling Sector** -> **Boundary Sector**</span>: "For Ident, (Position), (Callsign), (Details as required)"  
+    <span class="hotline">**Boundary Sector** -> **Controlling Sector**</span>: "(Callsign), (Restriction)"
 
 !!! phraseology
     <span class="hotline">**BIK** -> **CBE**</span>: "For Ident, overhead CB, QFA12, do you have any restrictions on descent?"  
@@ -81,6 +104,33 @@ The Boundary Sector may omit the restriction and readback the callsign only. Thi
 !!! phraseology
     <span class="hotline">**INL** -> **BAS**</span>: "For Ident, West of BLAKA, ABC"  
     <span class="hotline">**BAS** -> **INL**</span>: "ABC"
+
+### Next
+Next coordination is performed between ADC and TCU controllers to discuss the next aircraft to depart. As a general rule, all departing aircraft require Next coordination, unless stipulated by local SOPs through the use of autorelease.
+
+The format is as follows:
+
+!!! note "" 
+    <span class="hotline">**ADC** -> **TCU**</span>: "Next, (Callsign), (Runway)"  
+    <span class="hotline">**TCU** -> **ADC**</span>: "(Callsign), (Runway), (Lateral and/or Vertical Instructions)
+
+Aircraft assigned a procedural SID will generally not be issued with lateral instructions. Aircraft assigned a radar SID or visual departure must be provided with an assigned heading or other lateral departure instructions.
+
+An amended level may be instructed, or the term **unrestricted** used to indicate that no *additional* vertical restrictions apply. This permits the aircraft to climb to their cleared level (as issued with their airways clearance).
+
+!!! note
+    The term '*unrestricted*' is not a readback item.
+
+!!! phraseology
+    *LKU is conducting a visual departure from YBCS*  
+    <span class="hotline">**CS ADC** -> **CS TCU**</span>: "Next, LKU, runway 15"  
+    <span class="hotline">**CS TCU** -> **CS ADC**</span>: "LKU, runway 15, left turn, unrestricted"  
+    <span class="hotline">**CS ADC** -> **CS TCU**</span>: "Left turn, LKU"
+    
+    *QFA442 is assigned a procedural SID from YMML with autorelease cancelled*  
+    <span class="hotline">**ML ADC** -> **ML TCU**</span>: "Next, QFA442, runway 16"  
+    <span class="hotline">**ML TCU** -> **ML ADC**</span>: "QFA442, unrestricted"  
+
 
 ## The C-Prompt (Coordination Prompt)
 Display the "C-Prompt" when all coordination for an aircraft is complete, or voice coordination is not required for an aircraft (eg subject to voiceless coordination).

--- a/docs/controller-skills/coordination.md
+++ b/docs/controller-skills/coordination.md
@@ -55,7 +55,18 @@ In situations where additional changes have been discussed (and as such, both co
     <span class="hotline">**CS TCU** -> **CS ADC**</span>: "LKU, runway 15, left turn, unrestricted"  
     <span class="hotline">**CS ADC** -> **CS TCU**</span>: "Left turn, LKU"
 
+### Point-to-Point
+Coordination must be done on a **point-to-point** basis, meaning you can only coordinate with the sector which the aircraft is coming from, or going to, no skipping! 
+
+!!! example
+    You are controlling ELW and you would like to pass an amended route to someone on the ground at YMML. Whilst that may be no issue for ML SMC and ML ADC, it might not work for ML APP. ML APP would be the sector which the aircraft is coming from, so ELW must talk to them, and it is the responsibility of ML APP to work backwards down the line on a point-to-point basis.
+
+Ensure no coordination is ambiguous in its meaning. Not all coordination can be straight out of the phraseology books and the reality is, not everyone controlling the airspace is going to be 100% proficient and by the books. When using "plain english", ensure there is no ambiguity, and the message is fully understood by both parties.
+
 ## Types of Coordination
+### Voiceless
+Certain routes, areas, levels, airspace, etc, will have voiceless coordination agreements, which is where Heads-Up Coordination is not required. These routes may also have change parameters, where no changes are permitted within a certain distance of the sector boundary without prior coordination.
+
 ### Heads-up
 Heads-up Coordination is the act of giving the next sector a "heads-up" about an aircraft about to enter their airspace. The format is as follows:
 
@@ -65,29 +76,31 @@ Heads-up Coordination is the act of giving the next sector a "heads-up" about an
 
 
 !!! phraseology
-    <span class="hotline">**ELW** -> **BIK**</span>: "via CB, VOZ1234"  
-    <span class="hotline">**BIK** -> **ELW**</span>: "VOZ1234, F350"  
+    <span class="hotline">**SNO** -> **GUN**</span>: "Via CB, VOZ1531"  
+    <span class="hotline">**GUN** -> **SNO**</span>: "VOZ1531, F350"  
 
-If the level that will be assigned at transfer of jurisdiction is different from the current CFL, the Controlling Sector will use the phrase "Will be assigned (level)".
+If the level that will be assigned at transfer of jurisdiction is different from the current CFL, the Controlling Sector will use the phrase "*will be assigned (level)*".
 
-Once this coordination is completed, the aircraft's level and route is **locked in**. Any further changes must be recoordinated.
+If the Receiving Sector requires a change of level, they'll reply with the amended level.
 
 !!! phraseology
-    <span class="hotline">**ELW** -> **BIK**</span>: "VOZ1234, requesting DCT RIVET"  
-    <span class="hotline">**BIK** -> **ELW**</span>: "VOZ1234, concur DCT RIVET"  
+    <span class="hotline">**SNO** -> **GUN**</span>: "Via CB, VOZ1531"  
+    <span class="hotline">**GUN** -> **SNO**</span>: "VOZ1531, F330 due traffic"  
+    <span class="hotline">**SNO** -> **GUN**</span>: "F330, VOZ1531"
+
+Once this coordination is completed, the aircraft's level and route is **locked in**. Any further changes must be recoordinated. 
 
 !!! tip
     In situations where Heads-Up Coordination is required, the best time to do it is when the aircraft first calls you. There's no need to wait until half a mile before when its due, if you can get it done sooner.
 
-### Voiceless
-Certain routes, areas, levels, airspace, etc, will have voiceless coordination agreements, which is where Heads-Up Coordination is not required. These routes may also have change parameters, where no changes are permitted within a certain distance of the sector boundary without prior coordination.
-
 ### Boundary
 Boundary coordination is required when an aircraft may deviate within ***half the applicable standard*** of another sector's airspace.  
-Ie: Within:  
-**500ft** vertically; or  
-**2.5nm** laterally for **ENR**; or  
-**1.5nm** laterally for **TCU/ADC**.
+
+Ie: within:  
+
+- **500ft** vertically; or  
+- **2.5nm** laterally for **ENR**; or  
+- **1.5nm** laterally for **TCU/ADC**
 
 Boundary coordination must be completed so they are aware of the aircraft, and can nominate any restrictions. The format is as follows:
 
@@ -97,13 +110,13 @@ Boundary coordination must be completed so they are aware of the aircraft, and c
 
 !!! phraseology
     <span class="hotline">**BIK** -> **CBE**</span>: "For Ident, overhead CB, QFA12, do you have any restrictions on descent?"  
-    <span class="hotline">**CBE** -> **BIK**</span>: "QFA12, No restrictions on descent"  
+    <span class="hotline">**CBE** -> **BIK**</span>: "QFA12, no restrictions on descent"  
 
 The Boundary Sector may omit the restriction and readback the callsign only. This will be taken as the Boundary Sector having **no vertical or lateral restrictions**.
 
 !!! phraseology
-    <span class="hotline">**INL** -> **BAS**</span>: "For Ident, West of BLAKA, ABC"  
-    <span class="hotline">**BAS** -> **INL**</span>: "ABC"
+    <span class="hotline">**INL** -> **BAS**</span>: "For Ident, west of BLAKA, FD516"  
+    <span class="hotline">**BAS** -> **INL**</span>: "FD516"
 
 ### Next
 Next coordination is performed between ADC and TCU controllers to discuss the next aircraft to depart. As a general rule, all departing aircraft require Next coordination, unless stipulated by local SOPs through the use of autorelease.
@@ -112,7 +125,7 @@ The format is as follows:
 
 !!! note "" 
     <span class="hotline">**ADC** -> **TCU**</span>: "Next, (Callsign), (Runway)"  
-    <span class="hotline">**TCU** -> **ADC**</span>: "(Callsign), (Runway), (Lateral and/or Vertical Instructions)
+    <span class="hotline">**TCU** -> **ADC**</span>: "(Callsign), (Runway), (Lateral and/or Vertical Instructions)"
 
 Aircraft assigned a procedural SID will generally not be issued with lateral instructions. Aircraft assigned a radar SID or visual departure must be provided with an assigned heading or other lateral departure instructions.
 
@@ -131,9 +144,24 @@ An amended level may be instructed, or the term **unrestricted** used to indicat
     <span class="hotline">**ML ADC** -> **ML TCU**</span>: "Next, QFA442, runway 16"  
     <span class="hotline">**ML TCU** -> **ML ADC**</span>: "QFA442, unrestricted"  
 
+### Airways Clearance
+The local procedures of some aerodromes require ACD to coordinate with the TCU prior to issuing airways clearance to certain aircraft. This coordination allows the TCU controller to assess the current & projected traffic levels, and current position staffing, and determine whether clearance is available.
+
+The format is as follows:
+
+!!! note ""
+    <span class="hotline">**ACD** -> **TCU**</span>: "(Callsign) requests clearance to (Destination), (Any Other Relevant Details)"  
+    <span class="hotline">**TCU** -> **ACD**</span>: "(Callsign), clearance approved"
+
+!!! phraseology
+    <span class="hotline">**SY ACD** -> **SY TCU**</span>: "FD213 requests clearance to Bankstown"  
+    <span class="hotline">**SY TCU** -> **SY ACD**</span>: "FD213, clearance approved"
+
+If a change of level or tracking is required, the TCU controller shall provide this change during this exchange.
+
 
 ## The C-Prompt (Coordination Prompt)
-Display the "C-Prompt" when all coordination for an aircraft is complete, or voice coordination is not required for an aircraft (eg subject to voiceless coordination).
+Display the "C-Prompt" when all coordination for an aircraft is complete, or voice coordination is not required for an aircraft (ie. subject to voiceless coordination).
 
 The "C-Prompt" can be displayed by middle clicking the area just above the aircraft's callsign in the label.
 
@@ -145,7 +173,7 @@ The "C-Prompt" can be displayed by middle clicking the area just above the aircr
 Remove the "C-Prompt" once jurisdiction of the aircraft has been handed off, and the new frequency has been correctly read back.
 
 ## No Frequency Requirements (NFR)
-Occasionally, aircraft may clip small parts of a sector's airspace on their planned route. If an aircraft only enters someone's airspace for a small distance, there is usually no need for them to talk to that controller. In this instance, A controller may coordinate an aircraft to have "No Frequency Requirements" with another controller, or vice versa. This shall also be supplemented by the nomination of a restriction, or lack thereof. See below:
+Occasionally, aircraft may clip small parts of a sector's airspace on their planned route. If an aircraft only enters someone's airspace for a small distance, there is usually no need for them to talk to that controller. In this instance, a controller may coordinate an aircraft to have "No Frequency Requirements" with another controller, or vice versa. This shall also be supplemented by the nomination of a restriction, or lack thereof. See below:
 
 Source: [Annotations](../../controller-skills/annotations)
 
@@ -183,112 +211,6 @@ Source: [Annotations](../../controller-skills/annotations)
 !!! note
     It is important to remember that this coordination is still a negotiation. You are free to reject any proposition that doesn't work for you and your traffic picture. And if there is a particular restriction to nominate, it is always best to take the aircraft on frequency.
 
-## Rules
-### General
-Coordination must be done on a **point-to-point** basis. Meaning, you can only coordinate with the sector which the aircraft is coming from, or going to, no skipping! This is important to remember, for example, if you are controlling ELW, and you would like to pass an amended route to someone on the ground at YMML. Whilst that may be no issue for ELW, ML SMC and ML ADC, it might not work for ML APP. ML APP would be the sector which the aircraft is coming from, so ELW must talk to them, and it is the responsibility of ML APP to work backwards down the line on a point-to-point basis.
-
-Ensure no coordination is ambiguous in its meaning. Not all coordination can be straight out of the phraseology books, and the reality is, not everyone controlling the airspace is going to be 100% proficient and by the books. When using "plain english", ensure there is no ambiguity, and the message is fully understood by both parties.
-### ENR/TCU -> Class D TWR
-Heads-up coordinate arrivals/overfliers prior to **5 mins** from the boundary.
-#### Format
-- *"via (Route/Procedure)"*
-- Callsign
-- Level (if not Standard Assignable)
-- Runway (if not active runway)
-
-### Class D TWR -> ENR/TCU
-Voice coordinate 'Next' call **within 2 minutes of takeoff** for all CTA departures.
-#### Format
-- *"Next"*
-- Callsign
-- Level (if not Standard Assignable)
-
-### Radar TWR -> TCU
-Voice coordinate 'Next' call **within 2 minutes of takeoff** unless overridden by local Auto Release rules.
-
-#### Format
-- *"Next"*
-- Callsign
-- Runway
-
-If Auto Release is suspended by the TCU controller, respond by advising of any aircraft with a takeoff clearance.
-
-!!! phraseology
-    <span class="hotline">**TCU** -> **ADC**</span>: "Cancel auto release until time 45"  
-    <span class="hotline">**ADC** -> **TCU**</span>: "Cancel auto release until time 45, QLK108D released"  
-    <span class="hotline">**TCU** -> **ADC**</span>: "QLK108D"
-
-### TCU -> Radar TWR
-Radar TWRs will voice coordinate all departures unless permitted by local Auto Release rules. Respond with any lateral departure instructions (if required by SID or departure procedure) and any additional vertical restrictions, or "unrestricted". 
-
-If due to weather, overflying aircraft, runway config changes, etc. Auto Release needs to be cancelled, advise this to the ADC controller.  They will respond with any aircraft who have a takeoff clearance.
-
-### ENR -> TCU
-**Voiceless** for aircraft landing at main airport (eg YMML in ML TCU), assigned a STAR, and standard assignable level.  
-
-Heads-up coordinate all other aircraft by **20nm** to boundary.
-
-### TCU -> ENR
-**Voiceless** for aircraft assigned lower of standard assignable level or RFL, and tracking via a Procedural SID terminus.
-
-!!! note
-    Aircraft are *not required* to be tracking via the **SID procedure**, simply tracking via any of the terminus waypoints (Regardless of *departure airport* or *assigned SID*) is sufficient to meet the criteria for **voiceless coordination**
-
-Heads-up coordinate all other aircraft by the boundary.
-
-### ENR -> ENR
-**Voiceless**, no changes to route or CFL within **50nm** to boundary.
-
-!!! exception
-    Except as amended by Local Instructions.
-
-### To/from Oceanic/International Units
-
-#### Pacific Units
-For aircraft going between the following FIRs in Oceanic Airspace only:  
-- YBBB  
-- YMMM  
-- NFFF  
-- AGGG  
-- ANAU  
-- NZZO  
-- NZCM  
-- KZAK  
-- NTTT  
-- AYPM  
-- NWWW  
-- NVVV
-
-**Voiceless**, no changes to route or CFL within **15 mins** of boundary.
-
-#### Other Units
-For aircraft going to the following FIRs:  
-- WAAF  
-- WIIF  
-- VCCF  
-- VRMF  
-- FIMM  
-- FAJO
-
-Heads-up coordinate prior to **30 mins** to boundary.
-
-##### Format
-Coordination to **International** units shall be done in the following format:
-
-- *"Estimate"*
-- Callsign
-- Boundary Point
-- Estimate
-- Level
-- *"On climb"*/*"On descent*" (if applicable)
-
-!!! phraseology
-    <span class="coldline">**IND** -> **FIMM CTR**</span>: "Estimate, QFA63, IBMAT time 33, F360"  
-    <span class="coldline">**FIMM CTR** -> **IND**</span>: "QFA63, F360"
-
-### OCTA Coordination
-For any aircraft transiting **to or from** Uncontrolled airspace (ie: Class G, VFR Class E), heads-up coordination is **not required**. However, a **5 minute** change parameter applies to any aircraft that change level, route, or taxi within **5 minutes** of the next sector's airspace.
-
 ## Handoffs
 Receiving a handoff means you are permitted to turn an aircraft **45 degrees left or right**, and **climb/descend it to any level** without coordination. Do not handoff an aircraft to another sector if a turn of 45 degrees or a change of level would cause a conflict with any of your own aircraft. Or alternatively, you can nominate a restriction prior to handoff.
 
@@ -304,3 +226,96 @@ Upon receipt of a handoff, once the aircraft is established **half the applicabl
     KPL will place *"RKA NR"* in the label until 2.5nm clear of their airspace, to record that the coordination has been completed.
 
 For more information, refer to individual local instructions.
+
+## Rules
+### Class D Towers
+#### ENR/TCU -> Class D TWR
+[Heads-up](#heads-up) coordinate arrivals/overfliers prior to **5 mins** from the boundary.
+
+!!! note ""
+    "Via (Route/Procedure), (Callsign), (Level - *if not standard assignable*), (Runway - *if not duty runway*)"
+
+#### Class D TWR -> ENR/TCU
+[Next](#next) call **within 2 minutes of takeoff** for all **CTA** departures.
+
+### Radar Towers
+#### Radar TWR -> TCU
+[Next](#next) call **within 2 minutes of takeoff** unless overridden by local autorelease rules.
+
+If Auto Release is suspended by the TCU controller, respond by advising of any aircraft with a takeoff clearance.
+
+!!! phraseology
+    <span class="hotline">**TCU** -> **ADC**</span>: "Cancel autorelease"  
+    <span class="hotline">**ADC** -> **TCU**</span>: "Cancel autorelease, QLK108D released"  
+    <span class="hotline">**TCU** -> **ADC**</span>: "QLK108D"
+
+#### TCU -> Radar TWR
+Radar TWRs will [Next](#next) coordinate all departures unless permitted by local autorelease rules. Respond with any lateral departure instructions (if required by SID or departure procedure) and any additional vertical restrictions, or "unrestricted". 
+
+If due to weather, overflying aircraft, runway config changes, etc. autorelease needs to be cancelled, advise this to the ADC controller.  They will respond with any aircraft who have a takeoff clearance.
+
+!!! phraseology
+    <span class="hotline">**TCU** -> **ADC**</span>: "Cancel autorelease"  
+    <span class="hotline">**ADC** -> **TCU**</span>: "Cancel autorelease, QLK108D released"  
+    <span class="hotline">**TCU** -> **ADC**</span>: "QLK108D"
+
+### TCUs
+#### ENR -> TCU
+**Voiceless** for aircraft landing at main airport (eg YMML in ML TCU), assigned a STAR, and standard assignable level, unless overridden by local procedure.  
+
+Heads-up coordinate all other aircraft by **20nm** to boundary.
+
+#### TCU -> ENR
+**Voiceless** for aircraft assigned lower of standard assignable level or RFL, and tracking via a Procedural SID terminus, unless overridden by local procedure.
+
+!!! note
+    Aircraft are *not required* to be tracking via the **SID procedure**, simply tracking via any of the terminus waypoints (regardless of *departure airport* or *assigned SID*) is sufficient to meet the criteria for **voiceless coordination**
+
+Heads-up coordinate all other aircraft by the boundary.
+
+### Enroute
+#### ENR -> ENR
+**Voiceless**, no changes to route or CFL within **50nm** of the boundary, unless overridden by local procedure.
+
+#### To/from Oceanic/International Units
+##### Pacific Units
+For aircraft going between the following FIRs in Oceanic Airspace only:  
+
+- YBBB  
+- YMMM  
+- NFFF  
+- AGGG  
+- ANAU  
+- NZZO  
+- NZCM  
+- KZAK  
+- NTTT  
+- AYPM  
+- NWWW  
+- NVVV
+
+**Voiceless**, no changes to route or CFL within **15 mins** of boundary.
+
+##### Other Units
+For aircraft going to the following FIRs:  
+
+- WAAF  
+- WIIF  
+- VCCF  
+- VRMF  
+- FIMM  
+- FAJO
+
+Heads-up coordinate prior to **30 mins** to boundary.
+
+Voice coordination to **International** units shall be done in the following format:
+
+!!! note ""
+    "Estimate, (Callsign), (Boundary Point) (Estimate), (Level), on climb/descent *if applicable*"
+
+!!! phraseology
+    <span class="coldline">**IND** -> **FIMM CTR**</span>: "Estimate, QFA63, IBMAT time 33, F360"  
+    <span class="coldline">**FIMM CTR** -> **IND**</span>: "QFA63, F360"
+
+### OCTA Coordination
+For any aircraft transiting **to or from** uncontrolled airspace (ie: Class G, VFR Class E), heads-up coordination is **not required**. However, a **5 minute** change parameter applies to any aircraft that change level, route, or taxi within **5 minutes** of the next sector's airspace.

--- a/docs/controller-skills/coordination.md
+++ b/docs/controller-skills/coordination.md
@@ -119,7 +119,7 @@ The Boundary Sector may omit the restriction and readback the callsign only. Thi
     <span class="hotline">**BAS** -> **INL**</span>: "FD516"
 
 ### Next
-Next coordination is performed between ADC and TCU controllers to discuss the next aircraft to depart. As a general rule, all departing aircraft require Next coordination, unless stipulated by local SOPs through the use of autorelease.
+Next coordination is performed between ADC and TCU controllers to discuss the next aircraft to depart. As a general rule, all departing aircraft require Next coordination, unless stipulated by local SOPs through the use of Auto Release. Auto Release can be cancelled at any time through mutual agreement of the ADC and TCU controllers.
 
 The format is as follows:
 
@@ -127,7 +127,14 @@ The format is as follows:
     <span class="hotline">**ADC** -> **TCU**</span>: "Next, (Callsign), (Runway)"  
     <span class="hotline">**TCU** -> **ADC**</span>: "(Callsign), (Runway), (Lateral and/or Vertical Instructions)"
 
-Aircraft assigned a procedural SID will generally not be issued with lateral instructions. Aircraft assigned a radar SID or visual departure must be provided with an assigned heading or other lateral departure instructions.
+Aircraft assigned a procedural SID will generally not be issued with lateral instructions. Aircraft assigned a radar SID or visual departure must be provided with an assigned heading or other lateral departure instructions, with examples shown below:
+
+| Instruction | Meaning |
+| ----------- | ------- |
+| Left/right turn | Make a visual left/right turn to establish on the planned outbound track |
+| Left 180 | At the SID turn height, or at a safe altitude (if visual departure), fly heading 180 |
+| Left 180 visual | As above, but with a pilot requirement to maintain visual separation with the ground/water and any obstacles |
+| Extended runway centreline | Track the extended runway centreline (accounting for drift) |
 
 An amended level may be instructed, or the term **unrestricted** used to indicate that no *additional* vertical restrictions apply. This permits the aircraft to climb to their cleared level (as issued with their airways clearance).
 
@@ -140,7 +147,7 @@ An amended level may be instructed, or the term **unrestricted** used to indicat
     <span class="hotline">**CS TCU** -> **CS ADC**</span>: "LKU, runway 15, left turn, unrestricted"  
     <span class="hotline">**CS ADC** -> **CS TCU**</span>: "Left turn, LKU"
     
-    *QFA442 is assigned a procedural SID from YMML with autorelease cancelled*  
+    *QFA442 is assigned a procedural SID from YMML with Auto Release cancelled*  
     <span class="hotline">**ML ADC** -> **ML TCU**</span>: "Next, QFA442, runway 16"  
     <span class="hotline">**ML TCU** -> **ML ADC**</span>: "QFA442, unrestricted"  
 
@@ -240,23 +247,23 @@ For more information, refer to individual local instructions.
 
 ### Radar Towers
 #### Radar TWR -> TCU
-[Next](#next) call **within 2 minutes of takeoff** unless overridden by local autorelease rules.
+[Next](#next) call **within 2 minutes of takeoff** unless overridden by local Auto Release rules.
 
 If Auto Release is suspended by the TCU controller, respond by advising of any aircraft with a takeoff clearance.
 
 !!! phraseology
-    <span class="hotline">**TCU** -> **ADC**</span>: "Cancel autorelease"  
-    <span class="hotline">**ADC** -> **TCU**</span>: "Cancel autorelease, QLK108D released"  
+    <span class="hotline">**TCU** -> **ADC**</span>: "Cancel Auto Release"  
+    <span class="hotline">**ADC** -> **TCU**</span>: "Cancel Auto Release, QLK108D released"  
     <span class="hotline">**TCU** -> **ADC**</span>: "QLK108D"
 
 #### TCU -> Radar TWR
-Radar TWRs will [Next](#next) coordinate all departures unless permitted by local autorelease rules. Respond with any lateral departure instructions (if required by SID or departure procedure) and any additional vertical restrictions, or "unrestricted". 
+Radar TWRs will [Next](#next) coordinate all departures unless permitted by local Auto Release rules. Respond with any lateral departure instructions (if required by SID or departure procedure) and any additional vertical restrictions, or "unrestricted". 
 
-If due to weather, overflying aircraft, runway config changes, etc. autorelease needs to be cancelled, advise this to the ADC controller.  They will respond with any aircraft who have a takeoff clearance.
+If due to weather, overflying aircraft, runway config changes, etc. Auto Release needs to be cancelled, advise this to the ADC controller.  They will respond with any aircraft who have a takeoff clearance.
 
 !!! phraseology
-    <span class="hotline">**TCU** -> **ADC**</span>: "Cancel autorelease"  
-    <span class="hotline">**ADC** -> **TCU**</span>: "Cancel autorelease, QLK108D released"  
+    <span class="hotline">**TCU** -> **ADC**</span>: "Cancel Auto Release"  
+    <span class="hotline">**ADC** -> **TCU**</span>: "Cancel Auto Release, QLK108D released"  
     <span class="hotline">**TCU** -> **ADC**</span>: "QLK108D"
 
 ### TCUs

--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -193,14 +193,13 @@ TW ADC is responsible for the Class D airspace in the TW CTR `SFC` to `A045`, as
 Refer to [Reclassifications](#tw-ctr) for operations when TW ADC is offline.
 
 #### Departures
-Departures from YSTW in to ARL/MDE Class C will be coordinated when ready for departure.
+[Next](../../controller-skills/coordination.md#next) coordination is required from TW ADC to ARL/MDE for all aircraft **entering ARL/MDE CTA**.
 
-!!! phraseology
-    <span class="hotline">**TW ADC** -> **MDE**</span>: "Next, SKV"  
-    <span class="hotline">**MDE** -> **TW ADC**</span>: "SKV, Unrestricted"  
-    <span class="hotline">**TW ADC** -> **MDE**</span>: "SKV"  
+The Standard Assignable level from **TW ADC** to **ARL/MDE** is:
 
-The Standard Assignable level from **TW ADC** to ARL/MDE is the lower of `A070` or the `RFL`.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A070` and `RFL` |
 
 #### Arrivals
 YSTW arrivals shall be heads-up coordinated to **TW ADC** from ARL/MDE prior to **5 mins** from the boundary.
@@ -218,14 +217,15 @@ CFS ADC is responsible for the Class D airspace in the CFS CTR `SFC` to `A045`.
 Refer to [Reclassifications](#cfs-ctr) for operations when CFS ADC is offline.
 
 #### Departures
-Departures from YCFS in to MNN Class C will be coordinated when ready for departure.
+[Next](../../controller-skills/coordination.md#next) coordination is required from CFS ADC to ARL(MNN) for all aircraft **entering ARL(MNN) CTA**.
 
-!!! phraseology
-    <span class="hotline">**CFS ADC** -> **MNN**</span>: "Next, CFH21"  
-    <span class="hotline">**MNN** -> **CFS ADC**</span>: "CFH21, Unrestricted"  
-    <span class="hotline">**CFS ADC** -> **MNN**</span>: "CFH21"  
+The Standard Assignable level from **CFS ADC** to **ARL(MNN)** is:
 
-The Standard Assignable level from **CFS ADC** to MNN is the lower of `A070` or the `RFL`.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A070` and `RFL` |
+
+Where possible (and no possible conflict exists), a higher level shall be assigned by ARL(MNN) for high performance aircraft during next coordination.
 
 #### Arrivals
 YCFS arrivals shall be heads-up coordinated to **CFS ADC** from MNN prior to **5 mins** from the boundary.

--- a/docs/enroute/Brisbane Centre/INL.md
+++ b/docs/enroute/Brisbane Centre/INL.md
@@ -238,21 +238,15 @@ SU ADC is responsible for the Class D airspace in the SU CTR `SFC` to `A045`.
 Refer to [Reclassifications](#su-ctr) for operations when SU ADC is offline.
 
 #### Departures
-Departures from YBSU in to NSA Class C will be coordinated when ready for departure.
+[Next](../../controller-skills/coordination.md#next) coordination is required from SU ADC to INL(NSA/BUR) for all aircraft **entering INL(NSA/BUR) CTA**.
 
-!!! phraseology
-    <span class="hotline">**SU ADC** -> **NSA**</span>: "Next, BNZ123, runway 31"  
-    <span class="hotline">**NSA** -> **SU ADC**</span>: "BNZ123, unrestricted"  
-    <span class="hotline">**SU ADC** -> **NSA**</span>: "BNZ123"
+The Standard Assignable level from **SU ADC** to **INL(NSA/BUR)** is:
 
-The Standard Assignable level from **SU ADC** to INL(NSA/BUR) is the lower of `A040` or the `RFL`.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A040` and `RFL` |
 
 Where possible (and no possible conflict exists), a higher level shall be assigned by INL(NSA/BUR) for high performance aircraft during next coordination.
-
-!!! phraseology
-    <span class="hotline">**SU ADC** -> **NSA**</span>: "Next, VOZ924, runway 31"  
-    <span class="hotline">**NSA** -> **SU ADC**</span>: "VOZ924, F120"  
-    <span class="hotline">**SU ADC** -> **NSA**</span>: "F120, VOZ924"
 
 #### Arrivals
 NSA must ensure all YBSU arrivals have been assigned a STAR, unless the pilot is unable to accept one.  
@@ -294,14 +288,15 @@ CFS ADC is responsible for the Class D airspace in the CFS CTR `SFC` to `A045`.
 Refer to [Reclassifications](#cfs-ctr) for operations when CFS ADC is offline.
 
 #### Departures
-Departures from YCFS in to INL Class C will be coordinated when ready for departure.
+[Next](../../controller-skills/coordination.md#next) coordination is required from CFS ADC to INL for all aircraft **entering INL CTA**.
 
-!!! phraseology 
-    <span class="hotline">**CFS ADC** -> **INL**</span>: "Next, BNZ185"  
-    <span class="hotline">**INL** -> **CFS ADC**</span>: "BNZ185, Unrestricted"  
-    <span class="hotline">**CFS ADC** -> **INL**</span>: "BNZ185"  
+The Standard Assignable level from **CFS ADC** to **INL** is:
 
-The Standard Assignable level from **CFS ADC** to INL is the lower of `A070` or the `RFL`.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A070` and `RFL` |
+
+Where possible (and no possible conflict exists), a higher level shall be assigned by for high performance aircraft during next coordination.
 
 #### Arrivals
 YCFS arrivals shall be coordinated to **CFS ADC** from INL prior to **5 mins** from the boundary.

--- a/docs/enroute/Brisbane Centre/KEN.md
+++ b/docs/enroute/Brisbane Centre/KEN.md
@@ -220,20 +220,22 @@ HM ADC is responsible for the Class D airspace in the HM CTR `SFC` to `A045`.
 Refer to [Reclassifications](#hm-ctr) for operations when HM ADC is offline.
 
 #### Departures
-Departures from YBHM in to SWY Class C will be coordinated when ready for departure.  
+[Next](../../controller-skills/coordination.md#next) coordination is required from HM ADC to KEN(SWY) for all aircraft **entering KEN(SWY) CTA**.
 
-!!! phraseology
-    <span class="hotline">**HM ADC** -> **SWY**</span>: "Next, QFA797"  
-    <span class="hotline">**SWY** -> **HM ADC**</span>: "QFA797, Unrestricted"  
-    <span class="hotline">**HM ADC** -> **SWY**</span>: "QFA797"  
+The Standard Assignable level from **HM ADC** to **KEN(SWY)** is:
 
-The Standard Assignable level from HM ADC to SWY is the lower of `A050` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A050` and `RFL` |
+
+Where possible (and no possible conflict exists), a higher level shall be assigned by ARL(MNN) for high performance aircraft during next coordination.
+
 #### Arrivals
 YBHM arrivals shall be heads-up coordinated to **JM ADC** from SWY prior to **5 mins** from the boundary.
 
 !!! phraseology
-    <span class="hotline">**SWY** -> **HM ADC**</span>: "Via OPOSI for RNP U RWY 32, JST848”  
-    <span class="hotline">**HM ADC** -> **SWY**</span>: "JST848, RNP U RWY 32"  
+    <span class="hotline">**SWY** -> **HM ADC**</span>: "Via OPOSI for RNP-U, JST848”  
+    <span class="hotline">**HM ADC** -> **SWY**</span>: "JST848, A060"  
 
 The Standard Assignable level from KEN(SWY) to HM ADC is `A060`, any other level must be prior coordinated.
 

--- a/docs/enroute/Brisbane Centre/TRT.md
+++ b/docs/enroute/Brisbane Centre/TRT.md
@@ -116,14 +116,13 @@ All other aircraft going to TRT CTA will be **Heads-up** Coordinated by DN TCU.
 BRM ADC is responsible for the Class D airspace `SFC` to `A055`, as well as the Class E airspace `1200ft AGL` to `A055`, within the BRM CTR.
 
 #### Departures
-Departures from YBRM in to ASH CTA will be coordinated when ready for departure.  
+[Next](../../controller-skills/coordination.md#next) coordination is required from BRM ADC to TRT(ASH) for all aircraft **entering TRT(ASH) CTA**.
 
-!!! phraseology
-    <span class="hotline">**BRM ADC** -> **ASH**</span>: "Next, ANO333"  
-    <span class="hotline">**ASH** -> **BRM ADC**</span>: "ANO333, Unrestricted"  
-    <span class="hotline">**BRM ADC** -> **ASH**</span>: "ANO333"  
+The Standard Assignable level from **BRM ADC** to **TRT(ASH)** is:
 
-The Standard Assignable level from BRM ADC to TRT(ASH) is the lower of `A050` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A050` and `RFL` |
 
 #### Arrivals
 YBRM arrivals shall be heads-up coordinated to **BRM ADC** from TRT prior to **5 mins** from the boundary.

--- a/docs/enroute/Melbourne Centre/ASP.md
+++ b/docs/enroute/Melbourne Centre/ASP.md
@@ -83,14 +83,14 @@ AS ADC is responsible for the Class D airspace `SFC` to `A045`, as well as the C
 Refer to [Reclassifications](#as-ctr) for operations when AS ADC is offline.
 
 #### Departures
-Departures from YBAS in to ASP Class C will be coordinated when ready for departure.
+[Next](../../controller-skills/coordination.md#next) coordination is required from AS ADC to ASP for all aircraft **entering ASP CTA**.
 
-!!! phraseology
-    <span class="hotline">**AS ADC** -> **ASP**</span>: "Next, QFA797"  
-    <span class="hotline">**ASP** -> **AS ADC**</span>: "QFA797, Unrestricted"  
-    <span class="hotline">**AS ADC** -> **ASP**</span>: "QFA797"  
+The Standard Assignable level from **AS ADC** to **ASP** is:
 
-The Standard Assignable level from **AS ADC** to ASP is the lower of `A070` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A070` and `RFL` |
+
 #### Arrivals
 YBAS arrivals shall be heads-up coordinated to **AS ADC** from ASP prior to **5 mins** from the boundary.
 

--- a/docs/enroute/Melbourne Centre/ELW.md
+++ b/docs/enroute/Melbourne Centre/ELW.md
@@ -186,14 +186,13 @@ AY ADC is responsible for the Class D airspace in the AY CTR `SFC` to `A045`.
 Refer to [Reclassifications](#ay-ctr) for operations when AY ADC is offline.
 
 #### Departures
-Departures from YMAY in to BLA Class C will be coordinated when ready for departure.
+[Next](../../controller-skills/coordination.md#next) coordination is required from AY ADC to BLA for all aircraft **entering BLA CTA**.
 
-!!! phraseology
-    <span class="hotline">**AY ADC** -> **BLA**</span>: "Next, RXA6772"  
-    <span class="hotline">**BLA** -> **AY ADC**</span>: "RXA6772, Unrestricted"  
-    <span class="hotline">**AY ADC** -> **BLA**</span>: "RXA6772"  
+The Standard Assignable level from **AY ADC** to **BLA** is:
 
-The Standard Assignable level from **AY ADC** to BLA is the lower of `A070` or the `RFL`.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A070` and `RFL` |
 
 #### Arrivals
 YMAY arrivals shall be heads-up coordinated to **AY ADC** from BLA prior to **5 mins** from the boundary.

--- a/docs/enroute/Melbourne Centre/ELW.md
+++ b/docs/enroute/Melbourne Centre/ELW.md
@@ -163,7 +163,21 @@ That being said, it is *advised* that ELW/BLA/SNO give **Heads-up Coordination**
 - SNO to BLA for all aircraft
 
 ### ES TCU
-Reserved.
+#### Departures
+Voiceless for all aircraft:
+
+- Tracking via a Procedural SID terminus; and  
+- Assigned the lower of `F200` or the `RFL`
+
+All other aircraft going to ELW CTA must be **Heads-up** Coordinated by ES TCU prior to the boundary. 
+
+#### Arrivals
+Voiceless for all aircraft:
+
+- With ADES **YMES**; and
+- Assigned `A100`
+
+All other aircraft coming from ELW CTA will be **Heads-up** Coordinated to ES TCU.
 
 ### AY ADC
 #### Airspace

--- a/docs/enroute/Melbourne Centre/OLW.md
+++ b/docs/enroute/Melbourne Centre/OLW.md
@@ -70,14 +70,14 @@ KA ADC is responsible for the Class D airspace in the KA CTR `SFC` to `A055`.
 Refer to [Reclassifications](#ka-ctr) for operations when KA ADC is offline.
 
 #### Departures
-Departures from YPKA in to OLW CTA will be coordinated when ready for departure.  
+[Next](../../controller-skills/coordination.md#next) coordination is required from KA ADC to OLW for all aircraft **entering OLW CTA**.
 
-!!! phraseology
-    <span class="hotline">**KA ADC** -> **OLW**</span>: "Next, OHN"  
-    <span class="hotline">**OLW** -> **KA ADC**</span>: "OHN, Unrestricted"  
-    <span class="hotline">**KA ADC** -> **OLW**</span>: "OHN"  
+The Standard Assignable level from **KA ADC** to **OLW** is:
 
-The Standard Assignable level from KA ADC to OLW is the lower of `A050` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ---- | ---- |
+| All | The lower of `A050` and `RFL` |
+
 #### Arrivals
 YPKA arrivals shall be heads-up coordinated to **KA ADC** from OLW prior to **5 mins** from the boundary.
 

--- a/docs/enroute/Melbourne Centre/YWE.md
+++ b/docs/enroute/Melbourne Centre/YWE.md
@@ -159,4 +159,19 @@ Voiceless for all aircraft:
 All other aircraft going to KAT CTA will be **Heads-up** Coordinated.
 
 ### ES TCU
-Reserved.
+### Enroute
+#### Departures
+Voiceless for all aircraft:
+
+- Tracking via a Procedural SID terminus; and  
+- Assigned the lower of `F200` or the `RFL`
+
+All other aircraft going to YWE CTA must be **Heads-up** Coordinated by ES TCU prior to the boundary. 
+
+#### Arrivals
+Voiceless for all aircraft:
+
+- With ADES **YMES**; and
+- Assigned `A100`
+
+All other aircraft coming from YWE CTA will be **Heads-up** Coordinated to ES TCU.

--- a/docs/terminal/adelaide.md
+++ b/docs/terminal/adelaide.md
@@ -170,19 +170,20 @@ All other aircraft coming from TBD CTA will be **Heads-up** Coordinated to AD TC
 
 ### AD ADC
 #### Auto Release
-'Next' coordination is **not** required from AD ADC for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a **Procedural** SID
+[Next](../controller-skills/coordination.md#next) coordination is **not** required to AD TCU for aircraft that are:   
 
-!!! phraseology
-    <span class="hotline">**AD ADC** -> **AD TCU**</span>: "Next, ABC, runway 05"  
-    <span class="hotline">**AD TCU** -> **AD ADC**</span>: "ABC, Track Extended Centreline, unrestricted"  
-    <span class="hotline">**AD ADC** -> **AD TCU**</span>: "Track Extended Centreline, ABC"
+  - Departing from a runway nominated on the ATIS; and  
+  - Assigned the standard assignable level; and  
+  - Assigned a **Procedural** SID
+
+All other aircraft require a Next call to AD TCU.
 
 The Standard Assignable level from AD ADC to AD TCU is:  
-For Jets: `A050`  
-For Non-Jets: The lower of `A040` or the `RFL`
+
+| Aircraft | Level |
+| -------- | ----- |
+| Jets | `A050` |
+| Non-Jets | The lower of `A040` and `RFL` |
 
 ### AD TCU Internal
 All aircraft transiting between internal AD TCU boundaries must be heads-up coordinated.
@@ -200,14 +201,13 @@ PF ADC is responsible for the Class D airspace in the PF CTR `SFC` to `A015`.
 Refer to [Reclassifications](#pf-ctr) for operations when PF ADC is offline.
 
 #### Departures
-When the aircraft is ready for departure, PF ADC will coordinate with AD TCU for permission to release the aircraft into CTA.
+[Next](../controller-skills/coordination.md#next) coordination is required from PF ADC to AD TCU for all aircraft **entering AD TCU CTA**.
 
-!!! phraseology
-    <span class="hotline">**PF ADC** -> **AAW**</span>: "Next, XMM, 03L"  
-    <span class="hotline">**AAW** -> **PF ADC**</span>: "XMM, Heading 020, unrestricted"  
-    <span class="hotline">**PF ADC** -> **AAW**</span>: "Heading 020, XMM"
+The Standard Assignable level from **PF ADC** to **AD TCU** is:
 
-The Standard Assignable level from PF ADC to AD TCU is the lower of `A030` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ----- | ---- |
+| All | The lower of `A030` and `RFL` |
 
 #### Arrivals/Overfliers
 AD TCU will heads-up coordinate arrivals/overfliers from Class C to PF ADC prior to **5 mins** from the boundary.  
@@ -220,21 +220,19 @@ VFR aircraft require a level readback.
 
 ### ED ADC
 #### Departures
-'Next' coordination is required from ED ADC to AD TCU for all aircraft.
+[Next](../controller-skills/coordination.md#next) coordination is required from ED ADC to AD TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**ED ADC** -> **AD TCU**</span>: "Next, SGE"  
-    <span class="hotline">**AD TCU** -> **ED ADC**</span>: "SGE, unrestricted"  
-    <span class="hotline">**ED ADC** -> **AD TCU**</span>: "SGE"
+The Standard Assignable level from **ED ADC** to **AD TCU** is:
 
-The Standard Assignable level from ED ADC to AD TCU is the lower of `A040` or the `RFL`.
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `A040` and `RFL` |
 
 #### Arrivals/Overfliers
-AD TCU must Heads-up coordinate all arrivals/overfliers to ED ADC.
+AD TCU must [Heads-up](../controller-skills/coordination.md#heads-up) coordinate all arrivals/overfliers to ED ADC.
 
 !!! phraseology
     <span class="hotline">**AD TCU** -> **ED ADC**</span>: "To the west, PLE, for the ILS-Z"  
     <span class="hotline">**ED ADC** -> **AD TCU**</span>: "PLE, ILS-Z"
 
-- **IFR arrivals** must be cleared for the coordinated approach (Instrument or Visual) prior to handoff to ED ADC, unless ED ADC nominates a restriction.  
-- **VFR arrivals** must be cleared for the coordinated visual approach prior to handoff to ED ADC, unless ED ADC nominates a restriction.
+Inbound aircraft must be cleared for an instrument or visual approach prior to handoff to ED ADC, unless ADC nominates a restriction.

--- a/docs/terminal/amberleyoakey.md
+++ b/docs/terminal/amberleyoakey.md
@@ -105,44 +105,30 @@ Transfer these aircraft to ADC approaching the boundary.
 
 ## Coordination
 ### AMB/OK ADC
-#### Airspace
-AMB ADC owns the Class C airspace **in the AMB CTR** within 10nm of the YAMB ARP from `SFC` to `A015`.
-
-OK ADC owns the airspace within 5 DME of the OK VOR from `SFC` to `A025`.
-
 #### Departures
-'Next' coordination is required from AMB ADC to AMB TCU for all aircraft.
+[Next](../controller-skills/coordination.md#next) coordination is required from AMB ADC to AMB TCU for all aircraft.
 
 The Standard Assignable Level from  **AMB ADC** to **AMB TCU** is:  
-a) The Lower of `F180` or `RFL` for Aircraft assigned via Procedural or RNAV SID.  
-b) `F190` for Aircraft assigned a Coded Departure.
 
-!!! phraseology
-    <span class="hotline">**AMB ADC** -> **AMB TCU**</span>: "Next, STAL56, runway 33"  
-    <span class="hotline">**AMB TCU** -> **AMB ADC**</span>: "STAL56, unrestricted"  
-    <span class="hotline">**AMB ADC** -> **AMB TCU**</span>: "STAL56"   
+| Assigned Departure | Level |
+| ------------------ | ----- |
+| Procedural SID | The lower of `F180` and `RFL` |
+| Coded Departure | `F190` |
+
+[Next](../controller-skills/coordination.md#next) coordination is required from OK ADC to OK TCU for all aircraft.
+
+The Standard Assignable level from **OK ADC** to **OK TCU** is:
+
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `F120` and `RFL` |
 
 ### INL / BN TCU
 #### Departures
-All aircraft from AMB/OK TCU to INL(All) and BN TCU require Heads-up coordination prior to the boundary, however, as soon as practical (when is the aircraft becomes airborne) is prefered.
-
-The Standard Assignable Level from  **AMB ADC** to **AMB TCU** is:  
-a) The Lower of `F180` or `RFL` for Aircraft assigned via Procedural or RNAV SID.  
-b) `F190` for Aircraft assigned a Coded Departure.
-
-The Standard Assignable from **OK ADC** to **OK TCU** is the lower of `F120` or `RFL`.
-
-!!! phraseology
-    <span class="hotline">**AMB TCU** -> **BN TCU**</span>: "via BN, DRGN02"  
-    <span class="hotline">**BN TCU** -> **AMB TCU**</span>: "DRGN02, `F180`"  
-
-!!! phraseology
-    BUCK03 is assigned the BYRON 1 coded departure.  
-    <span class="hotline">**AMB TCU** -> **NSA**</span>: "via COWIE, BUCK3."  
-    <span class="hotline">**NSA** -> **AMB TCU**</span>: "BUCK03, `F190`"   
+All aircraft from AMB/OK TCU to INL(All) and BN TCU require [Heads-up](../controller-skills/coordination.md#heads-up) coordination prior to the boundary, however, as soon as practical (when is the aircraft becomes airborne) is preferred. 
 
 #### Arrivals/Overfliers
-All aircraft transiting from GOL/DOS/BUR to **AMB TCU** and **OK TCU** must be heads-up coordinated prior to **20nm** from the boundary and aircraft from **BN TCU** to **AMB TCU** only prior to the boundary. Operations within **AMB TCU** are fairly ad-hoc, so there are no standard assignable levels. GOL/DOS/BUR and **AMB TCU**/**OK TCU** controller must agree on a suitable level during coordination.
+All aircraft transiting from GOL/DOS/BUR to **AMB TCU** and **OK TCU** must be [Heads-up](../controller-skills/coordination.md#heads-up) coordinated prior to **20nm** from the boundary and aircraft from **BN TCU** to **AMB TCU** only prior to the boundary. Operations within **AMB TCU** are fairly ad-hoc, so there are no standard assignable levels. GOL/DOS/BUR and **AMB TCU**/**OK TCU** controller must agree on a suitable level during coordination.
 
 !!! phraseology
     <span class="hotline">**GOL** -> **AMB TCU**</span>: "via HUUGO, PUMA11, will be assigned A090"  

--- a/docs/terminal/brisbane.md
+++ b/docs/terminal/brisbane.md
@@ -192,23 +192,23 @@ All other aircraft coming from INL CTA will be **Heads-up** Coordinated to BN TC
 
 ### BN ADC
 #### Auto Release
-'Next' coordination is **not** required from BN ADC for aircraft that are:   
+[Next](../controller-skills/coordination.md#next) coordination is **not** required to BN TCU for aircraft that are:
 
 - Departing from a runway nominated on the ATIS (except during SODPROPS^); and  
 - Assigned the standard assignable level; and  
 - Assigned a **Procedural** SID; or
 - Assigned the **Radar** SID with a [Standard Assignable Heading](#standard-assignable-departure-headings)
 
-^Auto Release is not available during SODPROPS runway mode. All aircraft will be coordinated from BN ADC to BN TCU.
+^*Auto Release is not available during SODPROPS runway mode. All aircraft must be coordinated from BN ADC to BN TCU.*
 
-!!! phraseology
-    <span class="hotline">**BN ADC** -> **BN TCU**</span>: "Next, ABC, runway 19L"  
-    <span class="hotline">**BN TCU** -> **BN ADC**</span>: "ABC, Heading 030, Unrestricted"  
-    <span class="hotline">**BN ADC** -> **BN TCU**</span>: "Heading 030, ABC"
+All other aircraft require a 'Next' call to BN TCU.
 
 The Standard Assignable level from BN ADC to BN TCU is:  
-For Jets: `A060`  
-For Non-Jets: The lower of `A040` or the `RFL`
+
+| Aircraft | Level |
+| -------- | ----- |
+| Jets | `A060` |
+| Non-Jets | The lower of `A040` and `RFL` |
 
 #### Standard Assignable Departure Headings
 Aircraft that have been cleared the **BN (RADAR) SID** will receive an assigned heading with their line up or takeoff clearance. 'Next' coordination is not required (excluding during SODPROPS) from the BN ADC controller when the departing aircraft has been assigned the standard assignable level and assigned one of the headings listed below:
@@ -252,21 +252,20 @@ CG ADC is responsible for the Class C Airspace within the CG CTR `SFC` to `A015`
 Refer to [Reclassifications](#cg-ctr) for operations when CG ADC is offline.
 
 #### Auto Release
-'Next' coordination is **not** required from CG ADC for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a **Procedural** SID
+[Next](../controller-skills/coordination.md#next) coordination is **not** required to BN TCU for aircraft that are:   
+  
+  - Departing from a runway nominated on the ATIS; and  
+  - Assigned the standard assignable level; and  
+  - Assigned a **Procedural** SID
 
-!!! phraseology
-    <span class="hotline">**CG ADC** -> **BAC**</span>: "Next, CBN, runway 14"  
-    <span class="hotline">**BAC** -> **CG ADC**</span>: "CBN, heading 030, unrestricted"  
-    <span class="hotline">**CG ADC** -> **BAC**</span>: "Heading 030, CBN"  
-
-The BN TCU controller can suspend/resume Auto Release at any time, with the concurrence of **CG ADC**.
+All other aircraft require a 'Next' call to CG TCU.
 
 The Standard Assignable level from CG ADC to BN TCU is:  
-For Jets: `A060`  
-For Non-Jets: The lower of `A060` or the `RFL`
+
+| Aircraft | Level |
+| -------- | ----- |
+| Jets | `A060` |
+| Non-Jets | The lower of `A060` and `RFL` |
 
 ### AF ADC
 #### Airspace
@@ -275,14 +274,13 @@ AF ADC is responsible for the Class D Airspace within the AF CTR `SFC` to `A015`
 Refer to [Reclassifications](#af-ctr) for operations when AF ADC is offline.
 
 ### Departures
-When aircraft planned via a CTA departure are ready for takeoff and expected to depart imminently, **AF ADC** shall seek release of the aircraft through a 'Next' call.
+[Next](../controller-skills/coordination.md#next) coordination is required from AF ADC to BN TCU for all aircraft **entering BN TCU CTA**.
 
-!!! phraseology
-    <span class="hotline">**AF ADC** -> **BN TCU**</span>: "Next, XMM, Runway 10L"  
-    <span class="hotline">**BN TCU** -> **AF ADC**</span>: "XMM, Unrestricted"  
-    <span class="hotline">**AF ADC** -> **BN TCU**</span>: "XMM"
+The Standard Assignable level from **AF ADC** to **BN TCU** is:
 
-The Standard Assignable level from AF ADC to BN TCU is the lower of `A040` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| ------- | ----- |
+| All | The lower of `A040` and `RFL` |
 
 ### Arrivals/Overfliers
 BN TCU will heads-up coordinate arrivals/overfliers from Class C to AF ADC prior to **5 mins** from the boundary.  
@@ -294,13 +292,13 @@ VFR aircraft require a level readback.
     <span class="hotline">**AF ADC** -> **BN TCU**</span>: "UJE, visual approach"
 
 ### AMB TCU
-All aircraft transiting from **BN TCU** to **AMB TCU** and vice versa must be heads-up coordinated prior to the boundary. 
+All aircraft transiting from **BN TCU** to **AMB TCU** and vice versa must be [Heads-up](../controller-skills/coordination.md#heads-up) coordinated prior to the boundary. 
 
 !!! phraseology
     <span class="hotline">**AMB TCU** -> **BN TCU**</span>: "via BN, DRGN02"  
     <span class="hotline">**BN TCU** -> **AMB TCU**</span>: "DRGN02, `F140`"  
 
-For aircraft arriving into AMB TCU there is no standard assignable level and simply is what ever the controllers agree upon.
+For aircraft arriving into AMB TCU there is no standard assignable level.
 
 !!! phraseology
     <span class="hotline">**BN TCU** -> **AMB TCU**</span>: "via WACKO, STAL13, what level can I assign?"  

--- a/docs/terminal/cairns.md
+++ b/docs/terminal/cairns.md
@@ -108,39 +108,31 @@ Flow instructions shall be based on Feeder Fix times. The following points are t
 
 ## Coordination
 ### ADC
-### Airspace
-CS ADC is responsible for the Class C Airspace within the CS CTR `SFC` to `A010`.
-
 #### Departures
-'Next' coordination is **not** required from CS ADC for aircraft that are:   
-- Departing from a runway nominated on the ATIS; and  
-- Assigned the standard assignable level; and  
-- Assigned a **Procedural** SID
+[Next](../controller-skills/coordination.md#next) coordination is **not** required for aircraft that are:   
 
-!!! phraseology
-    <span class="hotline">**ADC** -> **TCU**</span>: "Next, RXA5417, runway 15"  
-    <span class="hotline">**TCU** -> **ADC**</span>: "RXA5417, heading 030, unrestricted"  
-    <span class="hotline">**ADC** -> **TCU**</span>: "Heading 030, RXA5417"
+  - Departing from a runway nominated on the ATIS; and  
+  - Assigned the standard assignable level; and  
+  - Assigned a **Procedural** SID
+
+All other aircraft require a 'Next' call to CS TCU.
+
+The Standard Assignable level from CS ADC to CS TCU is:
+
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `A060` and `RFL` |
 
 See [Standard Assignable Headings](#standard-assignable-headings) for the range of assignable headings available to aircraft on the **radar SID**.
-
-The Standard Assignable level from CS ADC to CS TCU is the lower of `A060` or the `RFL`.
 
 #### Arrivals
 Aircraft tracking via a visual right base to runway 33 must be coordinated with ADC (see [Visual Base Runway 33](#visual-base-runway-33)). All other arriving aircraft do not require coordination.
 
 ### ACD
-The controller assuming responsibility of **CS ACD** shall give heads-up coordination to the relevant CS TCU controller prior to the issue of the following clearances:  
-- VFR Departures  
+The controller assuming responsibility of **CS ACD** shall give [heads-up](../controller-skills/coordination.md#airways-clearance) coordination to the relevant CS TCU controller prior to the issue of the following clearances:  
+
+- VFR departures entering CS TCU CTA
 - Aircraft using a runway not on the ATIS
-
-!!! phraseology
-    <span class="coldline">**CS ACD** -> **CS TCU**</span>: "ABC, Requesting clearance for a Northbound VFR Coastal departure at A035"  
-    <span class="coldline">**CS TCU** -> **CS ACD**</span>: "ABC, Cleared for a Northbound VFR Coastal departure, A035"  
-    <span class="coldline">**CS ACD** -> **CS TCU**</span>: "Cleared for a Northbound VFR Coastal departure, A035, ABC"  
-
-    **CS ACD**: "ABC, Cleared for a Northbound VFR Coastal departure, A035, Squawk 3601"  
-    **ABC**: "Cleared for a Northbound VFR Coastal departure, A035, 3601, ABC"
 
 ### Enroute
 #### Departures

--- a/docs/terminal/canberra.md
+++ b/docs/terminal/canberra.md
@@ -19,6 +19,9 @@
 ## Airspace
 The Vertical limits of the CB TCU are `SFC` to `F245`.
 
+### CB ADC
+**CB ADC** is responsible for the Class C Airspace within the CB CTR `SFC` to `A035`.
+
 ### Airspace Division
 
 <figure markdown>
@@ -53,23 +56,21 @@ Voiceless for all aircraft:
 All other aircraft coming from ELW/BIK CTA will be **Heads-up** Coordinated to CB TCU prior to **20nm** from the boundary.
 
 ### ADC
-#### Airspace
-CB ADC is responsible for the Class C Airspace within the CB CTR `SFC` to `A035`.
+#### Departures
+[Next](../controller-skills/coordination.md#next) coordination is not required to CB TCU for aircraft that are:   
+  
+  - Departing from a runway nominated on the ATIS; and  
+  - Assigned the standard assignable level; and  
+  - Assigned a **Procedural** SID
 
-#### Auto Release
-'Next' coordination is **not** required from CB ADC for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a **Procedural** SID
-
-!!! phraseology
-    <span class="hotline">**CB ADC** -> **CB TCU**</span>: "Next, ABC, runway 35"  
-    <span class="hotline">**CB TCU** -> **CB ADC**</span>: "ABC, Track Extended Centreline, unrestricted"  
-    <span class="hotline">**CB ADC** -> **CB TCU**</span>: "Track Extended Centreline, ABC"
+All other aircraft require a 'Next' call to CB TCU.
 
 The Standard Assignable level from CB ADC to CB TCU is:  
-For IFR aircraft: `A100`  
-For VFR aircraft: The lower of `A040` or the `RFL`
+
+| Flight Rules | Level |
+| ------------ | ----- |
+| IFR | `A100` |
+| VFR | The lower of `A040` and `RFL` |
 
 #### Helipads in the CB CTR
 The Canberra CTR contains the Southcare Helicopter Base (YXSB) as well as two hospitals (Calvary Hospital and Canberra Hospital). Helicopters inbound to these helipads should be coordinated with **CB ADC** who can use a visual separation techniques as required. ADC and the TMA controller should work together to determine the most appropriate clearance limit (if required due traffic) for the helicopter, before frequency transfer is issued. ADC will issue a visual approach clearance when it is available.

--- a/docs/terminal/coral.md
+++ b/docs/terminal/coral.md
@@ -63,30 +63,24 @@ Voiceless for all aircraft:
 All other aircraft coming from SWY/KPL CTA will be **Heads-up** Coordinated to MKA/RKA.
 
 ### MK/RK ADC
-#### Airspace
-MK ADC is responsible for the Class D airspace in the MK CTR `SFC` to `A010`.
-
-RK ADC is responsible for the Class D airspace in the RK CTR `SFC` to `A010`.
-
 #### Auto Release
-'Next' coordination is **not** required from MK/RK ADC for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a **Procedural** SID
+[Next](../controller-skills/coordination.md#next) coordination is **not** required to MKA/RKA for aircraft that are:  
 
-!!! phraseology
-    <span class="hotline">**MK ADC** -> **MKA**</span>: "Next, ABC, runway 14"  
-    <span class="hotline">**MKA** -> **MK ADC**</span>: "ABC, Heading 150 Visual, unrestricted"  
-    <span class="hotline">**MK ADC** -> **MKA**</span>: "Heading 150 Visual unrestricted, ABC"
+- Departing from a runway nominated on the ATIS; and  
+- Assigned the standard assignable level; and  
+- Assigned a **Procedural** SID; or  
+- Not entering MKA/RKA CTA
 
-The TCU controller can suspend/resume Auto Release at any time, with the concurrence of **ADC**.
+The Standard Assignable level from **MK/RK ADC** to **MKA/RKA** is:
 
-The Standard Assignable level from MK/RK ADC to MKA/RKA is the lower of `A060` or the `RFL`.
+| Aircraft | Level |
+| ------ | ----- |
+| All | The lower of `A060` and `RFL` |
 
 #### MK/RK SMC
-The controller assuming responsibility of **SMC** shall give heads-up coordination to TCU controller prior to the issue of the following clearances:  
+The controller assuming responsibility of **SMC** shall give [Heads-up](../controller-skills/coordination.md#heads-up) coordination to TCU controller prior to the issue of the following clearances:  
 
-- VFR Departures  
+- VFR departures entering MKA/RKA CTA
 - Aircraft using a runway not on the ATIS
 
 #### Arrivals

--- a/docs/terminal/curtin.md
+++ b/docs/terminal/curtin.md
@@ -23,24 +23,23 @@ The above Restricted Areas are classified as Class C when CIN APP is active.
 !!! note
     See [VATPAC NOTAMs](https://vatpac.org/publications/notam){target=new} for active NOTAMs which may affect military operations.
 
-## Coordination
 ### ADC
-#### Airspace
 CIN ADC owns the Class C airspace within the CIN MIL CTR from `SFC` to `A015`.
 
+## Coordination
+### ADC
 #### Departures
-'Next' coordination is required from CIN ADC to CIN TCU for all aircraft.
+[Next](../controller-skills/coordination.md#next) coordination is required from CIN ADC to CIN TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**CIN ADC** -> **CIN TCU**</span>: "Next, ASY404, runway 29"  
-    <span class="hotline">**CIN TCU** -> **CIN ADC**</span>: "ASY404, unrestricted"  
-    <span class="hotline">**CIN ADC** -> **CIN TCU**</span>: "ASY404"  
+The Standard Assignable Level from  **CIN ADC** to **CIN TCU** is:
+
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `F190` and `RFL` |
 
 ### TRT(ASH)
 #### Departures
-Voiceless coordination is in place from CIN TCU to ASH for aircraft:  
-Planned at or above `F190`: `Assigned F190`  
-Planned below `F190`: `Assigned the RFL`  
+Voiceless coordination is in place from CIN TCU to ASH for aircraft assigned the lower of `F190` and `RFL`. 
 
 Any aircraft not meeting the above criteria must be prior coordinated to ENR.
 

--- a/docs/terminal/darwin.md
+++ b/docs/terminal/darwin.md
@@ -31,9 +31,7 @@ When both DN TCU positions are opened, DN TCU is split east and west along the r
 ADC owns the airspace within the DN CTR (`SFC`–`A010`). This airspace is designed to facilitate the processing of helicopter scenic flights and low-level helicopter circuits.  
 The CTR extends 7NM from the thresholds of runways 11 and 29 but does not including the Robertson Barracks transit zone.  
 
-ADC may request DN TCU (`SFC`–`A020`) from DN TCU to facilitate fixed-wing circuit operations:  
-a) Fixed-wing circuit operations are typically conducted at Delissaville (YDLV) due to high traffic density at Darwin  
-b) ADC may deny requests for circuits if IFR traffic may be unduly delayed  
+ADC may request DN TCU (`SFC`–`A020`) from DN TCU to facilitate fixed-wing circuit operations. Fixed-wing circuit operations are typically conducted at Delissaville (YDLV) due to high traffic density at Darwin.
 
 <figure markdown>
 ![DN ADC Airspace](img/dnadc.png){ width="700" }
@@ -64,34 +62,17 @@ The NETA is defined as the area between DN 360R–060R from 15NM–30NM DN DME.
 Aircraft are to be cleared to the NETA via the 030R outbound. Vertical limits are to be specified by DAW prior to issuing airways clearance  
 
 ### Designated Fuel Dumping Area
-Other than in an emergency, the designated fuel jettison area is:  
-a) Over water in the Beagle Gulf  
-b) Between the 320 and 020 TACAN radials  
-c) `A060` or above  
+Other than in an emergency, the designated fuel jettison area is:
+
+- Over water in the Beagle Gulf  
+- Between the 320 and 020 TACAN radials  
+- `A060` or above  
 
 ### Robertson Barracks
 Darwin TCU is not responsible for traffic or separation services within the A005 step to the east of Darwin. This step is designed for low-level VFR MIL helos to transit in/out of Robertson Barracks without the need for communication with Darwin TCU.
 
 ### YPDN VFR Departures
-`A020` or the planned level; whichever is lower, to all VFR aircraft.  
-
-VFR aircraft are required to track via one of the published VFR Routes.  
-
-VFR routes shall be assigned based on the destination radial from Darwin.  
-
-Assign VFR routes in accordance with the following radial chart:  
-
-|Outbound Radial |Assigned VFR Route|
-|---|---|
-|360 – 040 |VFR Route 1|
-|041 – 084 |VFR Route 2|
-|085 – 124 |VFR Route 3|
-|125 – 180 |VFR Route 4|
-|181 – 224 |VFR Route 5|
-|225 – 359| Direct|
-
-!!! tip
-    If a VFR aircraft has not planned via a VFR route as above, use the phraseology: “ABC, cleared amended route VFR route 1, maintain A020, squawk 4512”
+VFR aircraft generally track via designated VFR routes, as shown on the Darwin VTC.
 
 ## Coordination
 ### Enroute
@@ -120,22 +101,16 @@ Voiceless for all aircraft:
 All other aircraft coming from TRT CTA will be **Heads-up** Coordinated to DN TCU.
 
 ### ADC
-#### Airspace
-DN ADC owns the airspace within the DN CTR `SFC`–`A010`.
-
 #### Auto Release
-Auto-Release is **not available** at YPDN. All Departures will be coordinated when ready for departure.
+[Next](../controller-skills/coordination.md#next) coordination is required from DN ADC to DN TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**DN ADC** -> **DN TCU**</span>: "Next, EOC, runway 18"  
-    <span class="hotline">**DN TCU** -> **DN ADC**</span>: "EOC, Track Extended Centreline, unrestricted"  
-    <span class="hotline">**DN ADC** -> **DN TCU**</span>: "Track Extended Centreline, EOC"  
+The Standard Assignable Level from  **DN ADC** to **DN TCU** is:
 
-The Standard Assignable level from **DN ADC** to **DN TCU** is:
-
-- For IFR aircraft assigned a Procedural SID: the lower of `F180` or the `RFL`.  
-- For IFR aircraft **not** assigned a Procedural SID: the lower of `A030` or the `RFL`.  
-- For VFR aircraft: the lower of `A020` or the `RFL`.
+| Aircraft | Level |
+| -------- | ----- |
+| IFR aircraft assigned a **Procedural** SID | The lower of `F180` and `RFL` |
+| IFR aircraft **not** assigned a **Procedural** SID | The lower of `A030` and `RFL` |
+| VFR aircraft | The lower of `A020` and `RFL` |
  
 ### DN TCU Internal
 Heads-up coordination is not required between DAW and DAE for:

--- a/docs/terminal/eastsale.md
+++ b/docs/terminal/eastsale.md
@@ -8,7 +8,7 @@
 
 | Name               | ID      | Callsign             | Frequency        | Login ID    |
 | ------------------ | ------- | ------------------- | ---------------- | ------------------- |
-| **East Sale TMA**  | **ESA** | **East Sale Approach** | **123.300**      | **ES_APP**          |
+| **East Sale TMA**  | **ESA** | **Sale Approach** | **123.300**      | **ES_APP**          |
 
 ## Airspace
 

--- a/docs/terminal/eastsale.md
+++ b/docs/terminal/eastsale.md
@@ -12,14 +12,11 @@
 
 ## Airspace
 
-ES TCU controls the airspace within R360. Typically, sectors R360A through R360F are active. The enroute controllers manage the airspace beneath the active R360 sectors, with YWE controlling the southern section and ELW controlling the northern section.
-Coordination with both enroute controllers is needed if online.
+ES TCU is responsible for the restricted airspace within R360, from the base of CTA to `F210`. Typically, sectors R360A through R360F are active. The enroute controllers manage the airspace beneath the active R360 sectors, with YWE controlling the southern section and ELW controlling the northern section. Coordination with both enroute controllers is needed if online.
 
-R393 is a reserved and is activated only for special events.
+R393 is reserved and is activated only for special events.
 
 If operationally necessary, ES TCU may also request the activation of M301 airspace segments for military exercises up to `F450`.
-
-Release coordination with the overlying enroute controller is required.
 
 <figure markdown>
 ![ESL TMA](img/esltcu.png){ width="700" }
@@ -28,11 +25,10 @@ Release coordination with the overlying enroute controller is required.
 
 
 ## Logon Process
-
 Given the specific nature of the East Sale TCU airspace, surrounding controllers may not be fully aware of its boundaries. Upon logging on as East Sale TCU, it is essential to announce the activation status of R360/M301.
 
 !!! phraseology
-    <span class="hotline">**ESA** -> **ELW**</span>: "Request activation of R360 from SFC to F210"
+    <span class="hotline">**ESA** -> **ELW**</span>: "Request activation of R360 from BCTA to F210"
 
 ## Circuit Procedures
 
@@ -163,20 +159,19 @@ The training areas around East Sale are crucial for military operations. Each ar
 Aircraft arriving from any Training Area (TA) will remain in the TA until direct entry into an IAP is possible. ATC should anticipate the sequence to allow for efficient tracking and sequencing.
 
 ### Visual Approach
-
 When expect visual approach is advertised on the ATIS:
 
-- Maintain `A070`.
-- Track to intercept an inbound lane prior to exiting the TRA (20 NM).
-- Sequence aircraft for a Visual Approach via Initial Point (IP) for the duty runway.
+- Aircraft shall be instructed to maintain `A070`
+- Track to intercept an inbound lane prior to exiting the TRA (20 NM)
+- Sequence aircraft for a Visual Approach via Initial Point (IP) for the duty runway
 
 ### Instrument 
 
 When expect instrument approach is advertised on the ATIS:
 
-- Maintain `A070`.
-- Track to intercept an inbound lane prior to exiting the TRA (20 NM).
-- Sequence aircraft for an Instrument Approach Procedure in accordance with the table below.
+- Aircraft shall be instructed to maintain `A070`
+- Track to intercept an inbound lane prior to exiting the TRA (20 NM)
+- Sequence aircraft for an Instrument Approach Procedure in accordance with the table below
 
 | Runway   | Lane          | IAP   | IAF    | LSALT   |
 | -------- | ------------- | ----- | ------ | ------- |
@@ -195,29 +190,42 @@ When expect instrument approach is advertised on the ATIS:
 
 
 ## Coordination
+### Enroute
+#### Departures
+Voiceless for all aircraft:
+
+- Tracking via a Procedural SID terminus; and  
+- Assigned the lower of `F200` or the `RFL`
+
+All other aircraft going to ELW/YWE CTA must be **Heads-up** Coordinated by ES TCU prior to the boundary. 
+
+#### Arrivals
+Voiceless for all aircraft:
+
+- With ADES **YMES**; and
+- Assigned `A100`
+
+All other aircraft coming from ELW/YWE CTA will be **Heads-up** Coordinated to ES TCU.
 
 ### Auto Release
+[Next](../controller-skills/coordination.md#next) coordination is required from ES ADC to ES TCU for all aircraft.
 
-Auto release is not utilized at East Sale. 'Next' coordination is required from ES ADC to ES TCU for all aircraft.
+The Standard Assignable Level from  **ES ADC** to **ES TCU** is:
 
-!!! phraseology
-    <span class="hotline">**ES ADC** -> **ES TCU**</span>: "Next, ASY01, runway 09"     
-    <span class="hotline">**ES TCU** -> **ES ADC**</span>: "ASY01, Assigned Heading Left 030, unrestricted"         
-    <span class="hotline">**ES ADC** -> **ES TCU**</span>: "Left Heading 030, ASY01" 
-
-### Helicopter Operations Coordination
+| Aircraft | Level |
+| -------- | ----- |
+| Fixed-wing | The lower of `F160` and `RFL` |
+| Rotary-wing | The lower of `A040` and `RFL` |
 
 Helicopters departing from helicopter spots will be treated as if departing from the duty runway.
 
-*PSDN14 is a VFR helicopter departing from the threshold of RWY04 (in the direction of runway 27)*  
-
 !!! phraseology
-    <span class="hotline">**ES ADC** -> **ES TCU**</span>: "Next, PSDN14, runway 09"    
-    <span class="hotline">**ES TCU** -> **ES ADC**</span>: "PSDN14, Assigned Heading Left 010, unrestricted"  
-    <span class="hotline">**ES ADC** -> **ES TCU**</span>: "Left Heading 010, PSDN14"  
+    *PSDN14 is a VFR helicopter departing from the threshold of RWY04 (in the direction of runway 27)*  
+    <span class="hotline">**ES ADC** -> **ES TCU**</span>: "Next, PSDN14, runway 27"  
+    <span class="hotline">**ES TCU** -> **ES ADC**</span>: "PSDN14, right turn, unrestricted"  
+    <span class="hotline">**ES ADC** -> **ES TCU**</span>: "Right turn, PSDN14" 
 
 ### Transfer to Tower
-
 Transfer to tower frequency at the following points:
 
 - **Visual approach:** 10NM
@@ -229,5 +237,4 @@ Transfer to tower frequency at the following points:
   - **DME:** 10NM
 
 ## Charts
-
 Aerodrome and instrument approach charts are available in the AIP. Additionally, refer to the RAAF TERMA document, available towards the bottom of [RAAF AIP page](https://ais-af.airforce.gov.au/australian-aip).

--- a/docs/terminal/learmonth.md
+++ b/docs/terminal/learmonth.md
@@ -31,17 +31,17 @@ The above Restricted Areas are classified as Class C when LM APP is active.
 LM ADC owns the Class C airspace within the LM CTR from `SFC` to `A015`.
 
 #### Departures
-'Next' coordination is required from LM ADC to LM TCU for all aircraft.
+[Next](../controller-skills/coordination.md#next) coordination is required from LM ADC to LM TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**LM ADC** -> **LM TCU**</span>: "Next, QFA1601, runway 36"  
-    <span class="hotline">**LM TCU** -> **LM ADC**</span>: "QFA1601, Right heading 060 Visual, unrestricted"  
+The Standard Assignable Level from  **LM ADC** to **LM TCU** is:
+
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `F270` and `RFL` | 
 
 ### OLW 
 #### Departures
-Voiceless coordination is in place from LM TCU to OLW for aircraft:  
-Planned at or above `F270`: `Assigned F270`  
-Planned below `F270`: `Assigned the RFL`  
+Voiceless coordination is in place from LM TCU to OLW for aircraft assigned the lower of `F270` and `RFL`.
 
 Any aircraft not meeting the above criteria must be prior coordinated to ENR.
 

--- a/docs/terminal/melbourne.md
+++ b/docs/terminal/melbourne.md
@@ -263,7 +263,7 @@ All other aircraft coming from Enroute CTA will be **Heads-up** Coordinated to M
 !!! warning "Important"
     Melbourne utilises auto release for all **Procedural** SIDs and the **ML (RADAR)** SID provided aircraft are assigned the Standard Assignable Level and a [Standard Assignable Heading](#standard-assignable-departure-headings).
 
-'Next' coordination is **not** required for aircraft that are:  
+[Next](../controller-skills/coordination.md#next) coordination is **not** required for aircraft that are:  
 
 - Assigned a **Procedural** SID  
     - Departing from a runway nominated on the ATIS; and  
@@ -277,12 +277,13 @@ All other aircraft coming from Enroute CTA will be **Heads-up** Coordinated to M
     - Assigned `A050`; and  
     - Tracking via **MNG**, **NONIX**, **DOSEL**, **KEPPA**, **NEVIS** or **ESDIG**
 
-Any aircraft that don't meet these criteria will be coordinated to ML TCU with a "Next" Call.  
+All other aircraft require a 'Next' call to ML TCU.
 
-!!! phraseology
-    <span class="hotline">**ML ADC** -> **ML TCU**</span>: "Next, CYF, runway 34"  
-    <span class="hotline">**ML TCU** -> **ML ADC**</span>: "CYF, track extended centreline, unrestricted"  
-    <span class="hotline">**ML ADC** -> **ML TCU**</span>: "Track extended centreline, CYF"
+The Standard Assignable level from **ML ADC** to **ML TCU** is:
+
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `A050` and `RFL` |
 
 ##### Standard Assignable Departure Headings
 The following Standard Assignable Headings may be used for aircraft assigned the ML (RADAR) SID, depending on their direction of travel.
@@ -341,46 +342,42 @@ EN ADC is responsible for the Class C airspace shown below, `SFC` to `A020`.
 When an aircraft requests start clearance, the EN SMC controller shall coordinate with ML TCU to obtain the start clearance.
 
 #### Departures
-Essendon departures that will not enter ML TCU Class C airspace are not required to be coordinated.
+[Next](../controller-skills/coordination.md#next) coordination is required from ED ADC to AD TCU for all aircraft **entering ML TCU CTA**.
 
-All aircraft departing into Class C must be coordinated to ML TCU with a "Next" Call
+The Standard Assignable level from ED ADC to AD TCU is:
 
-!!! phraseology
-    <span class="hotline">**EN ADC** -> **ML TCU**</span>: "Next, FD318"  
-    <span class="hotline">**ML TCU** -> **EN ADC**</span>: "FD318, heading 330, unrestricted"  
-    <span class="hotline">**EN ADC** -> **ML TCU**</span>: "Heading 330, FD318"
-
-The Standard Assignable level from EN ADC to ML TCU is the lower of `A030` or the `RFL`, any other level must be prior coordinated.
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `A030` and `RFL` |
 
 #### Arrivals/Overfliers
 ML TCU will heads-up coordinate arrivals/overfliers from Class C to EN ADC prior to **5 mins** from the boundary.  
-IFR aircraft will be cleared for the coordinated approach (Instrument or Visual) prior to handoff to EN ADC, unless EN ADC nominates a restriction.  
-VFR aircraft require a level readback.
+IFR aircraft will be cleared for the coordinated approach (Instrument or Visual) prior to handoff to EN ADC, unless EN ADC nominates a restriction.
 
 !!! phraseology 
     <span class="hotline">**ML TCU** -> **EN ADC**</span>: "via KAO, KHU"  
     <span class="hotline">**EN ADC** -> **ML TCU**</span>: "KHU, A015"
 
 !!! Note
-    For aircraft not tracking via an Arrival Gate (ML TCU shall clear aircraft for approach via the appropriate arrival gate:), ML TCU is required to coordinate descent of aircraft into EN ADC airspace.
+    For aircraft not tracking via an Arrival Gate, ML TCU is required to coordinate descent of aircraft into EN ADC airspace.
 
 When “The Coffin” is released, ML TCU is required to coordinate any use of Runway 27 to EN ADC prior to use.
 
 ### AV ADC
 #### Departures
-'Next' coordination is **not** required from AV ADC for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; or  
-  b) Assigned the standard assignable level; or  
-  c) Assigned a **Procedural** SID
+[Next](../controller-skills/coordination.md#next) coordination is **not** required to ML TCU for aircraft that are:  
 
-Any aircraft that don't meet these criteria will be coordinated to ML TCU with a "Next" Call
+- Departing from a runway nominated on the ATIS; and  
+- Assigned the standard assignable level; and  
+- Assigned a **Procedural** SID
 
-!!! phraseology
-    <span class="hotline">**AV ADC** -> **MAV**</span>: "Next, UJI, Runway 18"  
-    <span class="hotline">**MAV** -> **AV ADC**</span>: "UJI, left 030, unrestricted"  
-    <span class="hotline">**AV ADC** -> **MAV**</span>: "Left 030, UJI"
+All other aircraft require a 'Next' call to ML TCU.
 
-The Standard Assignable level from AV ADC to ML TCU is the lower of `A040` or the `RFL`.
+The Standard Assignable level from **AV ADC** to **ML TCU** is:
+
+| Aircraft | Level |
+| ----- | -------| 
+| All | The lower of `A040` and `RFL` |
 
 #### Arrivals
 Heads-up Coordination is not required to AV ADC for YMAV arrivals, due to MAV owning the surrounding airspace. Aircraft shall be instructed to contact AV ADC on final, as per Class C Tower handoffs.
@@ -392,13 +389,15 @@ MB ADC is responsible for the Class D airspace in the MB CTR `SFC` to `A025`.
 Refer to [Reclassifications](#mb-ctr) for operations when MB ADC is offline.
 
 #### Departures
-**MB ADC** will issue airways clearances for all departures planned into the overlying Class C airspace. The Standard Assignable level from MB ADC to ML TCU is `A050` or `RFL` if lower.
+**MB ADC** will issue airways clearances for all departures planned into the overlying Class C airspace. Aircraft who will transit Class G airspace on climb into CTA will be cleared to leave and re-enter controlled airspace by **MB ADC**.
 
-Autorelease is not in effect at YMMB and all departures into Class C airspace require a 'Next' call. Consider the current traffic picture and provide a release when able.
+[Next](../controller-skills/coordination.md#next) coordination is required from MB ADC to ML TCU for all aircraft **entering ML TCU CTA**.
 
-!!! phraseology
-    <span class="hotline">**MB ADC** -> **MDS**</span>: "Next, SGE"  
-    <span class="hotline">**MDS** -> **MB ADC**</span>: "SGE, unrestricted"
+The Standard Assignable level from **MB ADC** to **ML TCU** is:
+
+| Aircraft | Level |
+| ----- | ---- |
+| All | The lower of `A050` and `RFL` |
 
 #### Arrivals/Overfliers
 ML TCU will heads-up coordinate arrivals/overfliers from Class C to MB ADC prior to **5 mins** from the boundary.  

--- a/docs/terminal/nowra.md
+++ b/docs/terminal/nowra.md
@@ -68,11 +68,12 @@ All other aircraft coming from BIK(WOL) CTA will be **Heads-up** Coordinated to 
 NW ADC owns the Class C airspace from `SFC` to `A020`, within a 5nm radius of the NWA TACAN. This airspace is designed to facilitate helicopter and circuit traffic.
 
 #### Auto Release
-Auto release is not utilised at Nowra. 'Next' coordination is required from NW ADC to NW TCU for all aircraft.
+[Next](../controller-skills/coordination.md#next) coordination is required from NW ADC to NW TCU for all aircraft.
 
-The Standard Assignable Level from **NW ADC** to **NW TCU** is `F120` or `RFL`, whichever is lower.
+The Standard Assignable level from **NW ADC** to **NW TCU** is:
 
-!!! phraseology
-    <span class="hotline">**NW ADC** -> **NW TCU**</span>: "Next, BUCK03, runway 08"  
-    <span class="hotline">**NW TCU** -> **NW ADC**</span>: "BUCK03, Assigned Heading Left 030, unrestricted"  
-    <span class="hotline">**NW ADC** -> **NW TCU**</span>: "Assigned Heading Heading Left 030, BUCK03"
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `F120` and `RFL` | 
+
+Helicopters departing from helicopter spots will be treated as if departing from the duty runway.

--- a/docs/terminal/pearce.md
+++ b/docs/terminal/pearce.md
@@ -56,28 +56,24 @@ All other arrivals/overfliers coming from HYD CTA will be **Heads-up** Coordinat
     <span class="hotline">**PH TCU** -> **PE TCU**</span>: "PHNX11, F180"  
 
 ### PE ADC
-'Next' coordination is required from PE ADC to PE TCU for all aircraft.
-
-!!! phraseology
-    <span class="hotline">**PE ADC** -> **PE TCU**</span>: "Next, ASY01, runway 36L"  
-    <span class="hotline">**PE TCU** -> **PE ADC**</span>: "ASY01, Heading 030, unrestricted"  
-    <span class="hotline">**PE ADC** -> **PE TCU**</span>: "Heading 030, ASY01"
+[Next](../controller-skills/coordination.md#next) coordination is required from PE ADC to PE TCU for all aircraft.
 
 The Standard Assignable Level from **PE ADC** to **PE TCU** is:
 
-- `F130` for aircraft assigned a Procedural SID; except
-- `A030` for aircraft assigned the **GUNOK** SID; or
-- The lower of `F130` or `RFL` for all other aircraft
+| Departure Procedure | Level |
+| ------------------- | ----- |
+| **GUNOK** SID | `A030` |
+| A **Procedural** SID | `F130` |
+| All others | The lower of `F130` and `RFL` |
 
 ### GIG ADC
-'Next' coordination is required from GIG ADC to PE TCU for all aircraft.
+[Next](../controller-skills/coordination.md#next) coordination is required from GIG ADC to PE TCU for all aircraft.
 
-!!! example
-    <span class="hotline">**GIG ADC** -> **PE TCU**</span>: "Next, VIPR01, Runway 08"  
-    <span class="hotline">**PE TCU** -> **GIG ADC**</span>: "VIPR01, Assigned Heading Right 030, unrestricted"  
-    <span class="hotline">**PE ADC** -> **PE TCU**</span>: "Right Heading 030, VIPR01"
+The Standard Assignable Level from **GIG ADC** to **PE TCU** is:
 
-The Standard Assignable Level from **GIG ADC** to **PE TCU** is the lower of `A050` or the `RFL`.
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `A050` and `RFL` |
 
 ## Charts
 !!! abstract "Reference"

--- a/docs/terminal/perth.md
+++ b/docs/terminal/perth.md
@@ -135,34 +135,25 @@ All other aircraft coming from PIY CTA will be **Heads-up** Coordinated to PH TC
 
 ### PH ADC
 #### Auto Release
-'Next' coordination is **not** required for aircraft that are:   
-    a) Departing from a runway nominated on the ATIS; and  
-    b) Assigned the standard assignable level; and  
-    c) Assigned a **Procedural SID**
+[Next](../controller-skills/coordination.md#next) coordination is **not** required for aircraft that are:   
+
+- Departing from a runway nominated on the ATIS; and  
+- Assigned the standard assignable level; and  
+- Assigned a **Procedural SID**
 
 All other aircraft require a 'Next' call to PH TCU.
 
-!!! phraseology
-    <span class="hotline">**PH ADC** -> **PH TCU**</span>: "Next, ABC, runway 03"  
-    <span class="hotline">**PH TCU** -> **PH ADC**</span>: "ABC, Heading 010, unrestricted"  
-    <span class="hotline">**PH ADC** -> **PH TCU**</span>: "Heading 010, ABC"  
+The Standard Assignable level from PH ADC to PH TCU is:
 
-    **PH ADC**: "ABC, Assigned heading left 010, Runway 03, Cleared for Takeoff"  
-    **ABC**: "Left heading 010, Runway 010, Cleared for Takeoff, ABC"
-
-The PH TCU controller can suspend/resume Auto Release at any time, with the concurrence of PH ADC.
-
-The Standard Assignable level from PH ADC to PH TCU is the lower of `A050` or the `RFL`.
+| Aircraft | Level |
+| -------- | ----- |
+| All | The lower of `A050` and `RFL` |
 
 #### Airways Clearances
-The controller assuming responsibility of ACD shall give heads-up coordination to the relevant PH TCU controller prior to the issue of the following clearances:  
-a) VFR Departures  
-b) Aircraft using a runway not on the ATIS
+The controller assuming responsibility of ACD shall give [heads-up](../controller-skills/coordination.md#airways-clearance) coordination to the relevant PH TCU controller prior to the issue of the following clearances:  
 
-!!! phraseology
-    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "ABC, requesting Victor 65"  
-    <span class="coldline">**PH TCU** -> **PH ACD**</span>: "ABC, cleared Victor 65, 1,500ft"  
-    <span class="coldline">**PH ACD** -> **PH TCU**</span>: "Cleared Victor 65, 1,500ft, ABC"
+- VFR departures into PH TCU CTA
+- Aircraft using a runway not on the ATIS 
 
 ### PH TCU Internal
 Voiceless coordination is in place for all aircraft processed by the Victor 65 and 66 routes in accordance with the table below.

--- a/docs/terminal/scherger.md
+++ b/docs/terminal/scherger.md
@@ -31,11 +31,13 @@ The above Restricted Areas are classified as Class C when SG APP is active.
 SG ADC owns the Class C airspace within the SG CTR from `SFC` to `A015`.
 
 #### Departures
-'Next' coordination is required from SG ADC to SG TCU for all aircraft.
+[Next](../controller-skills/coordination.md#next) coordination is required from SG ADC to SG TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**SG ADC** -> **SG TCU**</span>: "Next, ASY219, runway 30"  
-    <span class="hotline">**SG TCU** -> **SG ADC**</span>: "ASY219, unrestricted"  
+The Standard Assignable Level from  **SG ADC** to **SG TCU** is:
+
+| Aircraft | Level |
+| ------- | ------- |
+| All | The lower of `F240` and `RFL` | 
 
 ### ISA(ARA)
 #### Departures

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -579,6 +579,12 @@ Heads-up coordination is not required from a SY TCU position to SRI for aircraft
 #### Airspace
 SY ADC is responsible for the Class C airspace in the SY CTR `SFC` to `A005`.
 
+#### ACD to SY TCU
+The controller assuming responsibility of **SY ACD** shall give [heads-up](../controller-skills/coordination.md#airways-clearance) coordination to the relevant SY TCU controller prior to the issue of the following clearances: 
+
+- VFR departures, other than helicopters assigned a helicopter route coded clearance  
+- Aircraft using a runway not on the ATIS
+
 #### Auto Release
 Auto Release is used for virtually all fixed-wing departures at Sydney. Unlike some other aerodromes, aircraft cleared via the **SY (RADAR) SID** do not need to be 'Next' coordinated, provided they are assigned the standard assignable level and a standard assignable heading from the table below.
 
@@ -597,31 +603,29 @@ Auto Release is used for virtually all fixed-wing departures at Sydney. Unlike s
 !!! tip
     If strong winds are present at altitude, TWR/DEP should discuss slight changes to these headings (+/- 5 degrees) to compensate for large crosswind components.
 
-'Next' coordination is **not** required for aircraft that are:   
-    a) Departing from a runway nominated on the ATIS; and   
-    b) Assigned the Standard assignable level; and  
-    c) Assigned a **Procedural SID** (except **ABBEY** SID); or  
-    d) Assigned the **Radar** SID with a Standard Assignable Heading
+[Next](../controller-skills/coordination.md#next) coordination is **not** required for aircraft that are:   
 
-All other aircraft require a 'Next' call from SY ADC.
+- Departing from a runway nominated on the ATIS; and   
+- Assigned the Standard assignable level; and  
+- Assigned a **Procedural SID** (except **ABBEY** SID); or  
+- Assigned the **Radar** SID with a Standard Assignable Heading
+
+All other aircraft require a 'Next' call to SY TCU.
 
 'Next' coordination is additionally required for:  
-    a) Visual departures  
-    b) Departures to YSBK  
-    c) After a go around, the next departure from that runway  
-    d) Jets departing 16L via WOL  
-    e) All aircraft during the Curfew Runway Mode
 
-!!! phraseology
-    <span class="hotline">**SY ADC** -> **SY TCU**</span>: "Next, ADA4, runway 34R"  
-    <span class="hotline">**SY TCU** -> **SY ADC**</span>: "ADA4, Heading 030, unrestricted"  
-    <span class="hotline">**SY ADC** -> **SY TCU**</span>: "Heading 030, ADA4"
+- Visual departures  
+- Departures to YSBK  
+- After a go around, the next departure from that runway  
+- Jets departing 16L via WOL  
+- All aircraft during the Curfew Runway Mode
 
-The SY TCU controller can suspend/resume Auto Release at any time, with the concurrence of **SY ADC**.
+The Standard Assignable level from SY ADC to SY TCU is: 
 
-The Standard Assignable level from SY ADC to SY TCU is:  
-For Jets: `A050`  
-For Non-Jets: The lower of `A030` or the `RFL`
+| Aircraft | Level |
+| -------- | ----- |
+| Jets | `A050` |
+| Non-Jets | The lower of `A030` and `RFL` |
 
 ### BK ADC
 #### Airspace
@@ -630,16 +634,13 @@ BK ADC is responsible for the Class D airspace in the BK CTR `SFC` to `A015`.
 Refer to [Reclassifications](#bk-ctr) for operations when BK ADC is offline.
 
 #### Departures
-Aircraft departing YSBK in to SY TCU Class C will be coordinated from **BK ADC** when ready for takeoff.
+[Next](../controller-skills/coordination.md#next) coordination is required from BK ADC to SY TCU for all aircraft **entering SY TCU CTA**.
 
-!!! phraseology
-    <span class="hotline">**BK ADC** -> **SY TCU**</span>: "Next, TFX12"  
-    <span class="hotline">**SY TCU** -> **BK ADC**</span>: "TFX12, Unrestricted"  
-    <span class="hotline">**BK ADC** -> **SY TCU**</span>: "TFX12"  
+The Standard Assignable level from **BK ADC** to **SY TCU** is:
 
-    **BK ADC** will then clear the aircraft to takeoff , and instruct them to contact SY TCU passing `A015`.
-
-The Standard Assignable level from BK ADC to SY TCU is `A030`.
+| Aircraft | Level |
+| --- | -----|
+| All | `A030` |
 
 #### Arrivals
 SY TCU will heads-up coordinate arrivals/overfliers from Class C to BK ADC prior to **5 mins** from the boundary.  

--- a/docs/terminal/tassie.md
+++ b/docs/terminal/tassie.md
@@ -86,23 +86,30 @@ All other aircraft coming from HUO CTA will be **Heads-up** Coordinated to TAS T
 HB ADC owns the Class D airspace in the HB CTR `SFC` to `A015` north of the runway centreline and `A025` south of the runway centreline. HBA owns the Class D and C airspace above these levels.
 
 #### Departures
-'Next' coordination is **not** required from HB ADC for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a **Procedural** SID; or  
-  d) Not entering HBA CTA
+[Next](../controller-skills/coordination.md#next) coordination is **not** required to HBA for aircraft that are:   
 
-The Standard Assignable level from HB ADC to HBA is:  
-For IFR Aircraft: `A080`  
-For VFR Aircraft: The lower of `A045` or the `RFL`.
+- Departing from a runway nominated on the ATIS; and  
+- Assigned the standard assignable level; and  
+- Assigned a SID; or  
+- Not entering HBA CTA
+
+All other aircraft require a 'Next' call to HBA.
 
 !!! note
     All departures from YCBG who will enter the HBA CTA will be Next coordinated by ADC.
 
+The Standard Assignable level from **HB ADC** to **HBA** is:  
+
+| Flight Rules | Level |
+| ----- | ----- |
+| IFR | `A080` |
+| VFR | The lower of `A045` and `RFL` |
+
 ##### Airways Clearance
-**HB SMC** shall give heads-up coordination to HBA controller prior to the issue of the following clearances:  
-a) VFR Departures  
-b) Aircraft using a runway not on the ATIS
+**HB SMC** shall give [heads-up](../controller-skills/coordination.md#airways-clearance) coordination to HBA controller prior to the issue of the following clearances:
+
+- VFR departures entering HBA CTA
+- Aircraft using a runway not on the ATIS
 
 #### Arrivals
 HBA will coordinate all YMHB & YCBG arrivals to HB ADC prior to **5 mins** from the boundary. This coordination shall be as per [Standard Heads-up format](../../controller-skills/coordination/#heads-up), with the addition of:
@@ -120,14 +127,26 @@ HBA will coordinate all YMHB & YCBG arrivals to HB ADC prior to **5 mins** from 
 LT ADC owns the Class D airspace in the LT CTR `SFC` to `A015`. LTA owns the Class D and C airspace above `A015`.
 
 #### Departures
-'Next' coordination is **not** required from LT ADC for aircraft that are:   
-  a) Departing from a runway nominated on the ATIS; and  
-  b) Assigned the standard assignable level; and  
-  c) Assigned a **Procedural** SID
+[Next](../controller-skills/coordination.md#next) coordination is not required to LTA for aircraft that are:   
 
-The Standard Assignable level from LT ADC to LTA is:  
-For IFR Aircraft: `A080`  
-For VFR Aircraft: The lower of `A045` or the `RFL`.
+- Departing from a runway nominated on the ATIS; and  
+-Assigned the standard assignable level; and  
+-Assigned a SID; or  
+-Not entering LTA CTA
+
+All other aircraft require a 'Next' call to LTA. 
+
+The Standard Assignable level from **LT ADC** to **LTA** is:  
+
+| Flight Rules | Level |
+| ------- | ------ |
+| IFR | `A080` |
+| VFR | The lower of `A045` and `RFL` |
+
+LT ADC shall give [heads-up](../controller-skills/coordination.md#airways-clearance) coordination to LTA controller prior to the issue of the following clearances:  
+
+- VFR departures entering LTA CTA
+- Aircraft using a runway not on the ATIS 
 
 #### Arrivals
 LTA will coordinate all YMLT arrivals to LT ADC prior to **5 mins** from the boundary. This coordination shall be as per [Standard Heads-up format](../../controller-skills/coordination/#heads-up), with the addition of:

--- a/docs/terminal/tindal.md
+++ b/docs/terminal/tindal.md
@@ -90,11 +90,10 @@ Voiceless for all aircraft:
 All other aircraft coming from TRT(TRS) CTA will be **Heads-up** Coordinated to TN TCU.
 
 ### TN ADC
-'Next' coordination is required from TN ADC to TN TCU for all aircraft.
+[Next](../controller-skills/coordination.md#next) coordination is required from TN ADC to TN TCU for all aircraft.
 
-!!! phraseology
-    <span class="hotline">**TN ADC** -> **TN TCU**</span>: "Next, ASY01, runway 32"  
-    <span class="hotline">**TN TCU** -> **TN ADC**</span>: "ASY01, Heading 030, unrestricted"  
-    <span class="hotline">**TN ADC** -> **TN TCU**</span>: "Heading 030, ASY01"  
+The Standard Assignable level from TN ADC to TN TCU is:
 
-The Standard Assignable level from TN ADC to TN TCU is the lower of `F180` or the `RFL`.
+| Aircraft | Level |
+| ----- | ---- |
+| All | The lower of `F180` and `RFL` |

--- a/docs/terminal/townsville.md
+++ b/docs/terminal/townsville.md
@@ -54,14 +54,14 @@ All other aircraft coming from TBP CTA will be **Heads-up** Coordinated to TL TC
 TL ADC owns the Class C airspace in the TL CTR from `SFC` to `A015`.
 
 #### Auto Release  
-'Next' coordination is **not** required from TL ADC to TL TCU for aircraft that are:  
-a) Departing from a runway nominated in the ATIS; and  
-b) Assigned the standard assignable level;  
-c) Assigned a **Procedural** SID  
+[Next](../controller-skills/coordination.md#next) coordination is **not** required from TL ADC to TL TCU for aircraft that are:  
 
-!!! phraseology
-    <span class="hotline">**TL ADC** -> **TL TCU**</span>: "Next, DNGO05, runway 19"  
-    <span class="hotline">**TL TCU** -> **TL ADC**</span>: "DNGO05, Assigned Heading Left 150, unrestricted"  
-    <span class="hotline">**TL ADC** -> **TL TCU**</span>: "Assigned Heading Left 150, DNGO05"  
+- Departing from a runway nominated in the ATIS; and  
+- Assigned the standard assignable level; and 
+- Assigned a **Procedural** SID 
 
-The Standard Assignable level from TL ADC to TL TCU is the lower of `F180` or the RFL.
+The Standard Assignable level from TL ADC to TL TCU is:
+
+| Aircraft | Level |
+| ------ | ------- |
+| All | The lower of `F180` and `RFL` |

--- a/docs/terminal/williamtown.md
+++ b/docs/terminal/williamtown.md
@@ -77,17 +77,17 @@ All other aircraft coming from ARL CTA will be **Heads-up** Coordinated to WLM T
 WLM ADC owns the airspace within the WLM MIL CTR A (`SFC`-`A050`). This may be amended/released as required between WLM ADC and WLM TCU.
 
 #### Departures
-'Next' coordination is **not** required from WLM ADC to WLM TCU for aircraft that are:  
-a) Departing from a runway nominated in the ATIS; and  
-b) Assigned the standard assignable level;  
-c) Assigned a **Procedural** SID  
+[Next](../controller-skills/coordination.md#next) coordination is **not** required from WLM ADC to WLM TCU for aircraft that are:  
 
-!!! phraseology
-    <span class="hotline">**WLM ADC** -> **WLM TCU**</span>: "Next, MVP"  
-    <span class="hotline">**WLM TCU** -> **WLM ADC**</span>: "MVP, Left Heading 010, Unrestricted"  
-    <span class="hotline">**WLM ADC** -> **WLM TCU**</span>: "Left Heading 010, MVP"  
+- Departing from a runway nominated in the ATIS; and  
+- Assigned the standard assignable level; and 
+- Assigned a **Procedural** SID
 
-The Standard Assignable level from WLM ADC to WLM TCU is the lower of `F120` or the `RFL`.
+The Standard Assignable level from WLM ADC to WLM TCU is:
+
+| Aircraft | Level |
+| ------- | ----- |
+| All | The lower of `F120` and `RFL` |
 
 #### Arrivals/Overfliers
 Voiceless coordination is in place from WLM TCU to WLM ADC for arrivals cleared for an approach on to a runway nominated on the ATIS. All other aircraft and all overfliers must be heads-up coordinated as soon as practical.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,6 @@
 # Project Information
 site_name: VATPAC Standard Operating Procedures
 site_url: https://sops.vatpac.org
-repo_url: https://github.com/vatpac-technology/sops
-repo_name: vatpac-technology/sops
 edit_uri: "" #removes edit button and icon
 copyright: ""
 


### PR DESCRIPTION
## Summary
Standardises coordination rules, provides additional examples, and improves the formatting of some Controller Skills pages. Fixes numerous other small issues.

## Changes
**Fixes**:
- Improved formatting on **Coordination** page
- Auto Release formatting standardisation on **all pages**
- **YMES** formatting changes
- **YPED** formatting changes
- **YSRI** formatting changes
- **YPDN** formatting changes
- **YMES** formatting changes, including airspace upper limit
- **YMES** position callsigns

**Changes**:
- **YSSY** coordination requirements prior to issuing airways clearance
- **YBCS** coordination requirements prior to issuing airways clearance
- **YPPH** coordination requirements prior to issuing airways clearance
- **YMHB** coordination requirements prior to issuing airways clearance
- **YMLT** coordination requirements prior to issuing airways clearance
- Auto Release formatting standardisation on **all pages**

**Additions**:
- Airways Clearance coordination format
- Edge cases and additional examples for various coordination scenarios
- Note for HB SMC to update the FDR of any IFR departures from YCBG assigned a YMHB SID
- YMML pushback disconnect point note
- ES TCU to ELW/YWE coordination rules
