### PR TITLE
Fix dependabot schema issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -13,6 +14,7 @@ updates:
 
   # JavaScript / Node.js dependencies
   - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -22,6 +24,7 @@ updates:
 
   # Python dependencies via requirements.txt
   - package-ecosystem: "pip"
+    directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    commit-message:
-      prefix: "ci"
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## Pull Request Overview

This pull request addresses schema issues in the dependabot configuration file. The changes add a required "directory" field for each dependency update block and remove an unsupported "commit-message" option for GitHub Actions.
- Add missing directory field for GitHub Actions, npm, and Python update blocks  
- Remove unsupported commit-message configuration from the GitHub Actions block

No need to notify.