### PR TITLE
Adjust HYD(GEL) STAR expectation, Essendon Typo fix

### DIFF
--- a/docs/aerodromes/classc/Essendon.md
+++ b/docs/aerodromes/classc/Essendon.md
@@ -109,9 +109,9 @@ YMEN ATIS identifiers only uses letters `A` through to `M`, due to nearby YMML u
 When an aircraft requests start clearance, the EN SMC controller shall coordinate with ML TCU to obtain the start clearance.
 
 #### Departures
-[Next](../../controller-skills/coordination.md#next) coordination is required from ED ADC to AD TCU for all aircraft **entering ML TCU CTA**.
+[Next](../../controller-skills/coordination.md#next) coordination is required from EN ADC to ML TCU for all aircraft **entering ML TCU CTA**.
 
-The Standard Assignable level from ED ADC to AD TCU is:
+The Standard Assignable level from EN ADC to ML TCU is:
 
 | Aircraft | Level |
 | -------- | ----- |

--- a/docs/enroute/Melbourne Centre/HYD.md
+++ b/docs/enroute/Melbourne Centre/HYD.md
@@ -120,7 +120,7 @@ Aircraft being transferred from the following sectors shall be given STAR Cleara
 | GVE, CRS, HYD | PIY | YPPH, YPEA | Non-jets only |
 | GVE, CRS, HYD | PIY | YPJT | |
 | GEL, IND | LEA | YPPH | |
-| IND | GEL, LEA, JAR | YPPH | |
+| IND | LEA, JAR | YPPH | |
 
 ## Coordination
 ### PH TCU

--- a/docs/oceanic/Positions/IND.md
+++ b/docs/oceanic/Positions/IND.md
@@ -44,7 +44,7 @@ Aircraft being transferred to the following sectors shall be told to Expect STAR
 
 | Transferring Sector | Receiving Sector | ADES | Notes |
 | ---- | -------- | --------- | --------- |
-| IND | HYD(All) | YPPH | |
+| IND | HYD(LEA, JAR) | YPPH | |
 
 ## Coordination
 ### Domestic Enroute


### PR DESCRIPTION
## Summary
Removes GEL from the STAR Expectation list on the HYD Enroute page. Fixes a typo on the YMEN page.

## Changes
**Fixes**:
- HYD page to remove reference to GEL STAR clearance issuance
- IND page to specify only LEA and JAR will provide STAR clearances for YPPH
- Essendon page typo fixes