### PR TITLE
Auto update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # JavaScript / Node.js dependencies
+  - package-ecosystem: "npm"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  # Python dependencies via requirements.txt
+  - package-ecosystem: "pip"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"


### PR DESCRIPTION

## Summary
Introduce dependabot, a github feature which automatically updates the dependencies of projects. 

at the moment targetting npm/github-actions/pip

Just does weekly checks.

Noticed that the github actions were dramatically out of date, and dependabot is a free service by github for public repos

**Additions**:
- Add dependabot
