### PR TITLE
Clarify STAR Assignment Responsibility for CB NE Arrivals

### DIFF
--- a/docs/enroute/Brisbane Centre/ARL.md
+++ b/docs/enroute/Brisbane Centre/ARL.md
@@ -172,7 +172,8 @@ Aircraft being transferred to the following sectors shall be told to Expect STAR
 | Transferring Sector | Receiving Sector | ADES | Notes |
 | ---- | -------- | --------- | --------- |
 | MNN | INL | YBBN, YBCG | |
-| MDE | YWE(KAT) | YSCB | |
+| MDE | GUN(KAT) | YSCB | |
+| CNK, MLD, OCN | WOL | YSCB | Jets only |
 | MNN, MDE | ARL | YSSY | |
 
 ### First Contact

--- a/docs/enroute/Melbourne Centre/GUN.md
+++ b/docs/enroute/Melbourne Centre/GUN.md
@@ -52,6 +52,11 @@ Refer to the [Sequencing into YSSY](#sequencing-into-yssy) notes below for runwa
 #### YSBK Arrivals
 BIK is responsible for issuing final descent, and ascertaining arrival intentions.
 
+#### YSCB Arrivals
+BIK is responsible for issuing STAR clearances, and initial descent for aircraft inbound to YSCB via WOL.
+
+Aircraft cruising above `F290` should be assigned *no lower* than `F290` and handed to WOL for further descent.
+
 #### Overfliers
 For aircraft overflying the SY TMA, place *'O/FLY'* in the LABEL DATA field.
     
@@ -63,6 +68,9 @@ GUN is also responsible for initial sequencing actions into YSSY. Aircraft cruis
 
 Refer to the [Sequencing into YSSY](#sequencing-into-yssy) notes below for runway and STAR selection notes.
 
+#### YSCB Arrivals
+BIK is responsible for final sequencing actions and final descent for aircraft arriving from the north.
+
 ### Katoomba (KAT)
 #### YSSY Arrivals
 KAT is responsible for issuing STAR Clearances.
@@ -70,7 +78,7 @@ KAT is responsible for issuing STAR Clearances.
 Refer to the [Sequencing into YSSY](#sequencing-into-yssy) notes below for runway and STAR selection notes.
 
 #### YSCB Arrivals
-KAT is responsible for issuing STAR Clearances.
+KAT is responsible for issuing STAR clearances and initial descent for aircraft inbound to YSCB via GUN.
 
 ### Sequencing into YSSY
 Sequencing arrivals from the west into YSSY is a joint responsibility of GUN and BIK. Initial sequencing actions should be performed by GUN, with fine tuning and any holding required issued by BIK.
@@ -128,7 +136,7 @@ Aircraft being transferred from the following sectors shall be given STAR Cleara
 | BLA, WOL | GUN | YSSY | |
 | ASP(BKE), MUN(GTH) | KAT | YSSY | Jets only |
 | MUN(GTH) | GUN | YSSY | Non-Jets only |
-| ARL(MDE) | KAT | YSCB | |
+| ARL(CNK), ARL(MLD), ARL(OCN) | BIK | YSCB | Jets only |
 
 ## Coordination
 ### SY TCU

--- a/docs/enroute/Melbourne Centre/WOL.md
+++ b/docs/enroute/Melbourne Centre/WOL.md
@@ -58,7 +58,7 @@ The CPDLC Station Code is `YWOL`.
 ## Sector Responsibilities
 ### Wollongong (WOL)
 #### YSCB Arrivals
-WOL is responsible for issuing STAR clearances, descent, and sequencing actions.
+WOL is responsible for issuing STAR clearances to non-jet aircraft, as well as descent and sequencing actions for all aircraft inbound YSCB.
 
 Refer to the [Sequencing into YSCB](#sequencing-into-yscb) notes below regarding adjacent Feeder Fixes.
 
@@ -85,6 +85,13 @@ Aircraft being transferred to the following sectors shall be told to Expect STAR
 | WOL | GUN | YSSY | |
 | SNO | HUO(WON) | YMML | 
 | SNO | HUO | YMHB | |
+
+### First Contact
+Aircraft being transferred from the following sectors shall be given STAR Clearance on first contact:
+
+| Transferring Sector | Receiving Sector | ADES | Notes |
+| ---- | -------- | --------- | --------- |
+| GUN(BIK) | WOL | YSCB | Non-jets only |
 
 ## Coordination
 ### SY TCU


### PR DESCRIPTION
## Summary
This PR clarifies the responsible enroute sector for assigning STARs to aircraft arriving CB from the north east. Aircraft inbound to YSCB via the IGDAM-TESAT-WOL-LEECE track will be assigned their STAR on first contact with BIK.

## Changes
**Changes**:
- Changes STAR Handoff expectation for ARL -> BIK.
- Clarifies GUN sector responsibilities for CB arrivals.
- Adds 'First Contact' STAR expectation and non-jet STAR assignment responsibility (WOL)