### PR TITLE
Fix navbar using full height on WebKit browsers

### DIFF
--- a/docs/stylesheets/navigation.css
+++ b/docs/stylesheets/navigation.css
@@ -22,18 +22,15 @@
 .md-tabs__link--active, .md-tabs__link:focus {
   border-bottom: 1.5px solid #b5b6b3;
   color: var(--md-primary-fg-color);
-  height: -webkit-fill-available;
 }
 .md-tabs__item--active {
   border-bottom: 1.5px solid #b5b6b3;
   color: #344767;
-  height: -webkit-fill-available;
 }
 
 .md-tabs__link:hover {
   border-bottom: 1.5px solid #3447679f;
   color: var(--md-primary-fg-color);
-  height: -webkit-fill-available;
 }
 .md-nav__link[data-md-state=blur]:not(.md-nav__link--active) {
   color: inherit;


### PR DESCRIPTION
## Changes
**Fixes**:
- Removes the `height: -webkit-fill-available` property from the tab styles

Tested using Safari and Orion browsers. Checked compatibility on mobile too.