### PR TITLE
Procedural Twr -> Enroute "Next" Coord Change

### DIFF
--- a/docs/controller-skills/coordination.md
+++ b/docs/controller-skills/coordination.md
@@ -151,7 +151,7 @@ An amended level may be instructed, or the term **unrestricted** used to indicat
     <span class="hotline">**ML ADC** -> **ML TCU**</span>: "Next, QFA442, runway 16"  
     <span class="hotline">**ML TCU** -> **ML ADC**</span>: "QFA442, unrestricted"
     
-When next coordination is being conducted with a procedural ADC, the assigned altitude is required, even if the same as the standard assignable level.
+When next coordination is being conducted with a procedural ADC, the assigned altitude is required, even if it is the same as the standard assignable level.
 
 !!! phraseology  
     <span class="hotline">**AS ADC** -> **ASP**</span>: "Next, QFA1956, runway 12"  

--- a/docs/controller-skills/coordination.md
+++ b/docs/controller-skills/coordination.md
@@ -155,7 +155,7 @@ When next coordination is being conducted with a procedural ADC, the assigned al
 
 !!! phraseology  
     <span class="hotline">**AS ADC** -> **ASP**</span>: "Next, QFA1956, runway 12"  
-    <span class="hotline">**ASP** -> **AS ADC**</span>: "QFA442, `A070`"  
+    <span class="hotline">**ASP** -> **AS ADC**</span>: "QFA1956, `A070`"  
     <span class="hotline">**AS ADC** -> **ASP**</span>: "`A070`, QFA1956"  
     
 #### After a go around

--- a/docs/controller-skills/coordination.md
+++ b/docs/controller-skills/coordination.md
@@ -156,6 +156,7 @@ When next coordination is being conducted with a procedural ADC, the assigned al
 !!! phraseology  
     <span class="hotline">**AS ADC** -> **ASP**</span>: "Next, QFA1956, runway 12"  
     <span class="hotline">**ASP** -> **AS ADC**</span>: "QFA442, `A070`, unrestricted"  
+    <span class="hotline">**AS ADC** -> **ASP**</span>: "`A070`, QFA1956"  
     
 #### After a go around
 Following a go around, the next departure from that runway **must** be next coordinated between the ADC and TCU controllers, regardless if it would otherwise meet the voiceless coordination criteria.

--- a/docs/controller-skills/coordination.md
+++ b/docs/controller-skills/coordination.md
@@ -155,7 +155,7 @@ When next coordination is being conducted with a procedural ADC, the assigned al
 
 !!! phraseology  
     <span class="hotline">**AS ADC** -> **ASP**</span>: "Next, QFA1956, runway 12"  
-    <span class="hotline">**ASP** -> **AS ADC**</span>: "QFA442, `A070`, unrestricted"  
+    <span class="hotline">**ASP** -> **AS ADC**</span>: "QFA442, `A070`"  
     <span class="hotline">**AS ADC** -> **ASP**</span>: "`A070`, QFA1956"  
     
 #### After a go around

--- a/docs/controller-skills/coordination.md
+++ b/docs/controller-skills/coordination.md
@@ -151,6 +151,12 @@ An amended level may be instructed, or the term **unrestricted** used to indicat
     <span class="hotline">**ML ADC** -> **ML TCU**</span>: "Next, QFA442, runway 16"  
     <span class="hotline">**ML TCU** -> **ML ADC**</span>: "QFA442, unrestricted"
     
+When next coordination is being conducted with a procedural ADC, the assigned altitude is required, even if the same as the standard assignable level.
+
+!!! phraseology  
+    <span class="hotline">**AS ADC** -> **ASP**</span>: "Next, QFA1956, runway 12"  
+    <span class="hotline">**ASP** -> **AS ADC**</span>: "QFA442, `A070`, unrestricted"  
+    
 #### After a go around
 Following a go around, the next departure from that runway **must** be next coordinated between the ADC and TCU controllers, regardless if it would otherwise meet the voiceless coordination criteria.
 


### PR DESCRIPTION
## Summary
This SOP adds a clarifying note to the Controller Skills Coordination page, noting that when 'Next' coordination is conducted between Enroute and a Procedural Tower, the Assigned Level is a required item.