### PR TITLE
Minor Perth Refresh

### DIFF
--- a/docs/aerodromes/classc/Perth.md
+++ b/docs/aerodromes/classc/Perth.md
@@ -26,27 +26,13 @@ Everything West of the Runway belongs to SMC West, everything East of the Runway
 
 ## Runway Selection
 ### Southwest Plan
-With the Southwest Plan active, all departures shall be assigned runway 21. Arrivals will be processed to either runway 21 or 24 based on their feeder fix, as per the table below:
-
-| Feeder Fix | Assigned Runway |
-| --- | --- |
-| JULIM | 21 |
-| SAPKO | 21 |
-| IPMOR | 21 |
-| KABLI | 24 (or 21 if operationally required) |
-| LAVEX | 24 |
-| SOLUS | 24 |
-
-The ATIS shall notify `EXP ILS APCH`.
+With the Southwest Plan active, all departures shall be assigned runway 21. Arrivals will be processed to either runway 21 or 24.
 
 ### Northeast Plan
 With the Northeast Plan active, departures via `AVNEX`, `OTLED`, `OLMAM`, `SOLUS`, and `OPEGA` shall be assigned runway 03. All other departures shall be assigned runway 06. All arrivals will be processed to runway 03.
 
-When both Runway 03 and Runway 06 are nominated as departure runways, broadcast the following: `RWY 03 FOR DEP VIA OTLED, AVNEX, OLMAM, SOLUS AND OPEGA. RWY 06 FOR ALL OTHER DEP.`
-
-In the following conditions, ATIS shall notify `EXP ILS APCH`:  
-    - By night; and/or  
-    - Cloud base of `A032` or below
+### Single Runway Ops
+Where excessive crosswind components exist on a runway in the southwest or northeast runway modes, nominate the most into wind runway as a single runway mode.
 
 ## Circuit Training
 Circuit training traffic shall be issued SSR code and clearance to operate within circuit area not above `A015`. Circuit training is typically conducted on Runway 03/21.
