### PR TITLE
Heli sop update

### DIFF
--- a/docs/aerodromes/classc/Sydney.md
+++ b/docs/aerodromes/classc/Sydney.md
@@ -30,20 +30,23 @@ SY ADC is responsible for the Class C airspace in the SY CTR `SFC` to `A005` as 
 
 ### Helicopter Operations
 
-VFR helicopters are generally processed via one of Sydney's Helicopter Routes. There are both inbound and outbound routes. The helicopter routes are coded clearances.
-**Inbound** coded clearances contain the route, altitudes, a clearance limit, freqencies and at which waypoint to self-transfer to tower.
-**Outbound** coded clearances contain the route and altitude to be flown. Outbound routes typically end at the CTA boundary
+VFR helicopters are generally processed via one of Sydney's Helicopter Routes. There are both inbound and outbound routes. Each procedure is delivered as a coded clearance designed to separate helicopters from fixed-wing aircraft.
+**Inbound** coded clearances contain tracking, altitudes, a clearance limit and at which waypoint to self-transfer to tower.
+**Outbound** coded clearances contain tracking and altitude to be flown. Outbound routes typically end at the CTA boundary
 
-The routes are shown here: 
-********************* INSERT THE DIAGRAM *****************
+You can find details of each Helicopter Route here, and full details are in the `ERSA FAC YSSY`.
+
+![heli routes 4](https://github.com/user-attachments/assets/8ccca578-d990-482f-b584-f60f2a5e58ae)
+
 Refer to [Heliport Responsibility](#heliport-responsibility) to determine which ADC position (when both are online) is responsible for managing helicopter arrivals and departures.
 
 #### Departures
+VFR helicopters are generally processed via an outbound helicopter route (see above)
 IFR helicopters should conform to fixed wing ops and be processed via the **SY (RADAR) SID** from an appropriate runway, unless a visual departure is acceptable.
 
-SY ACD will issue VFR airways clearance for a Helicopter Route through a coded clearance.
+SY ACD will issue VFR airways clearance for a Helicopter Route
 !!! tip
-    You can find details of each Helicopter Route (including applicable clearance limits) in the `ERSA FAC YSSY`.
+    
 
 !!! phraseology
     **YOE:** "Sydney Delivery, helicopter YOE, for the Harbour Bridge 5 outbound, request clearance"  
@@ -74,9 +77,9 @@ Helicopter operations should be accommodated without unduly delaying fixed wing 
     **HSZ:** "Maintain own separation, wilco, HSZ"
 
 #### Arrivals
-VFR helicopters are generally processed via by one of Sydney's Helicopter Routes.  IFR helicopters should conform to fixed wing ops and be processed via an appropriate runway.
+VFR helicopters are generally processed via by one of Sydney's Helicopter Routes (see above).  IFR helicopters should conform to fixed wing ops and be processed via an appropriate runway.
 
-SY TCU will clear helicopters for all inbound Helicopter Routes, with the exception of the `CAPE BANKS 5 INBOUND` and `WANDA 5 INBOUND`.  Tower controllers should assess the current traffic situation and issue clearances for these aircraft when available.  Each procedure is delivered as a coded clearance, which includes automatic altitude assignment, tracking, and a clearance limit designed to separate helicopters from fixed-wing aircraft.
+SY TCU will clear helicopters for all inbound Helicopter Routes, with the exception of the `CAPE BANKS 5 INBOUND` and `WANDA 5 INBOUND`.  Tower controllers should assess the current traffic situation and issue clearances for these aircraft when available.  
 
 !!! phraseology
     **YZD:** "Sydney Tower, helicopter YZD, JIBN, A005, received Tango, request Cape Banks 5 Inbound"  

--- a/docs/aerodromes/classc/Sydney.md
+++ b/docs/aerodromes/classc/Sydney.md
@@ -31,10 +31,15 @@ SY ADC is responsible for the Class C airspace in the SY CTR `SFC` to `A005` as 
 ### Helicopter Operations
 Refer to [Heliport Responsibility](#heliport-responsibility) to determine which ADC position (when both are online) is responsible for managing helicopter arrivals and departures.
 
-#### Departures
-VFR helicopters are generally processed via one of Sydney's Helicopter Routes. IFR helicopters should conform to fixed wing ops and be processed via the **SY (RADAR) SID** from an appropriate runway, unless a visual departure is acceptable.
+VFR helicopters are generally processed via one of Sydney's Helicopter Routes. There are both inbound and outbound routes. The helicopter routes are coded clearances. Inbound coded clearances contain the route, altitudes, freqencies and when to transfer to tower. Outbound coded clearances contain the route and altitude to be flown. 
 
-SY ACD will issue airways clearance for a Helicopter Route through a coded clearance.
+The routes are shown here: 
+********************* INSERT THE DIAGRAM *****************
+
+#### Departures
+IFR helicopters should conform to fixed wing ops and be processed via the **SY (RADAR) SID** from an appropriate runway, unless a visual departure is acceptable.
+
+SY ACD will issue VFR airways clearance for a Helicopter Route through a coded clearance.
 !!! tip
     You can find details of each Helicopter Route (including applicable clearance limits) in the `ERSA FAC YSSY`.
 

--- a/docs/aerodromes/classc/Sydney.md
+++ b/docs/aerodromes/classc/Sydney.md
@@ -30,9 +30,9 @@ SY ADC is responsible for the Class C airspace in the SY CTR `SFC` to `A005` as 
 
 ### Helicopter Operations
 
-VFR helicopters are generally processed via one of Sydney's Helicopter Routes. There are both inbound and outbound routes. The helicopter routes are coded clearances. 
-Inbound coded clearances contain the route, altitudes, a clearance limit, freqencies and at which waypoint to self-transfer to tower. 
-Outbound coded clearances contain the route and altitude to be flown. Outbound routes typically end at the CTA boundary
+VFR helicopters are generally processed via one of Sydney's Helicopter Routes. There are both inbound and outbound routes. The helicopter routes are coded clearances.
+**Inbound** coded clearances contain the route, altitudes, a clearance limit, freqencies and at which waypoint to self-transfer to tower.
+**Outbound** coded clearances contain the route and altitude to be flown. Outbound routes typically end at the CTA boundary
 
 The routes are shown here: 
 ********************* INSERT THE DIAGRAM *****************

--- a/docs/aerodromes/classc/Sydney.md
+++ b/docs/aerodromes/classc/Sydney.md
@@ -31,7 +31,9 @@ SY ADC is responsible for the Class C airspace in the SY CTR `SFC` to `A005` as 
 ### Helicopter Operations
 Refer to [Heliport Responsibility](#heliport-responsibility) to determine which ADC position (when both are online) is responsible for managing helicopter arrivals and departures.
 
-VFR helicopters are generally processed via one of Sydney's Helicopter Routes. There are both inbound and outbound routes. The helicopter routes are coded clearances. Inbound coded clearances contain the route, altitudes, freqencies and when to transfer to tower. Outbound coded clearances contain the route and altitude to be flown. 
+VFR helicopters are generally processed via one of Sydney's Helicopter Routes. There are both inbound and outbound routes. The helicopter routes are coded clearances. 
+Inbound coded clearances contain the route, altitudes, a clearance limit, freqencies and at which waypoint to self-transfer to tower. 
+Outbound coded clearances contain the route and altitude to be flown. Outbound routes typically end at the CTA boundary
 
 The routes are shown here: 
 ********************* INSERT THE DIAGRAM *****************

--- a/docs/aerodromes/classc/Sydney.md
+++ b/docs/aerodromes/classc/Sydney.md
@@ -29,7 +29,6 @@ SY ADC is responsible for the Class C airspace in the SY CTR `SFC` to `A005` as 
 </figure>
 
 ### Helicopter Operations
-Refer to [Heliport Responsibility](#heliport-responsibility) to determine which ADC position (when both are online) is responsible for managing helicopter arrivals and departures.
 
 VFR helicopters are generally processed via one of Sydney's Helicopter Routes. There are both inbound and outbound routes. The helicopter routes are coded clearances. 
 Inbound coded clearances contain the route, altitudes, a clearance limit, freqencies and at which waypoint to self-transfer to tower. 
@@ -37,6 +36,7 @@ Outbound coded clearances contain the route and altitude to be flown. Outbound r
 
 The routes are shown here: 
 ********************* INSERT THE DIAGRAM *****************
+Refer to [Heliport Responsibility](#heliport-responsibility) to determine which ADC position (when both are online) is responsible for managing helicopter arrivals and departures.
 
 #### Departures
 IFR helicopters should conform to fixed wing ops and be processed via the **SY (RADAR) SID** from an appropriate runway, unless a visual departure is acceptable.


### PR DESCRIPTION
Updated the Sydney SOP Heli section to provide an intro to Sydney Heli routes at the top of the section and adding a visual guide. 
Only the diagram is new. Much of the rest of the intro consolidating content in the existing sections.
Purpose being to allow controllers quick access to information when 'confronted' with a heli.

Image has two defects that will need future fixing. Maroubra 5 is drawn but not labeled. Erskineville 5 blue line bypasses Erksineville Oval


