### PR TITLE
Add Notes for New Taxiways

### DIFF
--- a/docs/aerodromes/classc/Sydney.md
+++ b/docs/aerodromes/classc/Sydney.md
@@ -35,6 +35,13 @@ SY ADC is responsible for the Class C airspace in the SY CTR `SFC` to `A005` as 
   <figcaption>Manoeuvring Area</figcaption>
 </figure>
 
+!!! note
+    The vatSys ground map includes new taxiways which some simulators may not include. Some pilots will be unable to accept taxi via:
+    
+    - Taxiway D south of G
+    - Taxiway J east of Runway 16R
+    - Taxiway K east of C
+
 #### Heliport Responsibility
 When runway 07 or 25 is in use for either arrivals or departures, the responsibility for management of the helicopter area and associated arriving and departing helicopters falls to **ADC West**. During all other runway modes, **ADC East** (if online) takes responsibility for the heliport.
 

--- a/docs/aerodromes/procedural/Albury.md
+++ b/docs/aerodromes/procedural/Albury.md
@@ -21,6 +21,14 @@ AY ADC is responsible for the Class D airspace in the AY keyhole `BCTA` to `A045
 
 Refer to [Class D Tower Separation Standards](../../../separation-standards/classd) for more information.
 
+## Manoeuvring Area
+
+!!! note
+    The vatSys ground map includes new taxiways which some simulators may not include. Some pilots will be unable to accept taxi via:
+    
+    - Taxiway A
+    - Taxiway C east of C1
+
 ## Separation
 ### Local Lateral Separation Points
 Due to the convergence of inbound/outbound air routes approaching AY, the [geographic feature separation standard](../../separation-standards/visual.md#geographic-features) may be useful to efficiently process opposite direction aircraft from the north.


### PR DESCRIPTION
## Summary
Adds notes to aerodromes where the vatSys taxiway layout does not match what the majority of simulators may show.

`Notify` not required.

## Changes
**Additions**:
- Note to YSSY and YMAY pages