### PR TITLE
Update GUN Frequency

### DIFF
--- a/docs/enroute/Melbourne Centre/GUN.md
+++ b/docs/enroute/Melbourne Centre/GUN.md
@@ -7,7 +7,7 @@
 
 | Name | Callsign | Frequency | Login ID |
 | ---- | -------- | --------- | -------- |
-| **Gundagai** | **Melbourne Centre** | **128.400** | **ML-GUN_CTR** |
+| **Gundagai** | **Melbourne Centre** | **133.150** | **ML-GUN_CTR** |
 | <span class="indented">Bindook :material-information-outline:{ title="Non-standard position"} | Melbourne Centre | 129.800 | ML-BIK_CTR |
 | <span class="indented">Katoomba :material-information-outline:{ title="Non-standard position"} | Melbourne Centre | 133.500 | ML-KAT_CTR |
 


### PR DESCRIPTION
## Summary
Updates the Gundagai sector frequency to the real world frequency of 133.150, in response to a number of events where pilots confused the frequency.

This frequency is the real world frequency for the Class A airspace in Gundagai and reduces the chance of confusion between GUN and SAS. 