### PR TITLE
Remove "More ATIS" plugin references

### DIFF
--- a/docs/pacific/Fiji/Enroute.md
+++ b/docs/pacific/Fiji/Enroute.md
@@ -23,7 +23,7 @@ All controlled airspace within the Fiji Domestic up to `F600` is classified as C
 When **NFNA ADC** is offline, NFNA TCU below `A065` is reclassified as Class G and is administed by NFFJ. Alternatively, NFFJ may provide a [top-down approach service](../Nausori/TCU) if they wish.
 
 !!! tip
-    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. 
 <!--	
 ## Extending
 -->

--- a/docs/pacific/New-Caledonia/TCU.md
+++ b/docs/pacific/New-Caledonia/TCU.md
@@ -38,7 +38,7 @@ This manoeuvre can take aircraft between two to three minutes, during which time
 ## Tower Offline Procedures 
 ### NWWM ADC Offline
 !!! tip
-    When NWWW ADC is offline, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+    When NWWW ADC is offline, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. 
 	
 #### Arrivals
 IFR aircraft cruising inside CTA will generally commence an instrument approach from within controlled airspace and leave CTA on descent. The missed approach procedure will keep these aircraft outside controlled airspace, so does not need to be protected by the TCU controller. Clear these aircraft to leave CTA descending via an appropriate approach.

--- a/docs/pacific/Papua-New-Guinea/Enroute.md
+++ b/docs/pacific/Papua-New-Guinea/Enroute.md
@@ -29,7 +29,7 @@ Refer to the [PNG Local instructions](../) for more information about Class F op
 When **AYNZ ADC** is offline, AYNZ CTR (Class C `SFC` to `A060`) is reclassified as Class F, and is administed by AYPM. Alternatively, AYPM may provide a [top-down procedural service](../Nadzab/AD) if they wish.
 
 !!! tip
-    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+    If choosing *not* to provide a top down service, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. 
 
 #### Class F Aerodromes
 When **AYGA ADC**, **AYMD ADC**, **AYMH ADC**, **AYTK ADC** are offline, the [ATZ](../#aerodrome-traffic-zones)'s of their respective aerodromes are inactive. The airspace remains Class F.

--- a/docs/terminal/melbourne.md
+++ b/docs/terminal/melbourne.md
@@ -34,7 +34,7 @@ AV CTR Class D `SFC` to `A007` reverts to Class G and `A007` to `A025` to Class 
 See also: [AV ADC Offline](#av-adc-offline).
 
 !!! tip
-    When AV ADC is not online, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. The *More ATIS* plugin has a formatted Zulu ATIS message.
+    When AV ADC is not online, consider publishing an **ATIS Zulu** for the aerodrome, to inform pilots about the airspace reclassification. 
 
 ### Airspace Division
 The divisions of the airspace between **MAE**, **MDN**, **MDS**, and **MAV** change based on the Runway Mode.


### PR DESCRIPTION
## Summary
Remove 4 references to a VATSYS plugin called "More ATIS" for Zulu ATIS messages

## Changes

**Removals**:
- Removed "The *More ATIS* plugin has a formatted Zulu ATIS message" from a Tips section in Papua New Guinea Enroute, NWWW, Fiji and Melbourne Terminal
