### PR TITLE
AIRAC 2607c Changes

### DIFF
--- a/docs/aerodromes/classc/brisbane.md
+++ b/docs/aerodromes/classc/brisbane.md
@@ -171,12 +171,9 @@ Winds must always be considered for Runway modes (Crosswind <20kts, Tailwind <5k
 | 3 - 01 PROPS      | 01L & 01R | 01L & 01R  |
 | 4 - 19 [Segregated](#segregated-operations) | 19R *or* 19L | 19L *or* 19R |
 | 5 - 01 [Segregated](#segregated-operations) | 01R *or* 01L | 01L *or* 01R |
-| *Curfew (RRO)   | 19L       | 01R        |
-
-*Permitted between the hours of 2200 and 0600 Local. If the pilot does not want to participate in curfew mode operations, the controller must accommodate this request.
 
 !!! note
-    The SODPROPS, Segregated Ops, and RRO modes are most suitable for Noise Abatement. The PROPS modes is most suitable for higher capacity. Since for the most part, neither of these are a factor on VATSIM, it is up to you which runway mode you would like to operate, subject to winds. Consider favouring the higher capacity PROPS modes during busy times, such as events like Panic Stations.
+    The SODPROPS and segregated ops modes are most suitable for Noise Abatement. The PROPS modes is most suitable for higher capacity. Since for the most part, neither of these are a factor on VATSIM, it is up to you which runway mode you would like to operate, subject to winds. Consider favouring the higher capacity PROPS modes during busy times, such as events like Panic Stations.
 
 #### SODPROPS
 When using the SODPROPS mode, pass traffic information to aircraft that are departing and landing at the same time
@@ -262,7 +259,6 @@ The Operational Information field should be updated based on the runway mode in 
 | ----------- | -------------- |
 | 19 PROPS<br>01 PROPS | `INDEPENDENT PARALLEL DEPARTURES IN PROG` |
 | SODPROPS    | `SIMULTANEOUS OPPOSITE DIRECTION PARALLEL RUNWAY OPERATIONS IN PROG` |
-| Curfew Mode | AEST: `CURFEW RWY NOMINATION. CURFEW IN OPERATION UNTIL TIME 2000.` |
 
 #### ACD Pushback Requests
 When implementing the [Pushback Requests on ACD](#pushback-requests-on-acd) procedure, the OPR INFO shall include:  

--- a/docs/terminal/adelaide.md
+++ b/docs/terminal/adelaide.md
@@ -10,7 +10,7 @@
 | ----------------------------- | ------- | ----------------------- | ----------- | ------------- |
 | **Adelaide Approach East**    | **AAE** | **Adelaide Approach**   | **118.200** | **AD_APP**    |
 | <span class="indented">Adelaide Approach West :material-information-outline:{ title="Non-standard position"}  | AAW | Adelaide Approach  | 124.200 | AD-W_APP |
-| <span class="indented">Adelaide Radar :material-information-outline:{ title="Non-standard position"}          | AAR | Adelaide Centre    | 130.450 | AD-R_DEP |
+| <span class="indented">Adelaide Radar :material-information-outline:{ title="Non-standard position"}          | AAR | Adelaide Centre    | 130.450 | AD-R_APP |
 | <span class="indented">Adelaide Flow :material-information-outline:{ title="Non-standard position"}           | AFL |                    |         | AD_FMP   |
 
 !!! abstract "Non-Standard Positions"

--- a/docs/terminal/brisbane.md
+++ b/docs/terminal/brisbane.md
@@ -12,7 +12,7 @@
 | <span class="indented">Brisbane Approach South :material-information-outline:{ title="Non-standard position"}   | BAS | Brisbane Approach   | 125.600 | BN-S_APP |
 | <span class="indented">Brisbane Departures North :material-information-outline:{ title="Non-standard position"} | BDN | Brisbane Departures | 133.450 | BN_DEP   |
 | <span class="indented">Brisbane Departures South :material-information-outline:{ title="Non-standard position"} | BDS | Brisbane Departures | 118.450 | BN-S_DEP |
-| <span class="indented">Brisbane Radar :material-information-outline:{ title="Non-standard position"}            | SHN | Brisbane Centre     | 119.500 | BN-R_DEP |
+| <span class="indented">Brisbane Radar :material-information-outline:{ title="Non-standard position"}            | SHN | Brisbane Centre     | 119.500 | BN-R_APP |
 | <span class="indented">Brisbane Flow :material-information-outline:{ title="Non-standard position"}             | BFL |                     |         | BN_FMP   |
 | **Gold Coast Approach**       | **BAC** | **Brisbane Approach**   | **123.500** | **BN-C_APP**  |
 | <span class="indented">Ballina Approach :material-information-outline:{ title="Non-standard position"}          | BAA | Ballina Approach    | 118.350 | BA_APP   |

--- a/docs/terminal/melbourne.md
+++ b/docs/terminal/melbourne.md
@@ -12,7 +12,7 @@
 | <span class="indented">Melbourne Departures North :material-information-outline:{ title="Non-standard position"}  | MDN | Melbourne Departures | 118.900 | ML_DEP   |
 | <span class="indented">Melbourne Departures South :material-information-outline:{ title="Non-standard position"}  | MDS | Melbourne Departures | 129.400 | ML-S_DEP |
 | <span class="indented">Melbourne (Avalon) Approach :material-information-outline:{ title="Non-standard position"} | MAV | Avalon Approach      | 133.550 | AV_APP   |
-| <span class="indented">Melbourne Radar :material-information-outline:{ title="Non-standard position"}             | MAW | Melbourne Centre     | 135.700 | ML-R_DEP  |
+| <span class="indented">Melbourne Radar :material-information-outline:{ title="Non-standard position"}             | MAW | Melbourne Centre     | 135.700 | ML-R_APP  |
 | <span class="indented">Melbourne Flow :material-information-outline:{ title="Non-standard position"}              | MFL |                      |         | ML_FMP   |
 
 !!! abstract "Non-Standard Positions"

--- a/docs/terminal/perth.md
+++ b/docs/terminal/perth.md
@@ -8,7 +8,7 @@
 | ----------------------------- | ------- | ----------------------- | ----------- | ------------- |
 | **Perth Approach**            | **PHA** | **Perth Approach**      | **123.600** | **PH_APP**    | 
 | <span class="indented">Perth Departures :material-information-outline:{ title="Non-standard position"}  | PHD | Perth Departures | 118.700 | PH_DEP   |
-| <span class="indented">Perth Radar :material-information-outline:{ title="Non-standard position"}       | PHR | Perth Centre     | 135.250 | PH-R_DEP |
+| <span class="indented">Perth Radar :material-information-outline:{ title="Non-standard position"}       | PHR | Perth Centre     | 135.250 | PH-R_APP |
 | <span class="indented">Perth Flow :material-information-outline:{ title="Non-standard position"}        | PFL |                  |         | PH_FMP   |
 
 !!! abstract "Non-Standard Positions"

--- a/docs/terminal/sydney.md
+++ b/docs/terminal/sydney.md
@@ -14,7 +14,7 @@
 | <span class="indented">Sydney Departures North :material-information-outline:{ title="Non-standard position"}    | SDN | Sydney Departures  | 123.000 | SY-N_DEP |
 | <span class="indented">Sydney Director West :material-information-outline:{ title="Non-standard position"}       | SFW | Sydney Director    | 126.100 | SY-D_APP |
 | <span class="indented">Sydney Director East :material-information-outline:{ title="Non-standard position"}       | SFE | Sydney Director    | 125.300 | SY-DE_APP|
-| <span class="indented">Sydney Centre :material-information-outline:{ title="Non-standard position"}              | SYC | Sydney Centre      | 124.550 | SY-R_DEP |
+| <span class="indented">Sydney Centre :material-information-outline:{ title="Non-standard position"}              | SYC | Sydney Centre      | 124.550 | SY-R_APP |
 | <span class="indented">Bankstown Approach :material-information-outline:{ title="Non-standard position"}         | SBA | Bankstown Approach | 125.800 | BK_APP   |
 | <span class="indented">Richmond Approach :material-information-outline:{ title="Non-standard position"}          | SRA | Richmond Approach  | 135.900 | RI_APP   |
 | <span class="indented">Nancy-Bird Walton Approach :material-information-outline:{ title="Non-standard position"} | SWA | Walton Approach    | 118.400 | WS_APP   |


### PR DESCRIPTION
## Summary
The callsign for Radar positions is changing from a -R_DEP suffix to a -R_APP suffix, to reduce confusion.
Brisbane Runway Modes selection updated to remove unused "curfew" runway mode.
