### PR TITLE
YMML ATIS APCH Correction

### DIFF
--- a/docs/aerodromes/classc/Melbourne.md
+++ b/docs/aerodromes/classc/Melbourne.md
@@ -193,7 +193,7 @@ YMML ATIS identifiers only uses letters `N` through to `Y`, due to nearby YMEN u
 | 09              | All                | `EXP GLS OR RNP APCH` |
 | 16 or 27        | All                | `EXP GLS OR ILS APCH` |
 | 16              | At or below `A005` | `EXP ILS APCH`        |
-| 34              | Above `A030`       | `ACFT ON THE ALPHA STAR EXP GLS OR ILS APCH`\* |
+| 34              | Above `A030`       | `ACFT ON THE ALPHA STAR EXP GLS OR RNP APCH`\* |
 | 34              | At or below `A030` | `EXP GLS OR RNP APCH` |
 | 34 & 27 (LAHSO) | All                | `EXP INST APCH`       |
 


### PR DESCRIPTION
## Summary
No ILS for RWY 34.

## Changes
**Fixes**:
- "ACFT ON THE ALPHA STAR EXP GLS OR ILS APCH" replaced with "ACFT ON THE ALPHA STAR EXP GLS OR RNP APCH"