### PR TITLE
Fix dark mode active link styling

### DIFF
--- a/docs/stylesheets/navigation.css
+++ b/docs/stylesheets/navigation.css
@@ -25,7 +25,7 @@
 }
 .md-tabs__item--active {
   border-bottom: 1.5px solid #b5b6b3;
-  color: #344767;
+  color: var(--md-primary-fg-color);
 }
 
 .md-tabs__link:hover {


### PR DESCRIPTION
## Summary
Fixes the display of the active link in the primary menu bar on desktop in dark mode. Previously, the active link was a fixed colour, optimised for light mode but with too little contrast in dark mode. This PR sets it to the variable foreground colour which updates based on the current theme mode.

`Notify` not required.
