### PR TITLE
Security Patch - Remove Polyfill

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,7 +151,6 @@ markdown_extensions:
 extra_javascript:
   - javascripts/mathjax.js
   - javascripts/table-indent.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 validation:


### PR DESCRIPTION
Depreciated maths library which has a known security flaw and was causing popups in the site. Have tested with no ill effects observed.