### PR TITLE
Fix broken internal links across docs

### DIFF
--- a/docs/aerodromes/classc/Tindal.md
+++ b/docs/aerodromes/classc/Tindal.md
@@ -142,7 +142,7 @@ Military aircraft that are unable to accept a procedural SID shall be assigned e
 
 ## ATIS
 ### Approach Types
-During high levels of military traffic, **TNA** may nominate [stereo approaches](../../../military/#stereo-approaches) as the preferred approach type.
+During high levels of military traffic, **TNA** may nominate [stereo approaches](../../../controller-skills/military/#stereo-approaches) as the preferred approach type.
 
 | Condition         | ATIS APCH field |
 | ----------------- | --------------- |

--- a/docs/aerodromes/classc/Townsville.md
+++ b/docs/aerodromes/classc/Townsville.md
@@ -127,8 +127,8 @@ In VMC, light aircraft travelling between YBTL and YPAM should be cleared a '**C
 | Duty RWY     | Clearance            | Tracking Points    | Notes |
 | ------------ | -------------------- | ------------------ | ----- |
 | RWY 01 or 07 | CORDELIA Outbound    | `YBTL RDRS RKI052005 YPAM` | Aircraft to remain east of RDRS and *Cordelia Rocks* (RKI052005) |
-| RWY 01 or 07 | RATTLESNAKE Inbound  | `YBTL MBHR RKI YPAM`       | When [R747 restricted area](../../../terminal/Townsville/#r747-rattlesnake-island) is active, expect amended tracking |
-| RWY 19 or 25 | RATTLESNAKE Outbound | `YPAM RKI MBHR YBTL`       | When [R747 restricted area](../../../terminal/Townsville/#r747-rattlesnake-island) is active, expect amended tracking 
+| RWY 01 or 07 | RATTLESNAKE Inbound  | `YBTL MBHR RKI YPAM`       | When [R747 restricted area](../../../terminal/townsville/#r747-rattlesnake-island) is active, expect amended tracking |
+| RWY 19 or 25 | RATTLESNAKE Outbound | `YPAM RKI MBHR YBTL`       | When [R747 restricted area](../../../terminal/townsville/#r747-rattlesnake-island) is active, expect amended tracking 
 | RWY 19 or 25 | CORDELIA Inbound     | `YPAM RKI052005 RDRS YBTL` | Aircraft to remain east of RDRS and *Cordelia Rocks* (RKI052005) |
 
 !!! phraseology
@@ -352,7 +352,7 @@ Aircraft **not** planned via any of these waypoints shall receive amended routin
 Light and **non-RNAV** aircraft shall be assigned a visual departure in VMC.
 
 #### CATEY Departures
-When the [R738A restricted area](../../../terminal/Townsville/r738a-h-townsville-land) is active, aircraft planned via **CATEY** shall be assigned the **ANRUB** (if southbound) or **CARMN** (if northbound) SID.
+When the [R738A restricted area](../../../terminal/townsville/#r738a-h-townsville-land) is active, aircraft planned via **CATEY** shall be assigned the **ANRUB** (if southbound) or **CARMN** (if northbound) SID.
 
 ### Military Aircraft
 Military aircraft that are unable to accept a procedural SID are generally processed through visual departures.

--- a/docs/aerodromes/classc/Williamtown.md
+++ b/docs/aerodromes/classc/Williamtown.md
@@ -37,7 +37,7 @@ The [intial points](../../../controller-skills/military/#initial-and-pitch) are 
 | 30   | Intersection of the coast and extended Taxiway A centreline | `A025`<br>(`A020` for PC21) |
 
 ### Coded Clearances
-Aircraft departing to the western training areas should be cleared the **STORM 1** coded clearance, in addition to the [appropriate SID](#sid-selection). The **STORM 1** coded clearance gives aircraft permission to transit via the **[Thunder Corridor](../../terminal/williamtown/#thunder-corridor)**, a [military corridor](../../../controller-skills/military/#military-corridors) that connects the WLM TCU to the R560 amd R570 restricted areas.
+Aircraft departing to the western training areas should be cleared the **STORM 1** coded clearance, in addition to the [appropriate SID](#sid-selection). The **STORM 1** coded clearance gives aircraft permission to transit via the **[Thunder Corridor](../../../terminal/williamtown/#thunder-corridor)**, a [military corridor](../../../controller-skills/military/#military-corridors) that connects the WLM TCU to the R560 amd R570 restricted areas.
 
 [Coordination](#acd-to-wlm-tcu) may be required with WLM TCU prior to issuing clearance to an aircraft intending to operate in an SUA.
 
@@ -128,7 +128,7 @@ All other military aircraft, including military aircraft that are unable to fly 
 
 ## ATIS
 ### Approach Types
-During high levels of military traffic, **WAL** may nominate [stereo approaches](../../../military/#stereo-approaches) as the preferred approach type.
+During high levels of military traffic, **WAL** may nominate [stereo approaches](../../../controller-skills/military/#stereo-approaches) as the preferred approach type.
 
 | Condition         | ATIS APCH field |
 | ----------------- | --------------- |

--- a/docs/aerodromes/procedural/Woomera.md
+++ b/docs/aerodromes/procedural/Woomera.md
@@ -20,12 +20,12 @@
   <figcaption>WR ADC Airspace</figcaption>
 </figure>
 
-**WR ADC** is responsible for the Class D airspace within the **R222F** [restricted area](../../../sua/#restricted-areas), `SFC` to `F120`.
+**WR ADC** is responsible for the Class D airspace within the **R222F** [restricted area](../../../controller-skills/sua/#restricted-areas), `SFC` to `F120`.
 
 Refer to [Class D Tower Separation Standards](../../../separation-standards/classd) for more information.
 
 ### Restricted Area Activations
-When **WR ADC** is online, the **R222F** restricted area `SFC` to `F120` is [activated](../../../sua/#activation-of-sua) by default.
+When **WR ADC** is online, the **R222F** restricted area `SFC` to `F120` is [activated](../../../controller-skills/sua/#activation-of-sua) by default.
 
 #### SUA in Enroute Airspace
 Military operations taking place in SUA in enroute airspace are outside the jurisdiction of WR ADC.
@@ -42,7 +42,7 @@ This gives the enroute controller sufficient time to assess the request, make ne
 
 ## Local Procedures
 ### Initial and Pitch
-The [intial points](../../controller-skills/military/#initial-and-pitch) are aligned with Taxiway C at the following locations.
+The [intial points](../../../controller-skills/military/#initial-and-pitch) are aligned with Taxiway C at the following locations.
 
 | RWY  | Initial Point | Altitude |
 | ---- | ------------- | ------------------------ |
@@ -87,7 +87,7 @@ Surveillance coverage can be expected to be available at all levels in the WR CT
 ### Departures
 Next coordination is not required from WR ADC to ASP(WRA). 
 
-Aircraft leaving WR ADC airspace both **laterally** and **vertically** will enter ASP(WRA) uncontrolled airspace. However, it is good practice for WR ADC to provide [heads-up](../../controller-skills/coordination/#heads-up) coordination for aircraft leaving WR ADC airspace **vertically** to help faciltiate an uninterrupted climb.
+Aircraft leaving WR ADC airspace both **laterally** and **vertically** will enter ASP(WRA) uncontrolled airspace. However, it is good practice for WR ADC to provide [heads-up](../../../controller-skills/coordination/#heads-up) coordination for aircraft leaving WR ADC airspace **vertically** to help faciltiate an uninterrupted climb.
 
 !!! phraseology
     <span class="hotline">**WR ADC** -> **WRA**</span>: "via WR 180 bearing outbound, LYBD11.”  
@@ -98,7 +98,7 @@ Aircraft leaving WR ADC airspace both **laterally** and **vertically** will ente
     **LYBD11**: "Leave and re-enter controlled airspace on climb to `F240`, LYBD11"  
  
 ### Arrivals/Overfliers
-As with departures, there is no inherent requirement for ASP(WRA) to coordinate arrivals or overfliers with WR ADC. However, it is good practice for ASP(WRA) to provide [heads-up](../../controller-skills/coordination/#heads-up) coordination for aircraft arriving into directly into WR ADC airspace.
+As with departures, there is no inherent requirement for ASP(WRA) to coordinate arrivals or overfliers with WR ADC. However, it is good practice for ASP(WRA) to provide [heads-up](../../../controller-skills/coordination/#heads-up) coordination for aircraft arriving into directly into WR ADC airspace.
 
 ## Charts
 !!! abstract "Reference"

--- a/docs/controller-skills/airwork.md
+++ b/docs/controller-skills/airwork.md
@@ -7,7 +7,7 @@ title: Airwork
 Not all flights online consist of an aircraft flying between airports. **Airwork** refers to any aerial operation that doesn't involve simply going from A to B. Providing control services to aircraft performing airwork requires specific skills and procedures, but offers a unique and rewarding experience for both pilots and controllers.
 
 !!! warning
-	Certain types of airwork, including search and rescue, firefighting, and other emergency operations are restricted under the [VATSIM Code of Conduct](https://vatsim.net/docs/policy/code-of-conduct){target=new}. See [Military and Special Operations](../miitary) for more information.
+	Certain types of airwork, including search and rescue, firefighting, and other emergency operations are restricted under the [VATSIM Code of Conduct](https://vatsim.net/docs/policy/code-of-conduct){target=new}. See [Military and Special Operations](../military) for more information.
 
 !!! tip
     It may be beneficial to refer pilots to VATPAC's [Pilot Procedures](https://pilots.vatpac.org){target=new} to provide them with reference material for special operations.
@@ -92,7 +92,7 @@ Remark codes are also used to advise intentions to perform specific types of air
 | RMK/ Code  | Description                      |
 | ---------- | -------------------------------- |
 | PJE        | [Parachute Jumping Exercise](#parachute-operations) |
-| SAR        | [Search and Rescue Operations](../military/#searh-and-rescue) |
+| SAR        | [Search and Rescue Operations](../military/#search-and-rescue-sar-operations) |
 | NOCOM      | [Non-Continuous Communication](../military/#nocom-operations) |
 | MILSPECREQ | Special Military Requirements, e.g. [MARSA](../military/#marsa-operations) |
     
@@ -259,7 +259,7 @@ Where PJE ops are occuring in CTA, controllers must ensure there is no conflicti
     
     After giving an aircraft clearance to perform a survey approach, maintain your situational awareness with good client usage:
     
-    - **Restricted Areas** Activate the [Restricted or Danger Area](sua/#danger-areas), if applicable.
+    - **Restricted Areas** Activate the [Restricted or Danger Area](../sua/#danger-areas), if applicable.
     - **Label Data**: Use label data to indicate the operation being conducted (e.g. *"PJE"*)
     - **Cleared Flight Level**: Adjust the aircrafts CFL to a block altitude from `000` to the cleared drop altitude (e.g. `000-140`).
     - **Text Labels**: Use text labels to outline the dimensions of the drop area, and location of the drop zone

--- a/docs/controller-skills/coordination.md
+++ b/docs/controller-skills/coordination.md
@@ -69,7 +69,7 @@ Ensure no coordination is ambiguous in its meaning. Not all coordination can be 
 This is most useful when controllers are coordinating to multiple lateral positions, or where the controller "in the middle" of the chain of coordination has [no frequency requirements](#no-frequency-requirements-nfr).
 
 !!! example
-    You are controlling SDS and an aircraft has requested track shortening to a waypoint in WOL airspace. You can see that the requested track shortening would result in the aircraft passing through SAS airspace and exiting the TCU outside the Sydney [voiceless coordination corridors](../terminal/sydney/#departures).   
+    You are controlling SDS and an aircraft has requested track shortening to a waypoint in WOL airspace. You can see that the requested track shortening would result in the aircraft passing through SAS airspace and exiting the TCU outside the Sydney [voiceless coordination corridors](../../terminal/sydney/#departures).   
 	
 	Ordinarily, SDS would be responsible for coordination with SAS, while SAS is responsible for coordination with WOL. With *onwards coordination*, SDS can coordinate with WOL on SAS's behalf.
 
@@ -260,7 +260,7 @@ Remove the "C-Prompt" once jurisdiction of the aircraft has been handed off, and
 ## No Frequency Requirements (NFR)
 Occasionally, aircraft may clip small parts of a sector's airspace on their planned route. If an aircraft only enters someone's airspace for a small distance, there is usually no need for them to talk to that controller. In this instance, a controller may coordinate an aircraft to have "No Frequency Requirements" with another controller, or vice versa. This shall also be supplemented by the nomination of a restriction, or lack thereof. See below:
 
-Source: [Annotations](../../controller-skills/annotations)
+Source: [Annotations](../../client/annotations/)
 
 | Label Data / Global Ops | Meaning | Note |
 | ---- | ----------- | --- |

--- a/docs/controller-skills/helicopters.md
+++ b/docs/controller-skills/helicopters.md
@@ -91,7 +91,7 @@ Air transit allows helicopters to proceed directly between two points on the aer
 	
 	**AS ADC**: "SVY801, air transit to the southern airpark, cross runway 12."
 	
-Before an SMC gives an air transit instruction to a helicopter, they must [coordinate with ADC](../coordination#air-transit).
+Before an SMC gives an air transit instruction to a helicopter, they must [coordinate with ADC](../coordination/#helicopter-air-transit).
 
 !!! tip 
     Where air transit will be prolonged or conflicts with other traffic are likely, consider issuing a takeoff/landing clearance instead.

--- a/docs/controller-skills/runwaymanagement.md
+++ b/docs/controller-skills/runwaymanagement.md
@@ -27,7 +27,7 @@ Where possible, select the most into wind runway/s. Your chosen runway configura
 Most major aerodrome SOP pages include guidance on preferred runway modes, which cater for traffic levels, common approach types, and airspace restrictions. After considering the prevailing winds, have a look at the appropriate SOP page to determine whether a preferred runway mode exists for the current meteorological conditions.
 
 !!! example
-    The [Sydney Aerodrome SOPs](../../aerodromes/Sydney/#runway-modes) dictate that the preferred runway mode is SODROPS (runway 34L for arrivals, runway 16L for departures), however a note below indicates the reduced capacity achievable with this mode and recommends PROPS where traffic levels are expected to be high.
+    The [Sydney Aerodrome SOPs](../../aerodromes/classc/Sydney/#runway-modes) dictate that the preferred runway mode is SODROPS (runway 34L for arrivals, runway 16L for departures), however a note below indicates the reduced capacity achievable with this mode and recommends PROPS where traffic levels are expected to be high.
 
 #### Non-Standard Runway Modes
 The usage of non-standard runway modes is **strongly discouraged**, unless approved by a Senior Controller for use in major events. Non-Standard runway modes can cause unintended conflicts in TCU and Enroute airspace that may only slightly reduce an ADC controller's workload, but *dramatically* increase that of the affected TCU or Enroute controller.

--- a/docs/controller-skills/sequencing.md
+++ b/docs/controller-skills/sequencing.md
@@ -8,14 +8,14 @@ title: Sequencing
 
 It's all well and good maintaining separation standards in your airspace, but if you handoff 2 aircraft to ML_APP overhead BOOIN at the same speed, 1000ft apart, you're not going to make any friends. By default, aircraft must be sequenced **2 minutes** apart at the **Feeder Fix** (generally the first waypoint of the STAR).  
 
-It's important to remember that aircraft aren't just arriving from your sector, they can be coming in from all directions at similar times. **MAESTRO** is a tool used to help aid with sequencing (what time do YOU need to get the aircraft to the feeder fix to avoid TCU congestion). You can find more info [here](../maestro).
+It's important to remember that aircraft aren't just arriving from your sector, they can be coming in from all directions at similar times. **MAESTRO** is a tool used to help aid with sequencing (what time do YOU need to get the aircraft to the feeder fix to avoid TCU congestion). You can find more info [here](../../client/maestro/).
 
 In real life, controllers have the luxury of putting a fair bit of the onus of forming the sequence on the pilots, by issuing instructions like *"Adjust speed to cross RIVET at time 52 at 250kts in to published speeds"*. On VATSIM, every pilot may be using a different clock, potentially even different weather, and the pilot may simply not be proficient enough to meet a FF time. As such, all sequencing is best left in the hands of you, the controller.
 
 There are multiple tools a controller can use to create and maintain a sequence.
 
 ## Arrivals List
-The Arrivals List window is a sequencing management tool that can be used side-by-side with, or in-lieu of, [Maestro](../maestro).
+The Arrivals List window is a sequencing management tool that can be used side-by-side with, or in-lieu of, [Maestro](../../client/maestro/).
 
 It is a **global** window that can be viewed and manipulated by Tower, TCU, and Enroute Controllers.
 
@@ -63,7 +63,7 @@ Flow Data can be entered in to the **Global Ops Info** field of the aircraft, wh
   <figcaption>Arrivals List Window</figcaption>
 </figure>
 
-[Sequencing/Flow Abbreviations](../annotations/#sequencingflow) should be used to manage the sequence.
+[Sequencing/Flow Abbreviations](../../client/annotations/#sequencingflow) should be used to manage the sequence.
 
 !!! example
     `L54/57 17W CSR<`
@@ -119,7 +119,7 @@ For information only, the following approximate time gains and losses achieved b
 | 180  |  | +3 MIN |
 
 !!! tip
-    Refer to [Annotations](../../controller-skills/annotations/#speed-control) for info regarding Label data pertaining to speed control sequencing.
+    Refer to [Annotations](../../client/annotations/#speed-control) for info regarding Label data pertaining to speed control sequencing.
 
 ### Relative speeds
 When using speed control for aircraft on *climb* with similar climb profiles, using the **same speed** as an instruction to both pilots is a good rule of thumb to ensure the speeds will open at all times (Eg, Lead aircraft: 280kts or Greater, Following aircraft: 280kts or Less). 

--- a/docs/controller-skills/sua.md
+++ b/docs/controller-skills/sua.md
@@ -14,7 +14,7 @@ Approval is required to operate in a restricted or military operating area, but 
 !!! note
     In the real world, details of SUA activations are distributed widely to ensure that filed flight plans already include the necessary diversions before they reach ATC. Online, pilots are very unlikely to be aware of the rerouting requirements, and may have difficulty adjusting to a reroute on short notice. Nearby controllers (particularly those performing the role of ACD) are also unlikely to be aware that some flight plans may require adjustments.
     
-    Unless an activation has been [advertised by local NOTAM](../../sua/#activation-by-notam), controllers should work with pilots patiently and, where a pilot is unable to comply with a reroute, attempt to facilitate the safe transit of the SUA. Controllers should also follow best practice by announcing activations in vatSys' controller chat, amending voiceless coordination requirements, and proactively assisting other controllers.
+    Unless an activation has been [advertised by local NOTAM](#activation-by-notam), controllers should work with pilots patiently and, where a pilot is unable to comply with a reroute, attempt to facilitate the safe transit of the SUA. Controllers should also follow best practice by announcing activations in vatSys' controller chat, amending voiceless coordination requirements, and proactively assisting other controllers.
     
     In all cases, controllers should display professional behaviour to other controllers and pilots when facilitating SUA operations.
 

--- a/docs/enroute/brisbane/ARL.md
+++ b/docs/enroute/brisbane/ARL.md
@@ -146,21 +146,21 @@ The ARL subsector is additionally responsible for issuing the **STORM 2** coded 
 
 ## Local Procedures
 ### Special Use Airspace
-There are multiple volumes of [SUA](../../controller-skills/sua) within ARL airspace, mostly associated with military operations in and out of YWLM.
+There are multiple volumes of [SUA](../../../controller-skills/sua/) within ARL airspace, mostly associated with military operations in and out of YWLM.
 
 <figure markdown>
 ![Notable SUA in ARL Airspace](../img/arl_sua.png){ width="700" }
   <figcaption>Notable SUA in ARL Airspace</figcaption>
 </figure>
 
-WLM TCU must [give heads up coordination](../../terminal/williamtown/#sua-in-enroute-airspace) with the relevant enroute controllers **prior** to any departures intending to operate in a currently inactive SUA.
+WLM TCU must [give heads up coordination](../../../terminal/williamtown/#sua-in-enroute-airspace) with the relevant enroute controllers **prior** to any departures intending to operate in a currently inactive SUA.
 
 !!! phraseology
     <span class="hotline">**WAL** -> **ARL**</span>: "On the groud YWLM, PTHR11, requests activation of R560A `A085-F240`, from 0300 until 0500.”  
     <span class="hotline">**ARL** -> **WAL**</span>: "PTHR11, expect activation of R560A `A085-F240` at 0300 until 0500."   
     <span class="hotline">**WAL** -> **ARL**</span>: "PTHR11."  
     
-Non-participating aircraft intending to transit an activated SUA should be rerouted, where possible, [subject to the VATSIM Code of Conduct](../../sua/#ad-hoc-activations).
+Non-participating aircraft intending to transit an activated SUA should be rerouted, where possible, [subject to the VATSIM Code of Conduct](../../../controller-skills/sua/#ad-hoc-activations).
 
 #### M581-M584 Williamtown
 The M581-M584 MOAs are located offshore within the MLD, MNN, OCN, and TSN(HWE) subsectors.
@@ -180,7 +180,7 @@ When activated these MOAs significantly disrupt traffic on the busy **A579**, **
 The **W149** and **W768** low altitude airways, connecting YLHI to YWLM and YPMQ, are also affected, requiring extensive rerouting or facilitated transit through the SUA.
 
 !!! note
-	 Aircraft tracking via a recommended rerouting must still be [separated from the SUA](../../sua/#separation-from-sua)  laterally and vertically. After amending flight plans for the purposes of rerouting around SUA, controllers should ensure the route is displayed visually and the BRL is used to measure for [>2.5nm](../../sua/#controlled-airspace) clearance with all parts of the SUA.
+	 Aircraft tracking via a recommended rerouting must still be [separated from the SUA](../../../controller-skills/sua/#separation-from-sua)  laterally and vertically. After amending flight plans for the purposes of rerouting around SUA, controllers should ensure the route is displayed visually and the BRL is used to measure for [>2.5nm](../../../controller-skills/sua/#controlled-airspace) clearance with all parts of the SUA.
 
 #### R560 & R570 Williamtown
 The R560A-B and R570A-H restricted areas are located west of YWLM and YSTW within the ARL and MDE subsectors. The restricted areas are connected to the WLM TCU by the **Thunder Corridor**.
@@ -223,7 +223,7 @@ When activated these restricted areas distrupt traffic on the **Q16**, **Q235**,
 Aircraft travelling below `F240` on the **H66**, **H76**, and **Q35** airways are also disrupted, most directly affecting aircraft departing YSBK to the northwest, and aircraft climbing out of YSSY via RIC. These aircraft may be given altitude requirements to assure separation with the restricted areas, where appropriate.
 
 !!! note
-	Aircraft tracking via a recommended rerouting must still be [separated from the SUA](../../sua/#separation-from-sua) laterally and vertically. After amending flight plans for the purposes of rerouting around SUA, controllers should ensure the route is displayed visually and the BRL is used to measure for [>2.5nm](../../sua/#controlled-airspace) clearance with all parts of the SUA.
+	Aircraft tracking via a recommended rerouting must still be [separated from the SUA](../../../controller-skills/sua/#separation-from-sua) laterally and vertically. After amending flight plans for the purposes of rerouting around SUA, controllers should ensure the route is displayed visually and the BRL is used to measure for [>2.5nm](../../../controller-skills/sua/#controlled-airspace) clearance with all parts of the SUA.
     
 #### R585-R586 Williamtown
 The R585A-D and R586A-C restricted areas are located north of the WLM TCU in the ARL and MNN subsectors.
@@ -231,7 +231,7 @@ The R585A-D and R586A-C restricted areas are located north of the WLM TCU in the
 The MOAs directly adjoin the WLM TCU, and when WAL is online aircraft will be transferred directly to/from the restricted areas. When [WAL is offline](#reclassifications), aircraft will contact ARL for transit through the surrounding civilian airspace.
 
 #### Amberley SUA
-There are three SUA associated with military operations at [Amberley](../../terminal/amberleyoakey) which clip ARL airspace: the R639D restricted area, located northeast of MOR VOR partially in the MDE subsector, and the M661A and M670A-B MOAs, which clips MNN airspace offshore east of YCFS.
+There are three SUA associated with military operations at [Amberley](../../../terminal/amberleyoakey/) which clip ARL airspace: the R639D restricted area, located northeast of MOR VOR partially in the MDE subsector, and the M661A and M670A-B MOAs, which clips MNN airspace offshore east of YCFS.
 
 AMA (or INL(DOS, INL, SDY) on their behalf) will coordinate the activation these SUA **prior** to any activity.
 

--- a/docs/enroute/brisbane/INL.md
+++ b/docs/enroute/brisbane/INL.md
@@ -38,7 +38,7 @@ INL is responsible for **DOS**, **GOL**, **SDY**, **BUR**, and **NSA** when they
         When either AMA or OKA is offline, consider publishing a pre-formatted **ATIS Zulu** for their respective aerodromes, to inform pilots about the airspace reclassification.
 
 === "CFS CTR"
-	When **CFS ADC** is offline, CFS CTR (Class D `SFC` to `A045`) reverts to Class G, and is administered by MNN and INL. Alternatively, INL may provide a [top-down procedural service](../../../aerodromes/Coffs) if they wish (not recommended), and this must be coordinated to ARL(MNN).
+	When **CFS ADC** is offline, CFS CTR (Class D `SFC` to `A045`) reverts to Class G, and is administered by MNN and INL. Alternatively, INL may provide a [top-down procedural service](../../../aerodromes/procedural/Coffs/) if they wish (not recommended), and this must be coordinated to ARL(MNN).
 
 	Due to the low ceiling of CTA, when CFS ADC is offline, INL shall instruct aircraft departing into CTA to report lined up on the runway and issue an airways clearance (traffic pending) at that time.
 
@@ -52,7 +52,7 @@ INL is responsible for **DOS**, **GOL**, **SDY**, **BUR**, and **NSA** when they
         If choosing *not* to provide a top down service, consider publishing a pre-formatted **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification.
         
 === "SU CTR"
-	When **SU ADC** is offline, SU CTR (Class D `SFC` to `A045`) reverts to Class G, and is administered by NSA and BUR. Alternatively, NSA may provide a [top-down procedural service](../../../aerodromes/Sunshinecoast) if they wish (not recommended), and this must be coordinated to BUR.
+	When **SU ADC** is offline, SU CTR (Class D `SFC` to `A045`) reverts to Class G, and is administered by NSA and BUR. Alternatively, NSA may provide a [top-down procedural service](../../../aerodromes/procedural/Sunshinecoast/) if they wish (not recommended), and this must be coordinated to BUR.
 
     !!! tip
         If choosing *not* to provide a top down service, consider publishing a pre-formatted **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification.

--- a/docs/enroute/brisbane/ISA.md
+++ b/docs/enroute/brisbane/ISA.md
@@ -55,7 +55,7 @@ SG TCU must [give heads up coordination](../../../terminal/scherger/#sua-in-enro
     <span class="hotline">**ARA** -> **SGA**</span>: "FBED14, expect activation of M610A `F125-F245` at 0300 until 0500."   
     <span class="hotline">**SGA** -> **ARA**</span>: "FBED14."   
 
-Non-participating aircraft intending to transit an activated SUA should be rerouted, where possible, [subject to the VATSIM Code of Conduct](../../../sua/#ad-hoc-activations).
+Non-participating aircraft intending to transit an activated SUA should be rerouted, where possible, [subject to the VATSIM Code of Conduct](../../../controller-skills/sua/#ad-hoc-activations).
 
 #### M610A Scherger
 The M610A Scherger [MOA](../../../controller-skills/sua/#military-operating-areas) is located over western coast of North Queensland and the Gulf of Carpentaria, `F125-F245`, located entirely in ARA airspace. 

--- a/docs/enroute/brisbane/KEN.md
+++ b/docs/enroute/brisbane/KEN.md
@@ -104,10 +104,10 @@ TL TCU must [give heads up coordination](../../../terminal/townsville/#sua-in-en
     <span class="hotline">**TBP** -> **TLA**</span>: "PSSM31, expect activation of M742 `A040-F240` at 0300 until 0500."   
     <span class="hotline">**TLA** -> **TBP**</span>: "PSSM31."   
     
-Non-participating aircraft intending to transit an activated SUA should be rerouted, where possible, [subject to the VATSIM Code of Conduct](../../../sua/#ad-hoc-activations).
+Non-participating aircraft intending to transit an activated SUA should be rerouted, where possible, [subject to the VATSIM Code of Conduct](../../../controller-skills/sua/#ad-hoc-activations).
 
 #### M742 Tiger
-The M742 Tiger [MOA](../../../controller-skills/sua/#military-operating-areas) is located off the coast, `A040-F240`, spanning both TL TCU and KEN(TBP) airspace. Activation of the M742 MOA is a [shared responsibility](../../../controller-skills/sua/#activation-of-SUA), and both TAL and KEN(TBP) must coordinate before activation.
+The M742 Tiger [MOA](../../../controller-skills/sua/#military-operating-areas) is located off the coast, `A040-F240`, spanning both TL TCU and KEN(TBP) airspace. Activation of the M742 MOA is a [shared responsibility](../../../controller-skills/sua/#activation-of-sua), and both TAL and KEN(TBP) must coordinate before activation.
 
 Aircraft will generally enter and exit the MOA via the appropriate [military gate](../../../terminal/townsville/#military-gates).
 
@@ -128,7 +128,7 @@ When activated the restricted area disrupts traffic on the **J184**, **W152**, *
 | Z51            | `... W841 DOTTE DCT KADMU ...` |
 
 !!! note
-	Aircraft tracking via a recommended rerouting must still be [separated from the SUA](../../../sua/#separation-from-sua) laterally and vertically. After amending flight plans for the purposes of rerouting around SUA, controllers should ensure the route is displayed visually and the BRL is used to measure for [>2.5nm](../../../sua/#controlled-airspace) clearance with all parts of the SUA.
+	Aircraft tracking via a recommended rerouting must still be [separated from the SUA](../../../controller-skills/sua/#separation-from-sua) laterally and vertically. After amending flight plans for the purposes of rerouting around SUA, controllers should ensure the route is displayed visually and the BRL is used to measure for [>2.5nm](../../../controller-skills/sua/#controlled-airspace) clearance with all parts of the SUA.
 
 #### R736 & R739 Townsville (Star)
 The R736 and R739 Townsville (Star) [restricted areas](../../../controller-skills/sua/#restricted-areas) straddle the border of the TL TCU and KEN(TBP) airspace. 

--- a/docs/enroute/brisbane/KPL.md
+++ b/docs/enroute/brisbane/KPL.md
@@ -28,13 +28,13 @@ KPL is responsible for **SWY** and **CVN** when they are offline.
 
 ### Reclassifications
 === "HM CTR"
-	When **HM ADC** is offline, HM CTR (Class D `SFC` to `A045`) reverts to Class G, and is administered by SWY. Alternatively, SWY may provide a [top-down procedural service](../../../aerodromes/Hammo) if they wish (not recommended).
+	When **HM ADC** is offline, HM CTR (Class D `SFC` to `A045`) reverts to Class G, and is administered by SWY. Alternatively, SWY may provide a [top-down procedural service](../../../aerodromes/procedural/HamiltonIsland/) if they wish (not recommended).
 
 === "MK CTR"
-	Whilst the **MKA** controller is expected to provide a [top-down service](../../../aerodromes/Mackay) to YBMK when **MK ADC** is offline, this is not expected of a SWY controller when both **MKA** and **MK ADC** are offline. If electing not to provide a top-down service to YBMK, the RK CTR Class D is reclassified to Class G `SFC` to `A007`, and Class E `A007` to `A045`.
+	Whilst the **MKA** controller is expected to provide a [top-down service](../../../aerodromes/classd/Mackay/) to YBMK when **MK ADC** is offline, this is not expected of a SWY controller when both **MKA** and **MK ADC** are offline. If electing not to provide a top-down service to YBMK, the RK CTR Class D is reclassified to Class G `SFC` to `A007`, and Class E `A007` to `A045`.
 
 === "RK CTR"
-	Whilst the **RKA** controller is expected to provide a [top-down service](../../../aerodromes/Rockhampton) to YBRK when **RK ADC** is offline, this is not expected of a KPL controller when both **RKA** and **RK ADC** are offline. If electing not to provide a top-down service to YBRK, the RK CTR Class D is reclassified to Class G `SFC` to `A007`, and Class E `A007` to `A045`.
+	Whilst the **RKA** controller is expected to provide a [top-down service](../../../aerodromes/classd/Rockhampton/) to YBRK when **RK ADC** is offline, this is not expected of a KPL controller when both **RKA** and **RK ADC** are offline. If electing not to provide a top-down service to YBRK, the RK CTR Class D is reclassified to Class G `SFC` to `A007`, and Class E `A007` to `A045`.
 
 !!! tip
 	If choosing *not* to provide a top down service, consider publishing a pre-formatted **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification.

--- a/docs/enroute/brisbane/TRT.md
+++ b/docs/enroute/brisbane/TRT.md
@@ -31,7 +31,7 @@ TRT is responsible for **TRS**, **ASH**, and **KIY**,  when they are offline.
 
 ### Reclassifications
 === "BRM CTR"
-	When **BRM ADC** is offline, BRM CTR (Class D/E `SFC` to `A055`) reverts to Class G, and is administered by ASH. Alternatively, ASH may provide a [top-down procedural service](../../../aerodromes/Broome) if they wish.
+	When **BRM ADC** is offline, BRM CTR (Class D/E `SFC` to `A055`) reverts to Class G, and is administered by ASH. Alternatively, ASH may provide a [top-down procedural service](../../../aerodromes/procedural/Broome/) if they wish.
 
 	!!! tip
 		If choosing *not* to provide a top down service, consider publishing a pre-formatted **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification.
@@ -95,7 +95,7 @@ Each TCU must [give heads up coordination](../../../controller-skills/coordinati
     <span class="hotline">**TRS** -> **TNA**</span>: "CLAS35, expect activation of R225D `A095-F600` at 0300 until 0500."   
     <span class="hotline">**TNA** -> **TRS**</span>: "CLAS35."   
 
-Non-participating aircraft intending to transit an activated SUA should be rerouted, where possible, [subject to the VATSIM Code of Conduct](../../../sua/#ad-hoc-activations).
+Non-participating aircraft intending to transit an activated SUA should be rerouted, where possible, [subject to the VATSIM Code of Conduct](../../../controller-skills/sua/#ad-hoc-activations).
 
 <!-- #### M240A-F Darwin
 
@@ -104,12 +104,12 @@ Non-participating aircraft intending to transit an activated SUA should be rerou
 #### Bradshaw Field Training Area SUA
 The Bradshaw Field Training Area is contained within three volumes of SUA: R268 Koolendong, R269 Angalarri North, and R270 Angalarri South; all `SFC-NOTAM`. The area is used for extensive army training and operations based at Nackaroo Airfield (YNKR). R269 and R270 are wholly located in the TRS subsector, while R268 extends slightly into KIY.
 
-When all three restricted areas are activated, they are referred to collectively as *'Bradshaw'*. Aircraft intending to operate in adjoining SUA should be notified *'[Bradshaw Active](../../terminal/tindal/#bradshaw-delamere-active)'* with their clearance.
+When all three restricted areas are activated, they are referred to collectively as *'Bradshaw'*. Aircraft intending to operate in adjoining SUA should be notified *'[Bradshaw Active](../../../terminal/tindal/#bradshawdelamere-active)'* with their clearance.
 
 #### Delamere Air Weapons Range SUA
 The Delamere Air Weapons Range is contained within three volumes of SUA: R211 Delamere (`SFC-A095`), R212 Delamere (`SFC-A095`), and R232 Delamere (`SFC-NOTAM`). The range is used for a variety of bombing and live-firing training exercises, and is wholly located within the TRS subsector.
 
-When all three restricted areas are activated, they are referred to collectively as *'Delamere'*. Aircraft intending to operate in adjoining SUA should be notified *'[Delamere Active](../../terminal/tindal/#bradshaw-delamere-active)'* with their clearance.
+When all three restricted areas are activated, they are referred to collectively as *'Delamere'*. Aircraft intending to operate in adjoining SUA should be notified *'[Delamere Active](../../../terminal/tindal/#bradshawdelamere-active)'* with their clearance.
 
 #### R225A-F and R250 Tindal
 The R225A-F and R250 Tindal restricted areas form the western part of the Tindal Flying Training Area, and are located entirely within the TRS subsector. The areas are used for a variety of training purposes, including supersonic flight.

--- a/docs/enroute/melbourne/ASP.md
+++ b/docs/enroute/melbourne/ASP.md
@@ -34,7 +34,7 @@
 
 ### Reclassifications
 === "AS CTR"
-	When **AS ADC** is offline, AS CTR (Class D and C `SFC` to `F125`) within 80 DME AS reverts to Class G, and AS CTA (Class C `F125` to `F245`) within 80 DME AS reverts to Class E, and both are administered by ASP. Alternatively, ASP may provide a [top-down procedural service](../../../aerodromes/Alice) if they wish.
+	When **AS ADC** is offline, AS CTR (Class D and C `SFC` to `F125`) within 80 DME AS reverts to Class G, and AS CTA (Class C `F125` to `F245`) within 80 DME AS reverts to Class E, and both are administered by ASP. Alternatively, ASP may provide a [top-down procedural service](../../../aerodromes/procedural/Alice/) if they wish.
 
 	!!! tip
 		If choosing *not* to provide a top down service, consider publishing a pre-formatted **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification.
@@ -63,24 +63,24 @@ WRA is responsibile for facilitating operations in and out of YPWR.
 
 ## Local Procedures
 ### Special Use Airspace
-There are multiple volumes of [SUA](../../controller-skills/sua) within ASP airspace, mostly associated with military operations in and out of YPWR.
+There are multiple volumes of [SUA](../../../controller-skills/sua/) within ASP airspace, mostly associated with military operations in and out of YPWR.
 
 <figure markdown>
 ![Notable SUA in ASP Airspace](../img/asp_sua.png){ width="700" }
   <figcaption>Notable SUA in ASP Airspace</figcaption>
 </figure>
 
-When **WR ADC** is online, **R222F** Restricted Area is activated `SFC` to `F120` by default. WR ADC must [give heads up coordination](../../aerodrome/procedural/Woomera/#sua-in-enroute-airspace) with the relevant enroute controllers **prior** to any departures intending to operate in a currently inactive SUA.
+When **WR ADC** is online, **R222F** Restricted Area is activated `SFC` to `F120` by default. WR ADC must [give heads up coordination](../../../aerodromes/procedural/Woomera/#sua-in-enroute-airspace) with the relevant enroute controllers **prior** to any departures intending to operate in a currently inactive SUA.
 
 !!! phraseology
     <span class="hotline">**WAL** -> **ARL**</span>: "On the groud YWLM, PTHR11, requests activation of R560A `A085-F240`, from 0300 until 0500.”  
     <span class="hotline">**ARL** -> **WAL**</span>: "PTHR11, expect activation of R560A `A085-F240` at 0300 until 0500."   
     <span class="hotline">**WAL** -> **ARL**</span>: "PTHR11."  
 
-Non-participating aircraft intenting to transit an activated SUA should be rerouted, where possible, [subject to the VATSIM Code of Conduct](../../sua/#ad-hoc-activations).
+Non-participating aircraft intenting to transit an activated SUA should be rerouted, where possible, [subject to the VATSIM Code of Conduct](../../../controller-skills/sua/#ad-hoc-activations).
 
 #### Woomera SUA
-There are multiple restricted areas associated with military operations at [YPWR](../../../aerodromes/procedural/Woomera): R222A-J, R237, R246A-C, R273, R281, and R287A-C. All restricted areas are located with the WRA subsector, and two (R22I and R22J) extend into FOR airspace.
+There are multiple restricted areas associated with military operations at [YPWR](../../../aerodromes/procedural/Woomera/): R222A-J, R237, R246A-C, R273, R281, and R287A-C. All restricted areas are located with the WRA subsector, and two (R22I and R22J) extend into FOR airspace.
 
 These restricted areas directly adjoin the jurisdiction of WR ADC, and when WR ADC is online aircraft will be transferred directly to/from the MOAs.
 
@@ -90,7 +90,7 @@ When activated these restricted areas distrupt traffic on the **J141**, **J251**
 Aircraft transiting the area should be rerouted via the **Z90**, **Z91**, **Z92**, and **Z93** as required.
 
 !!! note
-	 Aircraft tracking via a recommended rerouting must still be [separated from the SUA](../../sua/#separation-from-sua) laterally and vertically. After amending flight plans for the purposes of rerouting around SUA, controllers should ensure the route is displayed visually and the BRL is used to measure for [>2.5nm](../../sua/#controlled-airspace) clearance with all parts of the SUA.
+	 Aircraft tracking via a recommended rerouting must still be [separated from the SUA](../../../controller-skills/sua/#separation-from-sua) laterally and vertically. After amending flight plans for the purposes of rerouting around SUA, controllers should ensure the route is displayed visually and the BRL is used to measure for [>2.5nm](../../../controller-skills/sua/#controlled-airspace) clearance with all parts of the SUA.
 
 
 ## STAR Clearance Expectation
@@ -118,7 +118,7 @@ AS ADC is responsible for the Class D airspace `SFC` to `A045`, as well as the C
 Refer to [Reclassifications](#reclassifications) for operations when AS ADC is offline.
 
 #### Departures
-[Next](../../controller-skills/coordination.md#next) coordination is required from AS ADC to ASP for all aircraft **entering ASP CTA**.
+[Next](../../../controller-skills/coordination/#next) coordination is required from AS ADC to ASP for all aircraft **entering ASP CTA**.
 
 The Standard Assignable level from **AS ADC** to **ASP** is:
 
@@ -137,14 +137,14 @@ The Standard Assignable level from ASP to **AS ADC** is `A080`, any other level 
 
 ### WR ADC
 #### Airspace
-WR ADC is responsible for the Class D airspace `SFC` to `F120` within the R222F [restricted area](../../../sua/#restricted-areas).
+WR ADC is responsible for the Class D airspace `SFC` to `F120` within the R222F [restricted area](../../../controller-skills/sua/#restricted-areas).
 
 Refer to [Reclassifications](#reclassifications) for operations when WR ADC is offline.
 
 ### Departures
 Next coordination is not required from WR ADC to ASP(WRA). 
 
-Aircraft leaving WR ADC airspace both **laterally** and **vertically** will enter ASP(WRA) uncontrolled airspace. However, it is good practice for WR ADC to provide [heads-up](../../controller-skills/coordination/#heads-up) coordination for aircraft leaving WR ADC airspace **vertically** to help faciltiate an uninterrupted climb.
+Aircraft leaving WR ADC airspace both **laterally** and **vertically** will enter ASP(WRA) uncontrolled airspace. However, it is good practice for WR ADC to provide [heads-up](../../../controller-skills/coordination/#heads-up) coordination for aircraft leaving WR ADC airspace **vertically** to help faciltiate an uninterrupted climb.
 
 !!! phraseology
     <span class="hotline">**WR ADC** -> **WRA**</span>: "via WR 180 bearing outbound, LYBD11.”  
@@ -155,7 +155,7 @@ Aircraft leaving WR ADC airspace both **laterally** and **vertically** will ente
     **LYBD11**: "Leave and re-enter controlled airspace on climb to `F240`, LYBD11" 
  
 ### Arrivals/Overfliers
-As with departures, there is no inherent requirement for ASP(WRA) to coordinate arrivals or overfliers with WR ADC. However, it is good practice for ASP(WRA) to provide [heads-up](../../controller-skills/coordination/#heads-up) coordination for aircraft arriving into directly into WR ADC airspace. 
+As with departures, there is no inherent requirement for ASP(WRA) to coordinate arrivals or overfliers with WR ADC. However, it is good practice for ASP(WRA) to provide [heads-up](../../../controller-skills/coordination/#heads-up) coordination for aircraft arriving into directly into WR ADC airspace. 
 
 Arriving aircraft shall be instructed to leave CTA descending (if appropriate) and to contact WR ADC for clearance.
 

--- a/docs/enroute/melbourne/BLA.md
+++ b/docs/enroute/melbourne/BLA.md
@@ -23,7 +23,7 @@
 
 ### Reclassifications
 === "AY CTR"
-	When **AY ADC** is offline, AY CTR (Class D and C `SFC` to `A085`) reverts to Class G, and is administered by BLA. Alternatively, BLA may provide a [top-down procedural service](../../../aerodromes/Albury) if they wish.
+	When **AY ADC** is offline, AY CTR (Class D and C `SFC` to `A085`) reverts to Class G, and is administered by BLA. Alternatively, BLA may provide a [top-down procedural service](../../../aerodromes/procedural/Albury/) if they wish.
 
 	!!! tip
 		If choosing *not* to provide a top down service, consider publishing a pre-formatted **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification.

--- a/docs/enroute/melbourne/HUO.md
+++ b/docs/enroute/melbourne/HUO.md
@@ -36,7 +36,7 @@
 	If HUO chooses to operate top down to either aerodrome, they must administer all relevant airspace within the appropriate TMA, including the class D CTR.
 
 	!!! warning "Important"
-		Ensure you are familiar with the aerodrome procedures for [Launceston](../../../aerodromes/Launceston) and [Hobart](../../../aerodromes/Hobart) before extending top down, and are aware of the limited surveillence coverage available in the lower levels of the TMA.
+		Ensure you are familiar with the aerodrome procedures for [Launceston](../../../aerodromes/classd/Launceston/) and [Hobart](../../../aerodromes/classd/Hobart/) before extending top down, and are aware of the limited surveillence coverage available in the lower levels of the TMA.
 
 	!!! tip
 		If choosing *not* to provide a top down service, consider publishing a pre-formatted **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification.

--- a/docs/enroute/melbourne/OLW.md
+++ b/docs/enroute/melbourne/OLW.md
@@ -30,7 +30,7 @@ OLW is responsible for **POT**, **PAR**, **NEW**, **MEK**, **MTK** and **MZI** w
 
 ### Reclassifications
 === "KA CTR"
-	When **KA ADC** is offline, KA CTR (Class D `SFC` to `A055`) reverts to Class G, and is administered by OLW. Alternatively, OLW may provide a [top-down procedural service](../../../aerodromes/Karratha) if they wish.
+	When **KA ADC** is offline, KA CTR (Class D `SFC` to `A055`) reverts to Class G, and is administered by OLW. Alternatively, OLW may provide a [top-down procedural service](../../../aerodromes/procedural/Karratha/) if they wish.
 
 	!!! tip
 		If choosing *not* to provide a top down service, consider publishing a pre-formatted **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification.

--- a/docs/enroute/melbourne/TBD.md
+++ b/docs/enroute/melbourne/TBD.md
@@ -33,7 +33,7 @@ The following subsectors are responsible for issuing STAR clearance.
 
 ##### Assignment Rules
 
-Arrivals shall be assigned the STAR in accordance with the tables below, as per the approach expectations on the [ATIS](../../../aerodromes/classc/Adelaide/#approach-expectation).
+Arrivals shall be assigned the STAR in accordance with the tables below, as per the approach expectations on the [ATIS](../../../aerodromes/classc/Adelaide/#approach-types).
 
 - `R(rwy)` = Non-Jet Victor STAR
     - *Example:* `R23` via **ATNAR** = GULFS V STAR, ATNAR Transition, Runway 23

--- a/docs/enroute/melbourne/WOL.md
+++ b/docs/enroute/melbourne/WOL.md
@@ -78,7 +78,7 @@ During times of high traffic, NW TCU may request the release of R420F up to `F30
 
 With R420F released to NW TCU, transiting aircraft will need to be coordinated or rerouted. Every effort will be made to accommodate these aircraft on track, but if NW TCU can't accommodate them, they must be vertically or laterally rerouted to avoid the restricted area. NW TCU will communicate this requirement.
 
-See [Nowra Airspace](../../terminal/nowra#airspace) for more details about the lateral boundaries of the Nowra restricted areas.
+See [Nowra Airspace](../../../terminal/nowra/#airspace) for more details about the lateral boundaries of the Nowra restricted areas.
 
 ## STAR Clearance Expectation
 ### Handoff

--- a/docs/events/archive/worldflight-2024/Aerodromes/adelaide.md
+++ b/docs/events/archive/worldflight-2024/Aerodromes/adelaide.md
@@ -23,7 +23,7 @@ An additional Non-Standard position for AD SMC will be used
 Any other Runway Mode may **only** be used with approval from the Events Coordinator.
 
 ## Workload Management
-Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../client/towerstrips/#recommended-workflow).
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow).
 
 ## Airways Clearance Delivery (ACD)
 ### Flight Plan Compliance
@@ -42,7 +42,7 @@ If an aircraft has filed an *incorrect* route and you need to give an amended cl
 Upon readback of an airways clearance or PDC, instruct aircraft to contact Adelaide Ground on **121.700** when ready for pushback.
 
 ### WorldFlight Teams
-[WorldFlight Teams](../../../../#official-team-callsigns) shall have `STS/STATE` added to their remarks, and `WF TEAM` added to their Global Ops Field, to ensure they receive priority.
+WorldFlight Teams shall have `STS/STATE` added to their remarks, and `WF TEAM` added to their Global Ops Field, to ensure they receive priority.
 
 !!! tip
     The [vatSys Events Plugin](https://github.com/badvectors/EventsPlugin){target=new} will also highlight WF Teams, as shown below. Click on the link to install it, or alternatively, use the [Plugin Manager](https://github.com/badvectors/PluginManager){target=new}
@@ -109,7 +109,7 @@ SMC will be responsible for delaying aircraft's pushback requests, in order to a
 If there are more than **5** aircraft in the queue at the Holding Point for *any runway*, do not approve any more pushback requests.
 
 #### OzStrips
-All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../client/towerstrips/#recommended-workflow) for OzStrips.
+All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow) for OzStrips.
 
 Ensure the Queue function is used to actively to keep track of the order of requests.
 

--- a/docs/events/archive/worldflight-2024/Aerodromes/brisbane.md
+++ b/docs/events/archive/worldflight-2024/Aerodromes/brisbane.md
@@ -14,7 +14,7 @@
 *Single Runway* Operations and *SODPROPS* shall not be used.
 
 ## Workload Management
-Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../client/towerstrips/#recommended-workflow).
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow).
 
 ## Airways Clearance Delivery (ACD)
 ### Flight Plan Compliance
@@ -30,7 +30,7 @@ If an aircraft has filed an *incorrect* route and you need to give an amended cl
     **BN ACD:** *"AMENDED ROUTE CLEARANCE. CLEARED TO YSSY VIA SANEG H91 IGDAM H652 TESAT DCT. READBACK AMENDED ROUTE IN FULL DURING PDC READBACK. STANDBY FOR PDC."*
 
 ### WorldFlight Teams
-[WorldFlight Teams](../../../../#official-team-callsigns) shall have `STS/STATE` added to their remarks, and `WF TEAM` added to their Global Ops Field, to ensure they receive priority.
+WorldFlight Teams shall have `STS/STATE` added to their remarks, and `WF TEAM` added to their Global Ops Field, to ensure they receive priority.
 
 !!! tip
     The [vatSys Events Plugin](https://github.com/badvectors/EventsPlugin){target=new} will also highlight WF Teams, as shown below. Click on the link to install it, or alternatively, use the [Plugin Manager](https://github.com/badvectors/PluginManager){target=new}
@@ -92,7 +92,7 @@ SMC Domestic and South will be responsible for delaying aircraft's pushback requ
 If there are more than **5** aircraft in the queue at the Holding Point for *any runway*, do not approve any more pushback requests.
 
 #### OzStrips
-All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../client/towerstrips/#recommended-workflow) for OzStrips.
+All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow) for OzStrips.
 
 Ensure the Queue function is used to actively to keep track of the order of requests.
 

--- a/docs/events/archive/worldflight-2024/Aerodromes/darwin.md
+++ b/docs/events/archive/worldflight-2024/Aerodromes/darwin.md
@@ -8,7 +8,7 @@
 Single runway operations on either **runway 11 or 29** will be in use for all aircraft. Runway 18/36 will not be available for arrivals and departures, due to its use as a taxiway for some aircraft.
 
 ## Workload Management
-Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../client/towerstrips/#recommended-workflow).
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow).
 
 ## Airways Clearance Delivery (ACD)
 ### Flight Plan Compliance
@@ -24,7 +24,7 @@ If an aircraft has filed an *incorrect* route and you need to give an amended cl
     **DN ACD:** *"AMENDED ROUTE CLEARANCE. CLEARED TO AYPY VIA RUPEG DCT IGOPO B598 ESKIM DCT GUMBU DCT PY DCT. READBACK AMENDED ROUTE IN FULL DURING PDC READBACK. STANDBY FOR PDC."*
 
 ### WorldFlight Teams
-[WorldFlight Teams](../../../../#official-team-callsigns) shall have `STS/STATE` added to their remarks, and `WF TEAM` added to their Global Ops Field, to ensure they receive priority.
+WorldFlight Teams shall have `STS/STATE` added to their remarks, and `WF TEAM` added to their Global Ops Field, to ensure they receive priority.
 
 !!! tip
     The [vatSys Events Plugin](https://github.com/badvectors/EventsPlugin){target=new} will also highlight WF Teams, as shown below. Click on the link to install it, or alternatively, use the [Plugin Manager](https://github.com/badvectors/PluginManager){target=new}
@@ -70,7 +70,7 @@ SMC will be responsible for delaying aircraft's pushback requests, in order to a
 If there are more than **5** aircraft in the queue at any Holding Point, do not approve any more pushback requests. Instead, use the queue function to keep track of who is awaiting push.
 
 #### OzStrips
-All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../client/towerstrips/#recommended-workflow) for OzStrips.
+All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow) for OzStrips.
 
 Ensure the Queue function is used to actively to keep track of the order of requests.
 

--- a/docs/events/archive/worldflight-2024/Aerodromes/perth.md
+++ b/docs/events/archive/worldflight-2024/Aerodromes/perth.md
@@ -14,7 +14,7 @@
 Any other Runway Mode may **only** be used with approval from the Events Coordinator.
 
 ## Workload Management
-Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../client/towerstrips/#recommended-workflow).
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow).
 
 ### 24A21D
 Simultaneous Independent Crossing Runway Operations will be in use, allowing aircraft to depart from Runway 21 without conflicting with Runway 24 arrivals.
@@ -50,7 +50,7 @@ If an aircraft has filed an *incorrect* route and you need to give an amended cl
     **PH ACD:** *"AMENDED ROUTE CLEARANCE. CLEARED TO WIII VIA AVNEX Y15 ESDEG Q587 IGLUT T58 SAPDA A585 IPKON IPKO2G. READBACK AMENDED ROUTE IN FULL DURING PDC READBACK. STANDBY FOR PDC."*
 
 ### WorldFlight Teams
-[WorldFlight Teams](../../../../#official-team-callsigns) shall have `STS/STATE` added to their remarks, and `WF TEAM` added to their Global Ops Field, to ensure they receive priority.
+WorldFlight Teams shall have `STS/STATE` added to their remarks, and `WF TEAM` added to their Global Ops Field, to ensure they receive priority.
 
 !!! tip
     The [vatSys Events Plugin](https://github.com/badvectors/EventsPlugin){target=new} will also highlight WF Teams, as shown below. Click on the link to install it, or alternatively, use the [Plugin Manager](https://github.com/badvectors/PluginManager){target=new}
@@ -103,7 +103,7 @@ SMC East and West will be responsible for delaying aircraft's pushback requests,
 If there are more than **5** aircraft in the queue at the Holding Point for *any runway*, do not approve any more pushback requests.
 
 #### OzStrips
-All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../client/towerstrips/#recommended-workflow) for OzStrips.
+All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow) for OzStrips.
 
 Ensure the Queue function is used to actively to keep track of the order of requests.
 
@@ -127,7 +127,7 @@ Aircraft that cannot accept Intersection **P** for departure will be assigned a 
 #### Manoeuvring Area Responsibility
 Aircraft from the Western Apron shall be taxied via **D** and **N**.
 
-As per the [YPPH Aerodrome SOPs](../../../../../../aerodromes/classc/Perth/#manoeuvring-area-responsibility), ADC is responsible for the taxiways between the thresholds of Runway 21 and 24.
+As per the [YPPH Aerodrome SOPs](../../../../../../aerodromes/classc/Perth/#manuevering-area-responsibility), ADC is responsible for the taxiways between the thresholds of Runway 21 and 24.
 
 Instead of SMC coordinating runway crossings with ADC, aircraft taxiing via **N** and **C** shall be instructed to **contact ADC** at Holding Point **D**, where ADC will give them taxi instructions on their frequency. No coordination is required between SMC and ADC for this.
 
@@ -172,7 +172,7 @@ Full Length Departures have **equal priority** to aircraft that are compliant wi
 #### Manoeuvring Area Responsibility
 Aircraft from the Western Apron shall be taxied via **D** and **N**.
 
-As per the [YPPH Aerodrome SOPs](../../../../../../aerodromes/classc/Perth/#manoeuvring-area-responsibility), ADC is responsible for the taxiways between the thresholds of Runway 21 and 24.
+As per the [YPPH Aerodrome SOPs](../../../../../../aerodromes/classc/Perth/#manuevering-area-responsibility), ADC is responsible for the taxiways between the thresholds of Runway 21 and 24.
 
 Instead of SMC coordinating runway crossings with ADC, aircraft taxiing via **N** and **C** shall be instructed to **contact ADC** at Holding Point **D**, where ADC will give them taxi instructions on their frequency. No coordination is required between SMC and ADC for this.
 

--- a/docs/events/archive/worldflight-2024/Aerodromes/portmoresby.md
+++ b/docs/events/archive/worldflight-2024/Aerodromes/portmoresby.md
@@ -12,7 +12,7 @@ An additional Non-Standard position for AYPY ACD will be used
 | Port Moresby Delivery       | AYPY ACD | Jacksons Delivery             | 124.400 | AYPY_DEL                              |
 
 ## Workload Management
-Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../client/towerstrips/#recommended-workflow).
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow).
 
 ## Airways Clearance Delivery (ACD)
 ### Flight Plan Compliance
@@ -82,7 +82,7 @@ SMC will be responsible for delaying aircraft's pushback requests, in order to a
 If there are more than **5** aircraft in the queue at the Holding Point for the departure runway, do not approve any more pushback requests.
 
 #### OzStrips
-All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../client/towerstrips/#recommended-workflow) for OzStrips.
+All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow) for OzStrips.
 
 Ensure the Queue function is used to actively to keep track of the order of requests.
 
@@ -99,9 +99,9 @@ Runway 14R/32L will be used for taxiing. The Runway is released to SMC by defaul
 Ensure that a minimum of **90 second** spacing is applied between subsequent departures from the same runway.
 
 ### Wake Turbulence Separation
-Due to the tight sequence, there are times that [Wake Turbulence Separation](../../../../separation-standards/waketurb/#runways) cannot practically be applied.
+Due to the tight sequence, there are times that Wake Turbulence Separation cannot practically be applied.
 
-When a following aircraft is of a *lighter* [Wake Turbulence Category](../../../../separation-standards/waketurb/#categories) than the preceding aircraft, a traffic statement and wake turbulence **caution** shall be issued.
+When a following aircraft is of a *lighter* Wake Turbulence Category than the preceding aircraft, a traffic statement and wake turbulence **caution** shall be issued.
 
 !!! phraseology
     **AYPY ADC:** "ANG3, 747 has just departed. Caution Wake Turbulence. Runway 32L, Cleared for Takeoff"  

--- a/docs/events/archive/worldflight-2024/Aerodromes/sydneyarr.md
+++ b/docs/events/archive/worldflight-2024/Aerodromes/sydneyarr.md
@@ -16,10 +16,10 @@ The ACD role will perform as normal. Expect a handful of departures who want to 
 
 ## Surface Movement Control (SMC)
 ### OzStrips
-With two SMC controllers online, utilise [strip bay bars](../../../../client/towerstrips/#multiple-adcsmc-positions) to keep the **Taxi** and **Holding Point** strip bays organised.
+With two SMC controllers online, utilise [strip bay bars](../../../../../client/towerstrips/#multiple-adcsmc-positions) to keep the **Taxi** and **Holding Point** strip bays organised.
 
 ### Departures
-It is unlikely that Coordinator will be open, so normal outbound taxi procedures apply. If Coordinator is online, refer to the VATPAC [recommended workflow](../../../../client/towerstrips/#recommended-workflow).
+It is unlikely that Coordinator will be open, so normal outbound taxi procedures apply. If Coordinator is online, refer to the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow).
 
 ### Separation Assurance
 Both SMC positions must be careful to ensure separation is assured at all times, particularly through the complex taxiway intersections at Sydney.
@@ -37,7 +37,7 @@ If a crossing is required, coordinate *early* with ADC, who may obtain assurance
 
 ## Tower Control (ADC)
 ### OzStrips
-With two SMC controllers online, utilise [strip bay bars](../../../../client/towerstrips/#multiple-adcsmc-positions) to keep the **Holding Point** and **Runway** strip bays organised.
+With two SMC controllers online, utilise [strip bay bars](../../../../../client/towerstrips/#multiple-adcsmc-positions) to keep the **Holding Point** and **Runway** strip bays organised.
 
 ### Runway Vacating Instructions
 To avoid creating conflict for SMC, ADC shall instruct all arriving aircraft to vacate via the following exits when issued a landing clearance:
@@ -63,4 +63,4 @@ While runway crossings will be minimised, should a crossing be required, instruc
 If any aircraft need to depart during the arrival window, ensure that maximum efficiency is achieved by instructing them to line up as soon as the landing aircraft has cleared the threshold. Avoid go arounds at all costs, and if necessary, delay the departing aircraft where a gap between two arrivals is too tight.
 
 ## Coordination
-Standard as per [YSSY Local Instructions](../../../../aerodromes/classc/Sydney/#auto-release).
+Standard as per [YSSY Local Instructions](../../../../../aerodromes/classc/Sydney/#auto-release).

--- a/docs/events/archive/worldflight-2024/Aerodromes/sydneydep.md
+++ b/docs/events/archive/worldflight-2024/Aerodromes/sydneydep.md
@@ -15,7 +15,7 @@ An additional Non-Standard position for Sydney ACD will be used
 **16 PROPS** and **34 PROPS** are the available Runway Modes, with equal preference. Any other Runway Mode may **only** be used with approval from the Events Coordinator.
 
 ## Workload Management
-Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../client/towerstrips/#recommended-workflow). 
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow). 
 
 ## Airways Clearance Delivery (ACD)
 ### Flight Plan Compliance
@@ -64,7 +64,7 @@ YSSY will have a non-standard second ACD Controller.
 **SY-C_DEL** will be responsible for:
 
 - Checking [Flight Plan compliance](#flight-plan-compliance)
-- Entering Flight Data (Setting [Runway](#runway-selection), [SID](#sid-selection) and [CFL](../../../../aerodromes/classc/Sydney/#auto-release))
+- Entering Flight Data (Setting [Runway](#runway-selection), [SID](#sid-selection) and [CFL](../../../../../aerodromes/classc/Sydney/#auto-release))
 - Sending [PDCs](#pdcs)
 
 SY-C_DEL has *no frequency*, and will not talk to aircraft by voice.
@@ -100,13 +100,13 @@ PDCs will be in use by default, to avoid frequency congestion. ACD shall send a 
     OzStrips displays strips in the Preactive bay ordered by connection time. Aircraft who connected first are shown down the bottom of the bay.
 
 ## Coordinator
-Coordinator operations shall be conducted in accordance with the Sydney Aerodrome [Coordinator](../../../../aerodromes/classc/Sydney/#sydney-coordinator) procedures, using the OzStrips plugin.
+Coordinator operations shall be conducted in accordance with the Sydney Aerodrome [Coordinator](../../../../../aerodromes/classc/Sydney/#sydney-coordinator) procedures, using the OzStrips plugin.
 
 !!! warning "Important"
     Official WorldFlight teams should be afforded priority when requesting pushback or taxi (if no pushback required), and placed ahead of other non-official aircraft.
 
 ### OzStrips
-All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../client/towerstrips/#recommended-workflow) for OzStrips.
+All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow) for OzStrips.
 
 Coordinator must place a `MONITOR GROUND EAST` & `MONITOR GROUND WEST` bar in the **Cleared Bay Queue** and queue any aircraft who request pushback or taxi (if no pushback required) in the Cleared Bay.
 
@@ -133,7 +133,7 @@ If three strips are already present below a respective bar, any subsequent aircr
     **SY COORD**: "Velocity 318, Coordinator, remain this frequency, approximate 5 minute delay due traffic congestion"
 
 !!! warning "Important"
-    Ensure aircraft are [squawking mode C and the correct code](../../../../client/towerstrips/#strips) before instructing them to monitor ground.
+    Ensure aircraft are [squawking mode C and the correct code](../../../../../client/towerstrips/#strips) before instructing them to monitor ground.
 
 ### Delay Expectation
 Aircraft can expect **extensive** delays for Pushback during the event, possibly *multiple hours*. Try to keep pilots informed of their delay expectation, either by providing a figure in minutes, or a position in the queue.
@@ -144,7 +144,7 @@ Aircraft can expect **extensive** delays for Pushback during the event, possibly
 
 ## Surface Movement Control (SMC)
 ### OzStrips
-With two SMC controllers online, utilise [strip bay bars](../../../../client/towerstrips/#multiple-adcsmc-positions) to keep the **Taxi** and **Holding Point** strip bays organised.
+With two SMC controllers online, utilise [strip bay bars](../../../../../client/towerstrips/#multiple-adcsmc-positions) to keep the **Taxi** and **Holding Point** strip bays organised.
 
 ### Departures
 With Coordinator online, aircraft will request pushback on the Coordinator frequency and be told to monitor the applicable SMC frequency when appropriate. These pilots will be waiting for you to initiate contact with them.
@@ -168,7 +168,7 @@ SMC West should protect the Alpha 2 rapid exit and utilise taxiways Yankee and J
 
 ## Tower Control (ADC)
 ### OzStrips
-With two SMC controllers online, utilise [strip bay bars](../../../../client/towerstrips/#multiple-adcsmc-positions) to keep the **Holding Point** and **Runway** strip bays organised.
+With two SMC controllers online, utilise [strip bay bars](../../../../../client/towerstrips/#multiple-adcsmc-positions) to keep the **Holding Point** and **Runway** strip bays organised.
 
 ### Departure Spacing
 While PROPS are in use, subsequent departures from the same runway **must** be spaced by **3 minutes**, to assist with arrival flow in to YPAD.
@@ -198,7 +198,7 @@ The ATIS OPR INFO shall include:
 ## Coordination
 ### SY TCU
 #### Auto Release
-Standard as per [YSSY Local Instructions](../../../../aerodromes/classc/Sydney/#auto-release), with the exception of auto-release being available for the following:
+Standard as per [YSSY Local Instructions](../../../../../aerodromes/classc/Sydney/#auto-release), with the exception of auto-release being available for the following:
 
 - 16L/34R Departure SID: **SY3** RADAR
 - 16L/34R Standard Assignable Departure Heading: **H120**

--- a/docs/events/archive/worldflight-2024/Enroute/aypyybbn.md
+++ b/docs/events/archive/worldflight-2024/Enroute/aypyybbn.md
@@ -86,7 +86,7 @@ Aircraft must be tracking via **ENLIP** or **SMOKA**
 
 ### BUR to BAS/BAN
 #### Airspace
-Non-Standard Airspace Division will be in use for BN TCU. Refer to [these diagrams](../../../../Terminal Areas/brisbane/#airspace-division).
+Non-Standard Airspace Division will be in use for BN TCU. Refer to [these diagrams](../../../../../terminal/brisbane/#airspace-division).
 
 Runway **01L** and **19L** Arrivals will be handed off to BAN.  
 Runway **01R** and **19R** Arrivals will be handed off to BAS.  

--- a/docs/events/archive/worldflight-2024/Enroute/wammypdn.md
+++ b/docs/events/archive/worldflight-2024/Enroute/wammypdn.md
@@ -23,10 +23,10 @@ Minimum distance between arrivals at handoff to DAW is **10nm** (with no signifi
 
 ## Coordination
 ### WAAF CTR to TRT
-As per [Standard TRT coordination procedures](../../../../../../enroute/Brisbane Centre/TRT/#international-waaf), All aircraft should be Heads-up Coordinated by WAAF CTR prior to **30 mins** from boundary.
+As per [Standard TRT coordination procedures](../../../../../enroute/brisbane/TRT/#international-waaf), All aircraft should be Heads-up Coordinated by WAAF CTR prior to **30 mins** from boundary.
 
 !!! tip
     It may be prudent (especially if they are using vatSys) to set up a Voiceless Coordination Agreement with WAAF CTR, in order to reduce workload for both controllers.
 
 ### TRT to DAW
-Standard as per [TRT Local Instructions](../../../../../../nroute/Brisbane Centre/TRT/#arrivalsoverfliers)
+Standard as per [TRT Local Instructions](../../../../../enroute/brisbane/TRT/#arrivalsoverfliers)

--- a/docs/events/archive/worldflight-2024/Enroute/ybbnyssy.md
+++ b/docs/events/archive/worldflight-2024/Enroute/ybbnyssy.md
@@ -61,7 +61,7 @@ Changes to Route and CFL are **permitted** within **50nm** of the boundary, with
 Aircraft must be tracking via **BOREE** or **MEPIL**.
 
 ### CNK to SAS/SAN
-Standard as per [ARL Local Instructions](../../../../../../enroute/Brisbane Centre/ARL/#arrivalsoverfliers).
+Standard as per [ARL Local Instructions](../../../../../enroute/brisbane/ARL/#arrivalsoverfliers).
 
 **BOREE** Arrivals will be handed off to SAS.  
 **MEPIL** Arrivals will be handed off to SAN.  

--- a/docs/events/archive/worldflight-2024/Enroute/ypadypph.md
+++ b/docs/events/archive/worldflight-2024/Enroute/ypadypph.md
@@ -80,7 +80,7 @@ Aircraft must be tracking via **MALUP** or **KABLI**, with the exception of:
 **Runway 21** Arrivals may be assigned a Heading **North** of the **MALUP-KABLI** track, without coordination.
 
 ### PIY to PHA
-Standard as per [PIY Local Instructions](../../../../../../enroute/Melbourne Centre/PIY/#arrivalsoverfliers), with the exception of:
+Standard as per PIY Local Instructions, with the exception of:
 
 - During the [24A21D Runway Mode](#24a21d), arrivals assigned **Runway 21** may be handed off to PHA on a **Heading** *north* of the Runway 24 arrivals, without coordination.
 

--- a/docs/events/archive/worldflight-2024/Enroute/ypphwiii.md
+++ b/docs/events/archive/worldflight-2024/Enroute/ypphwiii.md
@@ -38,7 +38,7 @@ Voiceless for all aircraft:
 All other aircraft going to LEA CTA will be **Heads-up** Coordinated.
 
 ### INE to WIIF CTR
-As per [Standard IND coordination procedures](../../../../../../oceanic/Positions/IND/#international-non-pacific), Heads-up Coordination required for all aircraft prior to **30 mins** from boundary.
+As per [Standard IND coordination procedures](../../../../../oceanic/IND/#international-non-pacific), Heads-up Coordination required for all aircraft prior to **30 mins** from boundary.
 
 !!! tip
     It may be prudent (especially if they are using vatSys) to set up a Voiceless Coordination Agreement with WIIF CTR, in order to reduce workload for both controllers.

--- a/docs/events/archive/worldflight-2025/Aerodromes/brisbane.md
+++ b/docs/events/archive/worldflight-2025/Aerodromes/brisbane.md
@@ -14,7 +14,7 @@
 *Single Runway* Operations and *SODPROPS* shall not be used.
 
 ## Workload Management
-Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#recommended-workflow).
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow).
 
 !!! tip
     The following OzStrips [keyboard shortcuts](../../../../client/towerstrips.md#keyboard-shortcuts) may assist controllers managing busy frequencies:
@@ -36,7 +36,7 @@ If an aircraft has filed an *incorrect* route and you need to give an amended cl
     **BN ACD:** *"AMENDED ROUTE CLEARANCE. CLEARED TO YSSY VIA SANEG H91 IGDAM H652 TESAT DCT. READBACK AMENDED ROUTE IN FULL DURING PDC READBACK. STANDBY FOR PDC."*
 
 ### WorldFlight Teams
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by OzStrips and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by OzStrips and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight in OzStrips](../img/wfteamozstrips.png){ width="500" }
@@ -83,7 +83,7 @@ SMC Domestic and South will be responsible for delaying aircraft's pushback requ
 If there are more than **5** aircraft in the queue at the Holding Point for *any runway*, do not approve any more pushback requests.
 
 #### OzStrips
-All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#recommended-workflow) for OzStrips.
+All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow) for OzStrips.
 
 Ensure the Queue function is used to actively to keep track of the order of requests.
 

--- a/docs/events/archive/worldflight-2025/Aerodromes/cairns.md
+++ b/docs/events/archive/worldflight-2025/Aerodromes/cairns.md
@@ -10,7 +10,7 @@ Single runway operations on either **runway 15 or 33** will be in use for all ai
 **Runway 15** will be the preferred Runway Mode.
 
 ## Workload Management
-Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#recommended-workflow).
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow).
 
 !!! tip
     The following OzStrips [keyboard shortcuts](../../../../client/towerstrips.md#keyboard-shortcuts) may assist controllers managing busy frequencies:
@@ -32,7 +32,7 @@ If an aircraft has filed an *incorrect* route and you need to give an amended cl
     **CS ACD:** *"AMENDED ROUTE CLEARANCE. CLEARED TO YBBN VIA CS Y177 BN DCT. READBACK AMENDED ROUTE IN FULL DURING PDC READBACK. STANDBY FOR PDC."*
 
 ### WorldFlight Teams
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by OzStrips and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by OzStrips and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight in OzStrips](../img/wfteamozstrips.png){ width="500" }
@@ -63,7 +63,7 @@ SMC will be responsible for delaying aircraft's pushback requests, in order to a
 If there are more than **5** aircraft in the queue at any Holding Point, do not approve any more pushback requests. Instead, use the queue function to keep track of who is awaiting push.
 
 #### OzStrips
-All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#recommended-workflow) for OzStrips.
+All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow) for OzStrips.
 
 Ensure the Queue function is used to actively to keep track of the order of requests.
 

--- a/docs/events/archive/worldflight-2025/Aerodromes/darwin.md
+++ b/docs/events/archive/worldflight-2025/Aerodromes/darwin.md
@@ -12,7 +12,7 @@ Single runway operations on either **runway 11 or 29** will be in use for all ai
 Runway 18/36 will not be available for arrivals and departures, due to its use as a taxiway for some aircraft.
 
 ## Workload Management
-Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#recommended-workflow).
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow).
 
 !!! tip
     The following OzStrips [keyboard shortcuts](../../../../client/towerstrips.md#keyboard-shortcuts) may assist controllers managing busy frequencies:
@@ -34,7 +34,7 @@ If an aircraft has filed an *incorrect* route and you need to give an amended cl
     **DN ACD:** *"AMENDED ROUTE CLEARANCE. CLEARED TO WAJJ VIA DN DCT TOREX DCT TMK W68 JPA DCT. READBACK AMENDED ROUTE IN FULL DURING PDC READBACK. STANDBY FOR PDC."*
 
 ### WorldFlight Teams
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by OzStrips and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by OzStrips and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight in OzStrips](../img/wfteamozstrips.png){ width="500" }
@@ -64,7 +64,7 @@ SMC will be responsible for delaying aircraft's pushback requests, in order to a
 If there are more than **5** aircraft in the queue at any Holding Point, do not approve any more pushback requests. Instead, use the queue function to keep track of who is awaiting push.
 
 #### OzStrips
-All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#recommended-workflow) for OzStrips.
+All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow) for OzStrips.
 
 Ensure the Queue function is used to actively to keep track of the order of requests.
 

--- a/docs/events/archive/worldflight-2025/Aerodromes/sydneyarr.md
+++ b/docs/events/archive/worldflight-2025/Aerodromes/sydneyarr.md
@@ -12,7 +12,7 @@ Due to the nature of the event, a non-standard maximum crosswind limitation has 
 Runway mode changes will be extremely difficult, so ensure an appropriate mode is chosen with consideration to the forecast wind values over the course of the event.
 
 ## Workload Management
-Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#recommended-workflow). 
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow). 
 
 !!! tip
     The following OzStrips [keyboard shortcuts](../../../../client/towerstrips.md#keyboard-shortcuts) may assist controllers managing busy frequencies:
@@ -28,7 +28,7 @@ The ACD role will perform as normal. Expect a handful of departures who want to 
 With two SMC controllers online, utilise [strip bay bars](../../../../../client/towerstrips/#multiple-adcsmc-positions) to keep the **Taxi** and **Holding Point** strip bays organised.
 
 ### Departures
-It is unlikely that Coordinator will be open, so normal outbound taxi procedures apply. If Coordinator is online, refer to the VATPAC [recommended workflow](../../../../../client/towerstrips/#recommended-workflow).
+It is unlikely that Coordinator will be open, so normal outbound taxi procedures apply. If Coordinator is online, refer to the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow).
 
 ### Separation Assurance
 Both SMC positions must be careful to ensure separation is assured at all times, particularly through the complex taxiway intersections at Sydney.

--- a/docs/events/archive/worldflight-2025/Aerodromes/sydneydep.md
+++ b/docs/events/archive/worldflight-2025/Aerodromes/sydneydep.md
@@ -15,7 +15,7 @@ An additional Non-Standard position for Sydney ACD will be used
 **16 PROPS** and **34 PROPS** are the available Runway Modes, with equal preference. Any other Runway Mode may **only** be used with approval from the Events Coordinator.
 
 ## Workload Management
-Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#recommended-workflow). 
+Due to the extreme workload expected for all positions, the use of the OzStrips plugin for managing aerodrome positions is **mandatory**. Controllers should familiarise themselves with the plugin and the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow). 
 
 !!! tip
     The following OzStrips [keyboard shortcuts](../../../../client/towerstrips.md#keyboard-shortcuts) may assist controllers managing busy frequencies:
@@ -54,7 +54,7 @@ If an aircraft has filed an *incorrect* route and you need to give an amended cl
     *AMENDED ROUTE CLEARANCE. CLEARED TO NZAA VIA EVONN L521 LUNBI DCT. READBACK AMENDED ROUTE IN FULL DURING PDC READBACK. STANDBY FOR PDC.*
 
 ### WorldFlight Teams
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by OzStrips and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by OzStrips and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight in OzStrips](../img/wfteamozstrips.png){ width="500" }
@@ -126,7 +126,7 @@ Coordinator operations shall be conducted in accordance with the Sydney Aerodrom
     Official WorldFlight teams should be afforded priority when requesting pushback or taxi (if no pushback required), and placed ahead of other non-official aircraft.
 
 ### OzStrips
-All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#recommended-workflow) for OzStrips.
+All aerodrome controllers must be familiar with the VATPAC [recommended workflow](../../../../../client/towerstrips/#workflow) for OzStrips.
 
 Coordinator must place a `STANDBY FOR GROUND EAST` & `STANDBY FOR GROUND WEST` bar in the **Cleared Bay Queue** and queue any aircraft who request pushback or taxi (if no pushback required) in the Cleared Bay.
 

--- a/docs/events/archive/worldflight-2025/Enroute/leg1.md
+++ b/docs/events/archive/worldflight-2025/Enroute/leg1.md
@@ -23,7 +23,7 @@ WOL will not be staffed for the event, and they are taken to have *No Restrictio
 Due to the sheer volume of traffic departing from YSSY, arrivals will **not be possible** during the departure event. Any aircraft inbound to YSSY should be strongly encouraged to divert to another aerodrome.
 
 ## WorldFlight Teams
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by default and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by default and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight](../img/wfteam.png){ width="400" }

--- a/docs/events/archive/worldflight-2025/Enroute/leg2.md
+++ b/docs/events/archive/worldflight-2025/Enroute/leg2.md
@@ -24,7 +24,7 @@ All aircraft shall be issued the **ANUPA1A** STAR.
 Minimum distance between arrivals at handoff to DAW is **10nm** (with no significant closing speed). It is important to try not to exceed **15nm**, due to the large number of arrivals.
 
 ## WorldFlight Teams
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by default and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by default and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight](../img/wfteam.png){ width="400" }
@@ -33,13 +33,13 @@ Minimum distance between arrivals at handoff to DAW is **10nm** (with no signifi
 
 ## Coordination
 ### WAAF CTR to TRT
-As per [standard TRT coordination procedures](../../../../../../../../enroute/Brisbane Centre/TRT/#international-waaf), all aircraft should be **Heads-up Coordinated** by WAAF CTR prior to **30 mins** from boundary.
+As per [standard TRT coordination procedures](../../../../../enroute/brisbane/TRT/#international-waaf), all aircraft should be **Heads-up Coordinated** by WAAF CTR prior to **30 mins** from boundary.
 
 !!! tip
     It may be prudent (especially if they are using vatSys) to set up a Voiceless Coordination Agreement with WAAF CTR, in order to reduce workload for both controllers.
 
 ### TRT to DAW
-Standard as per [TRT Local Instructions](../../../../../../../../enroute/Brisbane Centre/TRT/#arrivalsoverfliers).
+Standard as per [TRT Local Instructions](../../../../../enroute/brisbane/TRT/#arrivalsoverfliers).
 
 ### TRT Release
 When ARA is online, the highlighted portion of TRT is released to ARA to facilitate YPDN departures to WAJJ

--- a/docs/events/archive/worldflight-2025/Enroute/leg3.md
+++ b/docs/events/archive/worldflight-2025/Enroute/leg3.md
@@ -11,7 +11,7 @@ ARA will be responsible for the ARA subsector **only**. The North-east portion o
 ARA shall ensure adequate vertical separation exists between nearby aircraft and may establish basic speed control to avoid any overtaking occurring.
 
 ## WorldFlight Teams
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by default and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by default and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight](../img/wfteam.png){ width="400" }
@@ -20,7 +20,7 @@ ARA shall ensure adequate vertical separation exists between nearby aircraft and
 
 ## Coordination
 ### DAE to ARA
-Standard as per [ISA Local Instructions](../../../../../../../../enroute/Brisbane Centre/ISA).
+Standard as per [ISA Local Instructions](../../../../../enroute/brisbane/ISA).
 
 !!! note
     All departing aircraft will be handled by DAE, regardless of duty runway.
@@ -34,7 +34,7 @@ When ARA is online, the highlighted portion of TRT is released to ARA to facilit
 </figure>
 
 ### ARA to WAAF CTR
-As per [standard ISA coordination procedures](../../../../../../../../enroute/Brisbane Centre/ISA/#international-waaf), all aircraft should be **Heads-up Coordinated** to WAAF CTR prior to **30 mins** from boundary.
+As per [standard ISA coordination procedures](../../../../../enroute/brisbane/ISA/#international-waaf), all aircraft should be **Heads-up Coordinated** to WAAF CTR prior to **30 mins** from boundary.
 
 !!! tip
     It may be prudent (especially if they are using vatSys) to set up a Voiceless Coordination Agreement with WAAF CTR, in order to reduce workload for both controllers.

--- a/docs/events/archive/worldflight-2025/Enroute/leg4.md
+++ b/docs/events/archive/worldflight-2025/Enroute/leg4.md
@@ -31,7 +31,7 @@ All aircraft shall be issued a STAR in accordance with the table below:
 | RWY 33 | HENDO2A, OVLET transition |
 
 ## WorldFlight Teams
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by default and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by default and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight](../img/wfteam.png){ width="400" }
@@ -40,13 +40,13 @@ All aircraft shall be issued a STAR in accordance with the table below:
 
 ## Coordination
 ### WAAF CTR to ARA
-As per [standard ISA coordination procedures](../../../../../../../../enroute/Brisbane Centre/ISA/#international-waaf), all aircraft should be **Heads-up Coordinated** by WAAF CTR prior to **30 mins** from boundary.
+As per [standard ISA coordination procedures](../../../../../enroute/brisbane/ISA/#international-waaf), all aircraft should be **Heads-up Coordinated** by WAAF CTR prior to **30 mins** from boundary.
 
 !!! tip
     It may be prudent (especially if they are using vatSys) to set up a Voiceless Coordination Agreement with WAAF CTR, in order to reduce workload for both controllers.
 
 ### ARA to BAR
-Standard as per [KEN Local Instructions](../../../../../../../../enroute/Brisbane Centre/KEN).
+Standard as per [KEN Local Instructions](../../../../../enroute/brisbane/KEN).
 
 ### BAR to CS TCU
 Voiceless for all aircraft:
@@ -60,7 +60,7 @@ All other aircraft coming from BAR CTA must be **Heads-up** Coordinated to CS TC
     All arriving aircraft from the north and west will be handled by CS2, regardless of duty runway.
 
 ### CS TCU to KEN
-Standard as per [KEN Local Instructions](../../../../../../../../enroute/Brisbane Centre/KEN).
+Standard as per [KEN Local Instructions](../../../../../enroute/brisbane/KEN).
 
 !!! note
     All departing aircraft will be handled by CS1, regardless of duty runway.

--- a/docs/events/archive/worldflight-2025/Enroute/leg5.md
+++ b/docs/events/archive/worldflight-2025/Enroute/leg5.md
@@ -63,7 +63,7 @@ Arrivals may, when suitable for the *sequence*, and clear of *01L/19R traffic*, 
     Refer to the MAESTRO plugin for guidance on which aircraft should be re-routed.
 
 ## WorldFlight Teams
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by default and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by default and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight](../img/wfteam.png){ width="400" }
@@ -87,7 +87,7 @@ Aircraft must be tracking via **ENLIP** or **SMOKA**
 
 ### BUR to BAS/BAN
 #### Airspace
-Non-Standard Airspace Division will be in use for BN TCU. Refer to [these diagrams](../../../../../Terminal Areas/brisbane/#airspace-division).
+Non-Standard Airspace Division will be in use for BN TCU. Refer to [these diagrams](../../../../../terminal/brisbane/#airspace-division).
 
 Runway **01L** and **19L** Arrivals will be handed off to BAN.  
 Runway **01R** and **19R** Arrivals will be handed off to BAS.  

--- a/docs/events/archive/worldflight-2025/Enroute/leg6.md
+++ b/docs/events/archive/worldflight-2025/Enroute/leg6.md
@@ -94,7 +94,7 @@ Most official team aircraft will depart from YBCG and track via **WLM** to facil
 !!! warning "Important"
     The YBCG to WLM track approximates a northbound airway. Be vigilant for any aircraft departing YSSY to the north who may conflict with the southbound aircraft.
 
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by default and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by default and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight](../img/wfteam.png){ width="400" }
@@ -129,7 +129,7 @@ Changes to Route and CFL are **permitted** within **50nm** of the boundary, with
 Aircraft must be tracking via **BOREE**.
 
 ### CNK/OCN to SAS/SAN
-Standard as per [ARL Local Instructions](../../../../../../../../enroute/Brisbane Centre/ARL/#arrivalsoverfliers).
+Standard as per [ARL Local Instructions](../../../../../enroute/brisbane/ARL/#arrivalsoverfliers).
 
 **BOREE** Arrivals will be handed off to SAN.  
 **MARLN** Arrivals will be handed off to SAS.  

--- a/docs/events/archive/worldflight-2025/Terminal Areas/brisbane.md
+++ b/docs/events/archive/worldflight-2025/Terminal Areas/brisbane.md
@@ -120,7 +120,7 @@ Subtract **1 minute** if assigned MX or CSR.
 BUR will instruct all arrivals to cross **SMOKA** and **ENLIP** at **250 knots**, then *published STAR speeds*.
 
 ## WorldFlight Teams
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by default and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by default and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight](../img/wfteam.png){ width="400" }

--- a/docs/events/archive/worldflight-2025/Terminal Areas/cairns.md
+++ b/docs/events/archive/worldflight-2025/Terminal Areas/cairns.md
@@ -30,7 +30,7 @@ Ensure that event traffic gets priority over non-event traffic.
 KEN will instruct all arrivals to cross **OVLET** at **250 knots**, then *published STAR speeds*.
 
 ## WorldFlight Teams
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by default and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by default and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight](../img/wfteam.png){ width="400" }

--- a/docs/events/archive/worldflight-2025/Terminal Areas/darwin.md
+++ b/docs/events/archive/worldflight-2025/Terminal Areas/darwin.md
@@ -32,7 +32,7 @@ Ensure that event traffic gets priority over non-event traffic.
 TRT will instruct all arrivals to cross **ANUPA** at **250 knots**, then *published STAR speeds*.
 
 ## WorldFlight Teams
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by default and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by default and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight](../img/wfteam.png){ width="400" }

--- a/docs/events/archive/worldflight-2025/Terminal Areas/sydneyarr.md
+++ b/docs/events/archive/worldflight-2025/Terminal Areas/sydneyarr.md
@@ -59,7 +59,7 @@ Participating aircraft will transfer to SY ADC on their own as they approach the
 ![Scenic Arrival](../img/worldflight-scenic-arrival.png){ width="600" }
 </figure>
 
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by default and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by default and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight](../img/wfteam.png){ width="400" }

--- a/docs/events/archive/worldflight-2025/Terminal Areas/sydneydep.md
+++ b/docs/events/archive/worldflight-2025/Terminal Areas/sydneydep.md
@@ -52,7 +52,7 @@ Aircraft for **NZOH** shall be subsequently processed with the following trackin
 Aircraft shall be handed off to OCN assigned the **final instruction** in the tables above.
 
 ## WorldFlight Teams
-[WorldFlight Teams](../../../../../#official-team-callsigns) will be highlighted by default and should receive priority at all stages of flight.
+WorldFlight Teams will be highlighted by default and should receive priority at all stages of flight.
 
 <figure markdown>
 ![WF Team Highlight](../img/wfteam.png){ width="400" }

--- a/docs/pacific/Papua-New-Guinea/Enroute.md
+++ b/docs/pacific/Papua-New-Guinea/Enroute.md
@@ -96,10 +96,10 @@ The Standard Assignable level from AYPM to AYNZA is `F250`. Any other level must
 
 ### Class F Aerodromes
 #### Departures and Arrivals
-As per [Standard coordination procedures](../../controller-skills/coordination/#octa-coordination), coordination between ADC and AYPM is **not required**. However, a **5 minute** change parameter applies to any aircraft that change level, route, or taxi within **5 minutes** of the next sector's airspace.
+As per [Standard coordination procedures](../../../controller-skills/coordination/#octa-coordination), coordination between ADC and AYPM is **not required**. However, a **5 minute** change parameter applies to any aircraft that change level, route, or taxi within **5 minutes** of the next sector's airspace.
 
 #### Overfliers
-As per [Standard coordination procedures](../../controller-skills/coordination/#octa-coordination), coordination between ADC and AYPM is **not required**. However, a **5 minute** change parameter applies to any aircraft that change level, route, or taxi within **5 minutes** of the next sector's airspace.
+As per [Standard coordination procedures](../../../controller-skills/coordination/#octa-coordination), coordination between ADC and AYPM is **not required**. However, a **5 minute** change parameter applies to any aircraft that change level, route, or taxi within **5 minutes** of the next sector's airspace.
 
 IFR aircraft may either be handed off to the ADC frequency by AYPM, or held on the AYPM frequency following coordination if there is no relevant traffic.
 
@@ -110,10 +110,10 @@ IFR aircraft may either be handed off to the ADC frequency by AYPM, or held on t
     AYPM CTR will put *"AYMH NFR NIT"* in the label data, and the aircraft will remain on the ENR frequency.
 
 ### International (ISA(ARA)/KEN(WIL))
-As per [Standard coordination procedures](../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
+As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
     
 ### Pacific Oceanic (TSN(COL)/KZAK)
-As per [Standard coordination procedures](../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
+As per [Standard coordination procedures](../../../controller-skills/coordination/#pacific-units), Voiceless, no changes to route or CFL within **15 mins** to boundary.
 
 Aircraft must have their identification terminated and be instructed to make a position report on first contact with the next (procedural) sector.
 
@@ -121,7 +121,7 @@ Aircraft must have their identification terminated and be instructed to make a p
     **AYPM**: "SOL712, identification terminated, report position to Brisbane Radio, 124.65"
 
 ### International (WAAF)
-As per [Standard coordination procedures](../../controller-skills/coordination/#other-units), Heads-up Coordination required for all aircraft prior to **30 mins** from boundary.
+As per [Standard coordination procedures](../../../controller-skills/coordination/#other-units), Heads-up Coordination required for all aircraft prior to **30 mins** from boundary.
 
 !!! phraseology
     <span class="coldline">**AYPM** -> **WAAF_CTR**</span>: "Estimate, ANG8, KADAB time 59, F380"  

--- a/docs/terminal/adelaide.md
+++ b/docs/terminal/adelaide.md
@@ -93,7 +93,7 @@ Non-Jet aircraft will be processed via a combination of:
 - No STAR, expecting vectors or direct tracking for VSA or IAP
 
 !!! tip
-    Refer to the [TBD page](../enroute/melbourne/TBD/#star-assignment) for more details on the ATIS conditions and feeder fix combinations which will determine how each aircraft is processed.
+    Refer to the [TBD page](../../enroute/melbourne/TBD/#star-assignment) for more details on the ATIS conditions and feeder fix combinations which will determine how each aircraft is processed.
 
 Non-jet aircraft processed via direct tracking for a VSA should be vectored or cleared as necessary to join a circuit leg (generally final or downwind).
 
@@ -122,7 +122,7 @@ Due to the low level of CTA at YPPF, it is best practice to give airways clearan
 - A competent pilot may be issued the appropriate Victor/Xray/Whiskey STAR in lieu of the Alpha STAR to reduce track miles.
 
 !!! tip
-    When flowing using the Arrivals List Window, AFL may use the abbreviations listed in the [TBD page](../../enroute/melbourne/TBD/#ypad-star-assignment) to prescribe certain STARs and Runways.
+    When flowing using the Arrivals List Window, AFL may use the abbreviations listed in the [TBD page](../../enroute/melbourne/TBD/#star-assignment) to prescribe certain STARs and Runways.
 
 ### Flow Tables
 The tables below give an estimated time **in minutes** from the **Feeder Fix** to the **Threshold**.

--- a/docs/terminal/scherger.md
+++ b/docs/terminal/scherger.md
@@ -84,7 +84,7 @@ If the pilot **does not** nominate a gate, or nominates a gate that does not pro
 ### SG MIL CTR
 The **SG MIL CTR** is defined as airspace within 15NM DME YBSG, `SFC-A040`. The SG TMA is unique in that the associated MIL CTR is not necessarily activated by default when **SGA** is online. When the SG MIL CTR is activated the entire area is reclassified as Class C airspace.
 
-The activation status of the SG MIL CTR must be reflected through the [ATIS operational field](../../aerodromes/class-c/Scherger/#operational-info).
+The activation status of the SG MIL CTR must be reflected through the [ATIS operational field](../../aerodromes/classc/Scherger/#operational-info).
 
 <figure markdown>
 ![CTA differences between SG MIL CTR and TRA Scherger](img/sg_tra-ctr_cta.png){ width="700" }

--- a/docs/terminal/tindal.md
+++ b/docs/terminal/tindal.md
@@ -50,7 +50,7 @@ This gives the enroute controller sufficient time to assess the request, make ne
     The requirement to coordinate activation of an SUA is in **addition** to existing coordination requirements. [**Heads-up** coordination](#departures) is still required for these aircraft if they do not meet the voiceless coordination criteria.
 
 ##### Bradshaw/Delamere Active
-When either the [Bradshaw Field Training Area](../../enroute/brisbane/TRT/#bradshaw-field-training-area-sua) or [Delamere Air Weapons Range](../../enroute/brisbane/TRT/#delamere-air-weapons-range) SUAs are active, aircraft intending to operate in the [R225D restricted area](../../enroute/brisbane/TRT/#r225a-f-and-r250-tindal) must be notified when given clearance.
+When either the [Bradshaw Field Training Area](../../enroute/brisbane/TRT/#bradshaw-field-training-area-sua) or [Delamere Air Weapons Range](../../enroute/brisbane/TRT/#delamere-air-weapons-range-sua) SUAs are active, aircraft intending to operate in the [R225D restricted area](../../enroute/brisbane/TRT/#r225a-f-and-r250-tindal) must be notified when given clearance.
 
 !!! phraseology
     *CLAS35 is has departed YPTN and is approaching MOROTAI for entry to the R225D restricted area*  

--- a/docs/terminal/williamtown.md
+++ b/docs/terminal/williamtown.md
@@ -97,7 +97,7 @@ If the pilot **does not** nominate a gate, or nominates a gate that does not pro
     [Coordination requirements](#acd-to-wlm-tcu) exist between ACD and TCU when aircraft are requesting clearance to operate in an SUA that has not been activated. Controllers performing the role of ACD should ensure they coordinate with TCU before providing clearance
     
 ### Military Corridors
-There are two [military corridors](../controller-skills/military/#military-corridors) established around the WLM TCU to facilitate transit of military aircraft between the TCU and adjoining SUAs.
+There are two [military corridors](../../controller-skills/military/#military-corridors) established around the WLM TCU to facilitate transit of military aircraft between the TCU and adjoining SUAs.
 
 <figure markdown>
 ![WLM TCU Military Corridors](img/wlm_mil_corridors.png){ width="700" }
@@ -128,7 +128,7 @@ Aircraft will access the corridor through the **[Lightning Gate](#military-gates
 The corridor itself is located entirely within SUA, and aircraft entering the corridor from WLM TCU airspace do not need to be handed off to ARL if the restricted areas are active. 
 
 !!! phraseology
-    **WAL**: "WGTL45 at LG cleared operating, report [ops normal](../controller-skills/airwork/#ops-normal) time 30."  
+    **WAL**: "WGTL45 at LG cleared operating, report [ops normal](../../controller-skills/airwork/#ops-normal) time 30."  
     **WGTL45**: "At LG cleared operating, ops normal time 30, WGTL45."  
     
 Aircraft transiting the Thunder Corridor should be assigned the appropriate altitude to ensure separation with opposite direction traffic while transiting to their desired restricted area.
@@ -160,7 +160,7 @@ WLM TCU is not responsible for assigning subareas, or ensuring separation betwee
 When an aircraft has declared an intention to operate within a subarea, the WLM TCU may provide a traffic statement to help provide situational awareness to the departing aircraft.
 
 !!! phraseology 
-    **WAL**: "WGTL46 at LG cleared operating, number 2 in Bravo One and Charlie One, report [ops normal](../controller-skills/airwork/#ops-normal) time 30.
+    **WAL**: "WGTL46 at LG cleared operating, number 2 in Bravo One and Charlie One, report [ops normal](../../controller-skills/airwork/#ops-normal) time 30.
     
 ### Special Use Airspace
 #### Salt Ash SUA


### PR DESCRIPTION
## Summary
Fixed incorrect paths to other documents. 

## Changes
**Fixes**:
- Fixed incorrect paths on a linux device (the web host and the compile host are linux based) and they are case sensitive.
- Correct relative `..` depth on cross-section page links
- Retarget renamed pages (e.g. controller-skills/annotations -> client/annotations, Brisbane Centre -> brisbane)
- Fix anchor slugs and typos (recommended-workflow -> workflow, miitary -> military, etc.)
- Drop link wrappers where the target page or anchor no longer exists
