### PR TITLE
Add Noindex tag to hide SOP subpages from search engine results

### DIFF
--- a/overrides/home.html
+++ b/overrides/home.html
@@ -1,4 +1,4 @@
-{% extends "main.html" %}
+{% extends "base.html" %}
 {% block tabs %}
 {{ super() }}
 <link rel="stylesheet" href="assets/stylesheets/home.css">

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,1 +1,5 @@
 {% extends "base.html" %}
+
+{% block site_meta %}
+    <meta name="robots" content="noindex,noarchive,nofollow" />
+{% endblock %}


### PR DESCRIPTION
## Summary
Adds a noindex, nofollow and noarchive meta tag to to the base "main" template to hide these pages from Google Search Results.

Unlinks home from extending main to extending base, so that the home page remains index-able