### PR TITLE
Remove IVA terminology BN TCU

### DIFF
--- a/docs/terminal/brisbane.md
+++ b/docs/terminal/brisbane.md
@@ -68,12 +68,6 @@ The divisions of the airspace between **BAN**, **BAS**, **BDS**, **BDN**, and **
 Refer to [Parallel Runway Separation Standards](../../separation-standards/parallelapps) for more information
 
 ## Departure/Arrival Procedures
-### Independent Visual Approach Phraseology at Night
-*"CLEARED INDEPENDENT VISUAL APPROACH RUNWAY (number), NOT BELOW (MVA) UNTIL ESTABLISHED ON THE PAPI (or GLIDEPATH)"*
-
-!!! phraseology
-    **BAS:** "QFA660, Turn left heading 040, join final Runway 01L, from that heading Cleared Independent Visual Approach Runway 01L, not below 2400 until established on the PAPI"   
-
 ### SODPROPS
 Arriving aircraft must be established on final and transferred to the tower frequency no later than 10NM from touchdown.
 


### PR DESCRIPTION
## Summary
Removes the IVA terminology example from BN TCU (not in use outside events, which have their own pages)