@@ -63,6 +49,19 @@ There are no helipad facilities at YPPH. Helicopters should be issued an airways
 
 ## Scenic Flights
 When traffic permits, VFR scenic flights over Perth are cleared via VICTOR 65 route (`CTE-PCTY-HKE`). Coordination with PH TCU is required prior to issuing this clearance, see [ACD to PH TCU](#acd-to-ph-tcu).
+
+## ATIS
+### Approach Type
+With the [Southwest Plan](#southwest-plan) active, the ATIS shall notify `EXP ILS APCH`.
+
+With the [Northeast Plan](#northeast-plan) active, the ATIS shall notify `EXP ILS APCH` only in the following conditions:
+
+- By night; and/or  
+- Cloud base of `A032` or below
+
+### Runway Nomination
+When both Runway 03 and Runway 06 are nominated as departure runways, the `RWY` field shall contain:  
+`RWY 03 FOR DEP VIA OTLED, AVNEX, OLMAM, SOLUS AND OPEGA. RWY 06 FOR ALL OTHER DEP.`
 
 ## Coordination
 ### Auto Release

--- a/docs/aerodromes/classc/Perth.md
+++ b/docs/aerodromes/classc/Perth.md
@@ -56,7 +56,7 @@ With the [Southwest Plan](#southwest-plan) active, the ATIS shall notify `EXP IL
 
 With the [Northeast Plan](#northeast-plan) active, the ATIS shall notify `EXP ILS APCH` only in the following conditions:
 
-- By night; and/or  
+- By night; or  
 - Cloud base of `A032` or below
 
 ### Runway Nomination

--- a/docs/aerodromes/classd/Jandakot.md
+++ b/docs/aerodromes/classd/Jandakot.md
@@ -42,29 +42,36 @@ Airspace Ownership when ADC East is online, is:
 - At `A015`; owned entirely by ADC West
 - At or below `A010`; split between ADC Circuit/West down the middle of the **06L/24R** and **06R/24L** extended centrelines.
 
+## Runway Modes
+### Parallel Runway Ops
+During parallel runway operations, the northern runway (**06L/24R**) shall be used for VFR arrivals and departures and the southern runway (**06R/24L**) for circuit training and departures via `SHOP`. 
+
+The [ATIS](#runway-nomination) shall be updated to reflect the use of each runway.
+
+### Single Runway Ops
+Where excessive crosswind exists on the parallel runways, Runway 12 or 30 shall be used for all operations.
+
 ## VFR Operations
 ### Arrivals
-VFR aircraft will report inbound at BOAT, POWR, OAKF or RUSS at `A015`. JT ADC will instruct aircraft to maintain `A015` or remain outside the control zone (workload permitting). Aircraft will then report again at ADWD when inbound from BOAT or POWR, or FDL when inbound from OAKF or RUSS. They should then be instructed to join the circuit as below:
+VFR aircraft will report inbound at `BOAT`, `POWR`, `OAKF` or `RUSS` at `A015`. JT ADC shall instruct aircraft to maintain `A015` and report again at `ADWD` when inbound from `BOAT` or `POWR`, or `FDL` when inbound from `OAKF` or `RUSS`.
+
+Aircraft should then be instructed to join the circuit as below:
 
 | VFR Approach Point | RWYs 06  | RWYs 24 | RWY 12 | RWY 30 |
 | ----------------| --------- | ---------- | ---------- | --------- |
-| ADWD   | *"Join base runway 06L"* | *"Join right downwind runway 24R, maintain A015"*, until the aircraft are clear of RWY 24R departures via *Fiona Stanley Hospital* and FREM, then *"Cleared Visual Approach"*  | *"Join final runway 12"* | *"Join downwind ruwnay 30, maintain A015"*, until the aircraft is clear of RWY 30 departures via YGB, then *"Cleared Visual Approach"* |
+| ADWD   | *"Join base runway 06L"* | *"Join right downwind runway 24R, maintain A015"*, until the aircraft are clear of RWY 24R departures via *Fiona Stanley Hospital* and `FREM`, then *"Cleared Visual Approach"*  | *"Join final runway 12"* | *"Join downwind ruwnay 30, maintain A015"*, until the aircraft is clear of RWY 30 departures via `YGB`, then *"Cleared Visual Approach"* |
 | FDL  | *"Join downwind runway 06L, maintain A015"*. Aircraft should fly overhead the airfield between the control tower and the upwind end of the runway and join the circuit. Once established in the circuit, *"Cleared visual approach"* | *"Join right downwind runway 24R, maintain A015"*. Aircraft should fly overhead the airfield between the control tower and the upwind end of the runway and join the circuit. Once established in the circuit, *"Cleared visual approach"* | *"Join right downwind runway 12"* | *"Join final runway 30"* |
 
-All aircraft will arrive on runway 06L/24R or 12/30.
+All aircraft will arrive on runway **06L/24R** or **12/30**.
 
 !!! note
     Circuit joining instructions given without an assigned altitude imply clearance to conduct the visual approach. There is no need to clear these aircraft for a visual approach.
 
 ### Departures
-VFR aircraft should report ready to **JT ADC** with their departure intentions.  A takeoff clearance constitutes a clearance to depart the zone by extending the pilot's requested leg of the circuit.  Aircraft departing the zone into class G airspace will transfer to area frequency upon leaving the zone, **no explicit frequency transfer is given to these aircraft**.
+VFR aircraft shall generally depart the zone on an extended circuit leg at `A010`.
 
-Aircraft departing a leg of the circuit will climb to and maintain the following levels until clear of the zone:  
-All runways: `A010`  
-
-VFR aircraft will depart via set outbound departure routes. Aircraft will track extended circuit legs to the departure point. These departure points include: YGB, FREM via *Fiona Stanley Hospital*, and SHOP.
-
-Departures via FREM and YGB will depart on runway 06L/24R. Runway 06R/24L is used for circuit traffic and departures via SHOP.
+!!! note
+    A takeoff clearance constitutes a clearance to depart the zone by extending the pilot's requested leg of the circuit.  Aircraft departing the zone into class G airspace will transfer to area frequency upon leaving the zone, **no explicit frequency transfer is given to these aircraft**.
 
 ## IFR Operations
 ### Arrivals
@@ -80,7 +87,7 @@ All IFR Departures must be assigned the most appropriate SID in accordance with 
 | East/North-east    | SCARP |
 
 ## Circuits
-The circuit direction changes depending on tower opening hours and runway being used.
+Circuits shall be flown at `A010`.
 
 | Runway | Direction  |
 | -------| ----- |
@@ -91,8 +98,6 @@ The circuit direction changes depending on tower opening hours and runway being 
 | 12     | Left  |
 | 30     | Left  |
 
-Circuits to be flown at `A010`
-
 ## Helicopter Operations
 ### General
 Unless otherwise depicted in the `ERSA FAC YPJT`, all helicopters must comply with fixed wing procedures.
@@ -102,15 +107,15 @@ Circuits are conducted within the lateral confines of the fixed-wing circuit at 
 
 ## ATIS
 ### Runway Nomination
-The ATIS must indicate the current runway config and nominate what each parallel runway is being used for. The northern runway (**06L/24R**) is primarily used for VFR arrivals and departures, the southern runway (**06R/24L**) for circuit training and departures via `SHOP`. The cross runway (**12/30**) for all arrivals/departures when weather is unsuitable for parallel runway operations.  
+Where multiple runways are in use, the ATIS `RWY` field shall indicate:
 
-This should be reflected on the ATIS as below:  
-
-- Single ADC: `RWY 06R/24L FOR CCTS AND DEPS VIA ARMADALE SHOPS. RWY 06L/24R FOR ARRS AND ALL OTHER DEPS`  
-- Dual ADC: `RWY 06R/24L FOR CCTS AND DEPS VIA ARMADALE SHOPS, FREQ 119.4. RWY 06L/24R FOR ARRS AND ALL OTHER DEPS, FREQ 118.1`  
+| ADC Configuration | RWY Field |
+| ----- | ---- |
+| Single ADC | `RWY 06R/24L FOR CCTS AND DEPS VIA ARMADALE SHOPS. RWY 06L/24R FOR ARRS AND ALL OTHER DEPS` |  
+| Dual ADC | `RWY 06R/24L FOR CCTS AND DEPS VIA ARMADALE SHOPS, FREQ 119.4. RWY 06L/24R FOR ARRS AND ALL OTHER DEPS, FREQ 118.1` |
 
 ### Operational Info
-When PH RWY 03 is in operation, the ATIS OPR INFO shall include:
+When YPPH RWY 03 is in use, the `OPR INFO` shall include:  
 `DUE YPPH DUTY RWY 03, CAUTION WAKE TURB`
 
 ## Coordination

--- a/docs/aerodromes/classd/Jandakot.md
+++ b/docs/aerodromes/classd/Jandakot.md
@@ -44,7 +44,7 @@ Airspace Ownership when ADC East is online, is:
 
 ## Runway Modes
 ### Parallel Runway Ops
-During parallel runway operations, the northern runway (**06L/24R**) shall be used for VFR arrivals and departures and the southern runway (**06R/24L**) for circuit training and departures via `SHOP`. 
+During parallel runway operations, the northern runway (**06L/24R**) shall be used for VFR arrivals and departures and the southern runway (**06R/24L**) for circuit training and departures via SHOP. 
 
 The [ATIS](#runway-nomination) shall be updated to reflect the use of each runway.
 
@@ -53,13 +53,13 @@ Where excessive crosswind exists on the parallel runways, Runway 12 or 30 shall 
 
 ## VFR Operations
 ### Arrivals
-VFR aircraft will report inbound at `BOAT`, `POWR`, `OAKF` or `RUSS` at `A015`. JT ADC shall instruct aircraft to maintain `A015` and report again at `ADWD` when inbound from `BOAT` or `POWR`, or `FDL` when inbound from `OAKF` or `RUSS`.
+VFR aircraft will report inbound at BOAT, POWR, OAKF or RUSS at `A015`. JT ADC shall instruct aircraft to maintain `A015` and report again at ADWD when inbound from BOAT or POWR, or FDL when inbound from OAKF or RUSS.
 
 Aircraft should then be instructed to join the circuit as below:
 
 | VFR Approach Point | RWYs 06  | RWYs 24 | RWY 12 | RWY 30 |
 | ----------------| --------- | ---------- | ---------- | --------- |
-| ADWD   | *"Join base runway 06L"* | *"Join right downwind runway 24R, maintain A015"*, until the aircraft are clear of RWY 24R departures via *Fiona Stanley Hospital* and `FREM`, then *"Cleared Visual Approach"*  | *"Join final runway 12"* | *"Join downwind ruwnay 30, maintain A015"*, until the aircraft is clear of RWY 30 departures via `YGB`, then *"Cleared Visual Approach"* |
+| ADWD   | *"Join base runway 06L"* | *"Join right downwind runway 24R, maintain A015"*, until the aircraft are clear of RWY 24R departures via *Fiona Stanley Hospital* and FREM, then *"Cleared Visual Approach"*  | *"Join final runway 12"* | *"Join downwind ruwnay 30, maintain A015"*, until the aircraft is clear of RWY 30 departures via YGB, then *"Cleared Visual Approach"* |
 | FDL  | *"Join downwind runway 06L, maintain A015"*. Aircraft should fly overhead the airfield between the control tower and the upwind end of the runway and join the circuit. Once established in the circuit, *"Cleared visual approach"* | *"Join right downwind runway 24R, maintain A015"*. Aircraft should fly overhead the airfield between the control tower and the upwind end of the runway and join the circuit. Once established in the circuit, *"Cleared visual approach"* | *"Join right downwind runway 12"* | *"Join final runway 30"* |
 
 All aircraft will arrive on runway **06L/24R** or **12/30**.
@@ -68,9 +68,9 @@ All aircraft will arrive on runway **06L/24R** or **12/30**.
     Circuit joining instructions given without an assigned altitude imply clearance to conduct the visual approach. There is no need to clear these aircraft for a visual approach.
 
 ### Departures
-VFR aircraft shall generally depart the zone on an extended circuit leg at `A010`, except for those tracking via `FREM`.
+VFR aircraft shall generally depart the zone on an extended circuit leg at `A010`, except for those tracking via FREM.
 
-Aircraft departing via `FREM` shall track from the circuit to *Fiona Stanley Hospital*, then climb to `A015` and track to `FREM`.
+Aircraft departing via FREM shall track from the circuit to *Fiona Stanley Hospital*, then climb to `A015` and track to FREM.
 
 !!! note
     A takeoff clearance constitutes a clearance to depart the zone by extending the pilot's requested leg of the circuit.  Aircraft departing the zone into class G airspace will transfer to area frequency upon leaving the zone, **no explicit frequency transfer is given to these aircraft**.

--- a/docs/aerodromes/classd/Jandakot.md
+++ b/docs/aerodromes/classd/Jandakot.md
@@ -68,7 +68,9 @@ All aircraft will arrive on runway **06L/24R** or **12/30**.
     Circuit joining instructions given without an assigned altitude imply clearance to conduct the visual approach. There is no need to clear these aircraft for a visual approach.
 
 ### Departures
-VFR aircraft shall generally depart the zone on an extended circuit leg at `A010`.
+VFR aircraft shall generally depart the zone on an extended circuit leg at `A010`, except for those tracking via `FREM`.
+
+Aircraft departing via `FREM` shall track from the circuit to *Fiona Stanley Hospital*, then climb to `A015` and track to `FREM`.
 
 !!! note
     A takeoff clearance constitutes a clearance to depart the zone by extending the pilot's requested leg of the circuit.  Aircraft departing the zone into class G airspace will transfer to area frequency upon leaving the zone, **no explicit frequency transfer is given to these aircraft**.

--- a/docs/enroute/Melbourne Centre/HYD.md
+++ b/docs/enroute/Melbourne Centre/HYD.md
@@ -66,6 +66,8 @@ JAR is responsible for assigning and issuing arrival clearance to aircraft inbou
 Aircraft assigned the **same runway** inbound via **JULIM** and **SAPKO**, must be considered to be on the **same STAR** for sequencing purposes. That is, they must be at least **2 minutes** apart at their respective Feeder fixes.
 
 ## YPPH Runway Modes
+Generally, YPPH operates on either the Southwest or Northeast runway plan, as below. Where strong winds dictate the use of only a single runway, this will be nominated in the ATIS.
+
 ### Southwest Plan
 With the Southwest Plan active, arrivals shall be processed to either runway 21 or 24 based on their feeder fix, as per the table below:
 
@@ -74,9 +76,12 @@ With the Southwest Plan active, arrivals shall be processed to either runway 21 
 | JULIM | 21 |
 | SAPKO | 21 |
 | IPMOR | 21 |
-| KABLI | 24 (or 21 if operationally required) |
+| KABLI | 24 |
 | LAVEX | 24 |
 | SOLUS | 24 |
+
+!!! note
+    Where an aircraft operationally requires runway 21, they shall be assigned that runway regardless of feeder fix.
 
 ### Northeast Plan
 With the Northeast Plan active (runways 03 and 06 in use), all arrivals shall be processed to runway 03.

--- a/docs/terminal/perth.md
+++ b/docs/terminal/perth.md
@@ -85,8 +85,8 @@ Aircraft wishing to conduct a scenic flight over the Perth CBD should be cleared
     **VH-CYF:** "Squawk 0542, remain OCTA, CYF"  
 
     *When clearance (reference traffic into/out of YPPH) is available:*  
-    **PHA:** "CYF, cleared Victor 65, maintain A015"  
-    **VH-CYF:** "Cleared Victor 65, maintain A015, CYF"
+    **PHA:** "CYF, cleared Victor 65, maintain A015, QNH 1012"  
+    **VH-CYF:** "Cleared Victor 65, maintain A015, QNH 1012, CYF"
 
 Aircraft departing YPPH and intending to conduct the Victor 65 route will be coordinated by **PH ACD**. See [Airways Clearances](#airways-clearances).
 

--- a/docs/terminal/perth.md
+++ b/docs/terminal/perth.md
@@ -47,7 +47,7 @@ The divisions of the airspace between **PHA**, and **PHD** change based on the R
 </figure>
 
 ## Runway Modes
-Generally, YPPH operates on either the Southwest or Northeast runway plan, as below. Where strong winds dictate the use of only a single runway, this shall be nominated in the ATIS.
+Generally, YPPH operates on either the Southwest or Northeast runway plan, as below. Where strong winds dictate the use of only a single runway, this will be nominated in the ATIS.
 
 ### Southwest Plan
 With the Southwest Plan active, all departures shall be assigned runway 21 by **PH ACD**. Arrivals shall be processed to either runway 21 or 24 based on their feeder fix, as per the table below:
@@ -57,9 +57,12 @@ With the Southwest Plan active, all departures shall be assigned runway 21 by **
 | JULIM | 21 |
 | SAPKO | 21 |
 | IPMOR | 21 |
-| KABLI | 24 (or 21 if operationally required) |
+| KABLI | 24 |
 | LAVEX | 24 |
 | SOLUS | 24 |
+
+!!! note
+    Where an aircraft operationally requires runway 21, they shall be assigned that runway regardless of feeder fix.
 
 ### Northeast Plan
 With the Northeast Plan active, departures via `AVNEX`, `OTLED`, `OLMAM`, `SOLUS`, and `OPEGA` shall be assigned runway 03 by **PH ACD**. All other departures shall be assigned runway 06. All arrivals shall be processed to runway 03.


### PR DESCRIPTION
## Summary
Clarifies the YPPH runway modes and standardises the display of information like ATIS elements. Standardises YPJT page to follow existing conventions.

`Notify` tag not required.