### PR TITLE
PNG Aerodrome ATIS frequency updates

### DIFF
--- a/docs/enroute/Melbourne Centre/WOL.md
+++ b/docs/enroute/Melbourne Centre/WOL.md
@@ -8,7 +8,7 @@
 | Name | Callsign | Frequency | Login ID |
 | ---- | -------- | --------- | -------- |
 | **Wollongong** | **Melbourne Centre** | **125.000** | **ML-WOL_CTR** |
-| <span class="indented">Snowy :material-information-outline:{ title="Non-standard position"} | Melbourne Centre | 120.750 | ML-SNO_CTR |
+| <span class="indented">Snowy :material-information-outline:{ title="Non-standard position"} | Melbourne Centre | 124.000 | ML-SNO_CTR |
 
 !!! abstract "Non-Standard Positions"
     :material-information-outline: Non-standard positions may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}.  

--- a/docs/enroute/Melbourne Centre/WOL.md
+++ b/docs/enroute/Melbourne Centre/WOL.md
@@ -8,7 +8,7 @@
 | Name | Callsign | Frequency | Login ID |
 | ---- | -------- | --------- | -------- |
 | **Wollongong** | **Melbourne Centre** | **125.000** | **ML-WOL_CTR** |
-| <span class="indented">Snowy :material-information-outline:{ title="Non-standard position"} | Melbourne Centre | 124.000 | ML-SNO_CTR |
+| <span class="indented">Snowy :material-information-outline:{ title="Non-standard position"} | Melbourne Centre | 120.750 | ML-SNO_CTR |
 
 !!! abstract "Non-Standard Positions"
     :material-information-outline: Non-standard positions may only be used in accordance with [VATPAC Air Traffic Services Policy](https://vatpac.org/publications/policies){target=new}.  

--- a/docs/pacific/Papua-New-Guinea/Enroute.md
+++ b/docs/pacific/Papua-New-Guinea/Enroute.md
@@ -43,9 +43,9 @@ IFR aircraft may either be handed off to the ADC frequency by AYPM CTR, or held 
 
 !!! phraseology
     *DEF tracking YABAL H409 PAPTI*  
-    <span class="hotline">**AYPM CTR** -> **AYMH ADC**</span>: "via LEMER, DEF, overflying at `A180`."  
-    <span class="hotline">**AYMH ADC** -> **AYPM CTR**</span>: "DEF, No reported traffic, no frequency requirements."  
-    AYPM CTR will put *"AYMH NFR"* in the label data, and the aircraft will remain on the ENR frequency.
+    <span class="hotline">**AYPM CTR** -> **AYMH ADC**</span>: "via LEMER, DEF, any traffic or frequency requirements?."  
+    <span class="hotline">**AYMH ADC** -> **AYPM CTR**</span>: "DEF, No reported IFR traffic, no frequency requirements."  
+    AYPM CTR will put *"AYMH NFR NIT"* in the label data, and the aircraft will remain on the ENR frequency.
 
 ### International (ARA)
 As per [Standard coordination procedures](../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.

--- a/docs/pacific/Papua-New-Guinea/Mt-Hagen.md
+++ b/docs/pacific/Papua-New-Guinea/Mt-Hagen.md
@@ -9,7 +9,7 @@
 | Name                    | Callsign         | Frequency | Login ID    |
 | ----------------------- | --------- | ---------------- | --------- |
 | **Mt Hagen ADC** | **Hagen Tower**	| **120.500** | **AYMH_TWR**	| 
-| **Mt Hagen ATIS**	| | 	**128.400** | **AYMH_ATIS**	 |
+| **Mt Hagen ATIS**	| | 	**128.900** | **AYMH_ATIS**	 |
 
 ## Airspace
 ADC is responsible for the **Mt Hagen ATZ**; consisting of Class F airspace `SFC` to `A200`.

--- a/docs/pacific/Papua-New-Guinea/Nadzab.md
+++ b/docs/pacific/Papua-New-Guinea/Nadzab.md
@@ -10,4 +10,4 @@
 | ----------------------- | --------- | ---------------- | --------- |
 | **Nadzab (Lae) Approach**	| **Nadzab Approach** | **118.600** | **AYNZ_APP** | 
 | **Nadzab (Lae) ADC**	| **Nadzab Tower**	| **121.700** | **AYNZ_TWR** | 
-| **Nadzab (Lae) ATIS** | | **128.600** | **AYNZ_ATIS**	| 
+| **Nadzab (Lae) ATIS** | | **128.100** | **AYNZ_ATIS**	| 

--- a/docs/pacific/Papua-New-Guinea/Tokua.md
+++ b/docs/pacific/Papua-New-Guinea/Tokua.md
@@ -9,7 +9,7 @@
 | Name                    | Callsign         | Frequency | Login ID    |
 | ----------------------- | --------- | ---------------- | --------- |
 | **Tokua (Rabul) ADC**	| **Tokua Tower** | **118.200** | **AYTK_TWR** | 
-| **Tokua (Rabul) ATIS**	| | 	**128.000** | **AYTK_ATIS**	 | 
+| **Tokua (Rabul) ATIS**	| | 	**128.300** | **AYTK_ATIS**	 | 
 
 ## Airspace
 ADC is responsible for the **Tokua ATZ**; consisting of Class F airspace `SFC` to `A200` within a **25nm** Radius of AYTK ARP.


### PR DESCRIPTION
## Summary
Updates ATIS frequencies to match real world.

## Changes
**Fixes**:
- Syncronises example of Class F overflier coordination across pages

**Changes**:
- Updates Tokua, Mt Hagen and Nadzab ATIS frequency per real world.
